### PR TITLE
fix(statusline): resolve session id from stdin payload so per-session KPI renders

### DIFF
--- a/bin/statusline.mjs
+++ b/bin/statusline.mjs
@@ -96,7 +96,12 @@ function readStdinJson() {
     const raw = readFileSync(0, "utf-8");
     if (!raw.trim()) return {};
     return JSON.parse(raw);
-  } catch {
+  } catch (err) {
+    // The payload is load-bearing — it carries session_id, which resolves the
+    // per-session KPI. Empty stdin (normal first render) returned above and
+    // stays silent; a non-empty payload that fails to parse is a real anomaly
+    // worth one latched stderr line (never pollutes the statusline's stdout).
+    warnOnce("stdin-parse", `failed to parse statusline stdin JSON: ${err?.message ?? err}`);
     return {};
   }
 }
@@ -187,8 +192,23 @@ function findClaudePidDarwin() {
   return process.ppid;
 }
 
-function resolveSessionId() {
+function resolveSessionId(payload) {
+  // PRIMARY: the session_id Claude Code delivers in the statusLine stdin
+  // payload. This is the SAME id the recording hooks key session_events by,
+  // so it's the only source that reliably matches stored per-session data.
+  //
+  // Claude Code does NOT export a CLAUDE_SESSION_ID env var — session_id is
+  // delivered only in the stdin JSON (statusline.md "Available data"). And the
+  // /proc PID walk yields `pid-<n>`, which never matches a UUID-keyed session.
+  // So without reading the payload, the per-session KPI is unreachable and the
+  // bar falls back to the global lifetime aggregate — identical in every
+  // session and seemingly "frozen".
+  const fromPayload = payload?.session_id;
+  if (typeof fromPayload === "string" && fromPayload) return fromPayload;
+  // Fallback when the payload carries no session_id (and how test fixtures
+  // pin a deterministic id). NOT an override — payload wins when present.
   if (process.env.CLAUDE_SESSION_ID) return process.env.CLAUDE_SESSION_ID;
+  // Last resort: walk the process tree (only matches pid-keyed events).
   return `pid-${findClaudePid()}`;
 }
 
@@ -208,9 +228,9 @@ function statusDot(pct) {
 
 // ── Main render ──────────────────────────────────────────────────────────
 async function main() {
-  readStdinJson(); // drain stdin even if unused, keeps Claude Code happy
+  const payload = readStdinJson(); // canonical source of session_id
   const sessionsDir = resolveSessionDir();
-  const sessionId = resolveSessionId();
+  const sessionId = resolveSessionId(payload);
 
   const analytics = await loadAnalytics();
 

--- a/tests/statusline-sqlite.test.ts
+++ b/tests/statusline-sqlite.test.ts
@@ -62,9 +62,9 @@ function isolatedHomeEnv(): Record<string, string> {
   return buildIsolatedEnvObject().env;
 }
 
-function runStatusline(env: Record<string, string>) {
+function runStatusline(env: Record<string, string>, input = "{}") {
   const result = spawnSync("node", [STATUSLINE], {
-    input: "{}",
+    input,
     env: { ...process.env, NO_COLOR: "1", ...isolatedHomeEnv(), ...env },
     encoding: "utf-8",
   });
@@ -211,6 +211,66 @@ describe("statusline.mjs — SessionDB-backed reads", () => {
       stdout,
       /(this chat|kept out|lifetime)/,
       "byte-based render template is in effect",
+    );
+    assert.doesNotMatch(stdout, /NaN/);
+  });
+
+  // REGRESSION (#statusline-session-id): the per-session "this chat" KPI must
+  // resolve from the stdin payload's `session_id`. Claude Code does NOT export
+  // a CLAUDE_SESSION_ID env var (statusline.md "Available data" — session_id is
+  // delivered only in the stdin JSON), and the recording hooks key
+  // session_events by that same id. Reading only the env var / PID walk yields
+  // `pid-<n>`, which never matches → sessionBytes is always 0 → the bar shows
+  // only the global lifetime aggregate, identical in every session.
+  //
+  // Magnitude-based mutation-defeat: 'other' is deliberately ~60× larger than
+  // 'mine' (3000 vs 50 events). Two mutations turn this red:
+  //   • reverting resolveSessionId() to ignore the payload → "this chat"
+  //     disappears entirely (no KB match)
+  //   • dropping the sessionId filter in getRealBytesStats → "this chat"
+  //     absorbs 'other' and renders in MB, not KB
+  test("resolves per-session KPI from the stdin payload session_id (no env var)", { timeout: STATUSLINE_SQLITE_TIMEOUT_MS }, () => {
+    const sid = "11111111-2222-3333-4444-555555555555";
+    // Per-session bytes for THIS id…
+    const mine = Array.from({ length: 50 }, () => ({
+      sessionId: sid,
+      bytesAvoided: 1024,
+      data: "x".repeat(64),
+    }));
+    // …plus an unrelated session so lifetime > 0 regardless of the active id.
+    // Deliberately ~60× larger than 'mine' to make the magnitude check
+    // mutation-defeating: if the sessionId filter is dropped, "this chat"
+    // absorbs the combined total and renders in MB instead of KB.
+    const other = Array.from({ length: 3000 }, () => ({
+      sessionId: "99999999-aaaa-bbbb-cccc-dddddddddddd",
+      bytesAvoided: 1024,
+      data: "y".repeat(64),
+    }));
+    seedSessionDb({ dir, events: [...mine, ...other] });
+
+    // Production path: session_id arrives ONLY on stdin. CLAUDE_SESSION_ID is
+    // explicitly empty so the env branch cannot mask a broken payload read.
+    const { stdout } = runStatusline(
+      { CONTEXT_MODE_DIR: root, CLAUDE_SESSION_ID: "" },
+      JSON.stringify({ session_id: sid }),
+    );
+
+    assert.match(stdout, /context-mode/, "brand visible");
+    // The active session (mine, 50 events ≈ tens of KB) is ~60× smaller than
+    // the unrelated 'other' session (3000 events ≈ MB). So a correctly
+    // session-scoped "this chat" renders in KB. Two mutations turn this red:
+    //   • reverting resolveSessionId to ignore the payload → no "this chat" at all
+    //   • dropping the sessionId filter in getRealBytesStats → "this chat" absorbs
+    //     'other' and renders in MB
+    assert.match(
+      stdout,
+      /\d+(\.\d+)?\s*KB\s+this chat/,
+      "active-session KPI present and scoped to the small active session (KB)",
+    );
+    assert.doesNotMatch(
+      stdout,
+      /\bMB\s+this chat/,
+      "'this chat' must not include the large unrelated session's bytes",
     );
     assert.doesNotMatch(stdout, /NaN/);
   });


### PR DESCRIPTION
## Problem

The statusline (`context-mode statusline`) renders an **identical, seemingly-frozen line in every session** — the per-session "this chat" KPI never appears. Users see only the global lifetime aggregate (e.g. `138 MB kept out · 3.5 MB/day · across 3 tools · preserved across compact…`), which is the same everywhere and barely moves.

## Root cause

`bin/statusline.mjs` `resolveSessionId()` reads `process.env.CLAUDE_SESSION_ID`, else falls back to a `/proc` PID walk (`pid-<n>`). It parses the stdin JSON payload (`readStdinJson()` on the next line) and **throws it away** — it never reads the `session_id` field.

But:

- **Claude Code does not export a `CLAUDE_SESSION_ID` env var.** `session_id` is delivered *only* in the statusLine stdin JSON (see [statusline.md → Available data](https://code.claude.com/docs/en/statusline.md)). The env vars Claude Code sets for statusLine are `COLUMNS`, `LINES`, `CLAUDE_CODE_REMOTE`, `CLAUDE_PROJECT_DIR` — there is no `CLAUDE_SESSION_ID`.
- The recording hooks key `session_events` by the Claude session **UUID** (the `session_id` from each hook's stdin payload).

So `resolveSessionId()` always falls through to `pid-<n>`, which can never equal a stored UUID. `getRealBytesStats({ sessionsDir, sessionId })` matches nothing → `sessionBytes === 0` → the renderer permanently takes the "fresh session, no this-chat data" branch and shows the global lifetime aggregate.

### Reproduce
```bash
# Production reality — no CLAUDE_SESSION_ID; session_id only on stdin:
echo '{"session_id":"<a UUID present in your sessions DBs>"}' | env -u CLAUDE_SESSION_ID context-mode statusline
#  → context-mode  ●  138 MB kept out · 3.5 MB/day · … preserved across compact…   (lifetime-only, every session)

# Inject the same id as the (nonexistent-in-real-life) env var instead:
echo '{}' | CLAUDE_SESSION_ID=<same UUID> context-mode statusline
#  → context-mode  ●  2.3 MB this chat · 138 MB lifetime · … 98% kept out          (ACTIVE)
```
The data and the lookup both work — only the *key source* was wrong. In production the env var is never set, so the per-session branch was unreachable.

## Fix

`resolveSessionId(payload)` now reads `session_id` from the stdin payload **first**, then falls back to the env var, then the PID walk:

```js
const fromPayload = payload?.session_id;
if (typeof fromPayload === "string" && fromPayload) return fromPayload;
if (process.env.CLAUDE_SESSION_ID) return process.env.CLAUDE_SESSION_ID;
return `pid-${findClaudePid()}`;
```

Ordering is payload → env → pid: a **strict superset** of prior behavior, so existing env/pid tests stay green. `main()` now keeps the parsed payload (`const payload = readStdinJson()`) and passes it in.

## Why CI didn't catch it

- `tests/statusline-sqlite.test.ts` injected `CLAUDE_SESSION_ID: "any-session-id"` and seeded the DB under that same id — only ever proving the lookup works *when the env var matches*.
- `runStatusline()` hardcoded `input: "{}"`, so the harness **could not send a `session_id` on stdin** — the real production path was untested.

This PR widens `runStatusline(env, input = "{}")` and adds a **mutation-defeating** regression test that drives the true production path (`session_id` on stdin, `CLAUDE_SESSION_ID` empty) and asserts the `… this chat` block renders.

## Verification

- `npx tsc && npx vitest run tests/statusline-sqlite.test.ts` → **5/5 pass**.
- Mutation check: reverting `resolveSessionId` to ignore the payload turns the new test **red** (`… 425 KB kept out · preserved across compact…` — no "this chat"); restoring the fix → green again.

---
— Written by Claude Code (Opus 4.8) on behalf of @0reo
