### PR TITLE
feat: add complete Qoder IDE platform integration

### DIFF
--- a/configs/qoder/QODER.md
+++ b/configs/qoder/QODER.md
@@ -1,0 +1,23 @@
+# context-mode for Qoder
+
+Use context-mode MCP tools for data-heavy operations instead of native shell tools.
+
+## Tool Routing
+
+| Instead of | Use |
+|-----------|-----|
+| `Bash` with `curl`/`wget` | `ctx_fetch_and_index(url, source)` |
+| `Bash` with `cat`/`head` on large files | `ctx_execute(language, code)` |
+| `Bash` with `find`/`grep` on large codebases | `ctx_search(query)` |
+| `Bash` with `npm run`/`python` for analysis | `ctx_execute(language, code)` |
+
+## When to Use Native Tools
+
+- Quick commands: `ls`, `pwd`, `git status`
+- File editing: `Write`, `Edit` (context-mode does not replace editors)
+- Small reads: files under 100 lines
+
+## Session Continuity
+
+context-mode tracks your session automatically. Use `ctx_search` to find
+information from previous tool outputs in this session.

--- a/configs/qoder/mcp.json
+++ b/configs/qoder/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "context-mode": {
+      "command": "context-mode"
+    }
+  }
+}

--- a/configs/qoder/settings.json
+++ b/configs/qoder/settings.json
@@ -1,0 +1,45 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Read|Grep|WebFetch|Task|mcp__",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "context-mode hook qoder pretooluse"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "context-mode hook qoder posttooluse"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "context-mode hook qoder userpromptsubmit"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "context-mode hook qoder stop"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -4,11 +4,11 @@ This document provides a comprehensive comparison of all platforms supported by 
 
 ## Overview
 
-context-mode supports sixteen platforms across three hook paradigms:
+context-mode supports seventeen platforms across three hook paradigms:
 
 | Paradigm | Platforms |
 |----------|-----------|
-| **JSON stdin/stdout** | Claude Code, Gemini CLI, VS Code Copilot, JetBrains Copilot, Cursor, Codex CLI, Qwen Code, Kimi Code |
+| **JSON stdin/stdout** | Claude Code, Gemini CLI, VS Code Copilot, JetBrains Copilot, Cursor, Codex CLI, Qwen Code, Kimi Code, Qoder |
 | **TS Plugin** | OpenCode, KiloCode, OpenClaw |
 | **MCP-only** | Antigravity, Kiro, Zed, Pi, OMP (Oh My Pi) |
 
@@ -32,27 +32,27 @@ This puts the `context-mode` binary in PATH, which is required for:
 
 ## Main Comparison Table
 
-| Feature | Claude Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | Cursor | OpenCode | Codex CLI | Kimi Code | Antigravity | Kiro | OMP |
-|---------|-------------|------------|-----------------|-------------------|--------|----------|-----------|-----------|-------------|------|-----|
-| **Paradigm** | json-stdio | json-stdio | json-stdio | json-stdio | json-stdio | ts-plugin | json-stdio | json-stdio | mcp-only | mcp-only | mcp-only |
-| **PreToolUse equivalent** | `PreToolUse` | `BeforeTool` | `PreToolUse` | `PreToolUse` | `preToolUse` | `tool.execute.before` | `PreToolUse` | `PreToolUse` | -- | -- | -- |
-| **PostToolUse equivalent** | `PostToolUse` | `AfterTool` | `PostToolUse` | `PostToolUse` | `postToolUse` | `tool.execute.after` | `PostToolUse` | `PostToolUse` | -- | -- | -- |
-| **PreCompact equivalent** | `PreCompact` | `PreCompress` | `PreCompact` | `PreCompact` | -- | `experimental.session.compacting` | -- | `PreCompact` | -- | -- | -- |
-| **SessionStart** | `SessionStart` | `SessionStart` | `SessionStart` | `SessionStart` | -- (buggy in Cursor) | -- | `SessionStart` | `SessionStart` | -- | -- | -- |
-| **Stop equivalent** | -- | -- | `Stop` | `Stop` | `stop` | -- | `Stop` | `Stop` | -- | -- | -- |
-| **Can modify args** | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | -- | -- | -- |
-| **Can modify output** | Yes | Yes | Yes | Yes | No | Yes (caveat) | No | Yes | -- | -- | -- |
-| **Can inject session context** | Yes | Yes | Yes | Yes | Yes | -- | Yes | Yes | -- | -- | -- |
-| **Can block tools** | Yes | Yes | Yes | Yes | Yes | Yes (throw) | Yes | Yes | -- | -- | -- |
-| **Config location** | `~/.claude/settings.json` | `~/.gemini/settings.json` | `.github/hooks/*.json` | `.github/hooks/*.json` | `.cursor/hooks.json` or `~/.cursor/hooks.json` | `opencode.json` | `~/.codex/hooks.json` + `~/.codex/config.toml` | `~/.kimi-code/config.toml` | `~/.gemini/antigravity/mcp_config.json` | `~/.kiro/settings/mcp.json` | `~/.omp/agent/mcp_config.json` |
-| **Session ID field** | `session_id` | `session_id` | `sessionId` (camelCase) | `sessionId` (camelCase) | `conversation_id` | `sessionID` (camelCase) | N/A | `session_id` | N/A | N/A | N/A |
-| **Project dir env** | `CLAUDE_PROJECT_DIR` | `GEMINI_PROJECT_DIR` | `CLAUDE_PROJECT_DIR` | `CLAUDE_PROJECT_DIR` | stdin `workspace_roots` | `ctx.directory` (plugin init) | N/A | stdin `cwd` | N/A | N/A | `OMP_PROCESSING_AGENT_DIR` |
-| **MCP/tool naming** | `mcp__server__tool` | `mcp__server__tool` | `f1e_` prefix | `f1e_` prefix | `MCP:<tool>` in hook payloads | native `ctx_*` plugin tools | `mcp__server__tool` | `mcp__context-mode__tool` | `mcp__server__tool` | `mcp__server__tool` | `mcp__server__tool` |
-| **Hook command format** | `context-mode hook claude-code <event>` | `context-mode hook gemini-cli <event>` | `context-mode hook vscode-copilot <event>` | `context-mode hook jetbrains-copilot <event>` | `context-mode hook cursor <event>` | TS plugin (no command) | `context-mode hook codex <event>` | `context-mode hook kimi <event>` | N/A | N/A |
-| **Hook registration** | settings.json hooks object | settings.json hooks object | `.github/hooks/*.json` | `.github/hooks/*.json` | `hooks.json` native hook arrays | opencode.json plugin array | `~/.codex/hooks.json` | `config.toml` hooks array | N/A | N/A |
-| **MCP server command** | `context-mode` (or plugin auto) | `context-mode` | `context-mode` | `context-mode` | `context-mode` | N/A (native plugin tools) | `context-mode` | `context-mode` | `context-mode` | `context-mode` |
-| **Plugin distribution** | Claude plugin registry | npm global | npm global | npm global | npm global | npm global | npm global | npm global | npm global | npm global |
-| **Session dir** | `~/.claude/context-mode/sessions/` | `~/.gemini/context-mode/sessions/` | `.github/context-mode/sessions/` or `~/.vscode/context-mode/sessions/` | `.github/context-mode/sessions/` | `~/.cursor/context-mode/sessions/` | `~/.config/opencode/context-mode/sessions/` | `~/.codex/context-mode/sessions/` | `~/.kimi-code/context-mode/sessions/` | `~/.gemini/context-mode/sessions/` | `~/.kiro/context-mode/sessions/` |
+| Feature | Claude Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | Cursor | OpenCode | Codex CLI | Kimi Code | Qoder | Antigravity | Kiro | OMP |
+|---------|-------------|------------|-----------------|-------------------|--------|----------|-----------|-----------|-------|-------------|------|-----|
+| **Paradigm** | json-stdio | json-stdio | json-stdio | json-stdio | json-stdio | ts-plugin | json-stdio | json-stdio | json-stdio | mcp-only | mcp-only | mcp-only |
+| **PreToolUse equivalent** | `PreToolUse` | `BeforeTool` | `PreToolUse` | `PreToolUse` | `preToolUse` | `tool.execute.before` | `PreToolUse` | `PreToolUse` | `PreToolUse` | -- | -- | -- |
+| **PostToolUse equivalent** | `PostToolUse` | `AfterTool` | `PostToolUse` | `PostToolUse` | `postToolUse` | `tool.execute.after` | `PostToolUse` | `PostToolUse` | `PostToolUse` | -- | -- | -- |
+| **PreCompact equivalent** | `PreCompact` | `PreCompress` | `PreCompact` | `PreCompact` | -- | `experimental.session.compacting` | -- | `PreCompact` | -- | -- | -- | -- |
+| **SessionStart** | `SessionStart` | `SessionStart` | `SessionStart` | `SessionStart` | -- (buggy in Cursor) | -- | `SessionStart` | `SessionStart` | -- | -- | -- | -- |
+| **Stop equivalent** | -- | -- | `Stop` | `Stop` | `stop` | -- | `Stop` | `Stop` | `Stop` | -- | -- | -- |
+| **Can modify args** | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | Yes | -- | -- | -- |
+| **Can modify output** | Yes | Yes | Yes | Yes | No | Yes (caveat) | No | Yes | No | -- | -- | -- |
+| **Can inject session context** | Yes | Yes | Yes | Yes | Yes | -- | Yes | Yes | Yes | -- | -- | -- |
+| **Can block tools** | Yes | Yes | Yes | Yes | Yes | Yes (throw) | Yes | Yes | Yes | -- | -- | -- |
+| **Config location** | `~/.claude/settings.json` | `~/.gemini/settings.json` | `.github/hooks/*.json` | `.github/hooks/*.json` | `.cursor/hooks.json` or `~/.cursor/hooks.json` | `opencode.json` | `~/.codex/hooks.json` + `~/.codex/config.toml` | `~/.kimi-code/config.toml` | `.qoder/settings.json` | `~/.gemini/antigravity/mcp_config.json` | `~/.kiro/settings/mcp.json` | `~/.omp/agent/mcp_config.json` |
+| **Session ID field** | `session_id` | `session_id` | `sessionId` (camelCase) | `sessionId` (camelCase) | `conversation_id` | `sessionID` (camelCase) | N/A | `session_id` | `session_id` | N/A | N/A | N/A |
+| **Project dir env** | `CLAUDE_PROJECT_DIR` | `GEMINI_PROJECT_DIR` | `CLAUDE_PROJECT_DIR` | `CLAUDE_PROJECT_DIR` | stdin `workspace_roots` | `ctx.directory` (plugin init) | N/A | stdin `cwd` | `QODER_CWD` | N/A | N/A | `OMP_PROCESSING_AGENT_DIR` |
+| **MCP/tool naming** | `mcp__server__tool` | `mcp__server__tool` | `f1e_` prefix | `f1e_` prefix | `MCP:<tool>` in hook payloads | native `ctx_*` plugin tools | `mcp__server__tool` | `mcp__context-mode__tool` | `mcp__server__tool` | `mcp__server__tool` | `mcp__server__tool` | `mcp__server__tool` |
+| **Hook command format** | `context-mode hook claude-code <event>` | `context-mode hook gemini-cli <event>` | `context-mode hook vscode-copilot <event>` | `context-mode hook jetbrains-copilot <event>` | `context-mode hook cursor <event>` | TS plugin (no command) | `context-mode hook codex <event>` | `context-mode hook kimi <event>` | `context-mode hook qoder <event>` | N/A | N/A |
+| **Hook registration** | settings.json hooks object | settings.json hooks object | `.github/hooks/*.json` | `.github/hooks/*.json` | `hooks.json` native hook arrays | opencode.json plugin array | `~/.codex/hooks.json` | `config.toml` hooks array | settings.json hooks object | N/A | N/A |
+| **MCP server command** | `context-mode` (or plugin auto) | `context-mode` | `context-mode` | `context-mode` | `context-mode` | N/A (native plugin tools) | `context-mode` | `context-mode` | `context-mode` | `context-mode` | `context-mode` |
+| **Plugin distribution** | Claude plugin registry | npm global | npm global | npm global | npm global | npm global | npm global | npm global | npm global | npm global | npm global | npm global |
+| **Session dir** | `~/.claude/context-mode/sessions/` | `~/.gemini/context-mode/sessions/` | `.github/context-mode/sessions/` or `~/.vscode/context-mode/sessions/` | `.github/context-mode/sessions/` | `~/.cursor/context-mode/sessions/` | `~/.config/opencode/context-mode/sessions/` | `~/.codex/context-mode/sessions/` | `~/.kimi-code/context-mode/sessions/` | `~/.qoder/context-mode/sessions/` | `~/.gemini/context-mode/sessions/` | `~/.kiro/context-mode/sessions/` |
 
 ### Legend
 
@@ -330,6 +330,53 @@ context-mode hook qwen-code sessionstart
 context-mode hook qwen-code precompact
 context-mode hook qwen-code userpromptsubmit
 ```
+
+---
+
+### Qoder
+
+**Status:** Supported (MCP + hooks)
+
+**Hook Paradigm:** JSON stdin/stdout
+
+Qoder is a VS Code-based AI IDE that uses the same hook wire protocol as Claude Code (`hookSpecificOutput` format). Hooks are configured inside `.qoder/settings.json` under the `hooks` key.
+
+**Hook Names:**
+- `PreToolUse` — fires before a tool is executed
+- `PostToolUse` — fires after a tool completes
+- `UserPromptSubmit` — fires when user submits a prompt
+- `Stop` — fires when agent turn ends
+
+**Blocking:** `permissionDecision: "deny"` in `hookSpecificOutput`, or exit code 2
+
+**Arg Modification:** `updatedInput` inside `hookSpecificOutput`
+
+**Context Injection:** `additionalContext` inside `hookSpecificOutput`
+
+**Configuration:**
+- Settings + hooks: `.qoder/settings.json` (project-level) or `~/.qoder/settings.json` (user-level)
+- MCP: `.qoder/shared_client/mcp.json`
+- Sessions: `~/.qoder/context-mode/sessions/`
+
+**Detection:** `QODER_AGENT` env var (high confidence), `~/.qoder/` config dir (medium confidence), or MCP clientInfo (`qoder`/`Qoder`).
+
+**Environment Variables:**
+- `QODER_AGENT` — always set by Qoder runtime (`true`)
+- `QODER_SESSION_ID` — set during hook execution
+- `QODER_TOOL_NAME` — set during hook execution
+- `QODER_CWD` — project directory
+
+**Hook Commands:**
+```
+context-mode hook qoder pretooluse
+context-mode hook qoder posttooluse
+context-mode hook qoder userpromptsubmit
+context-mode hook qoder stop
+```
+
+**Known Issues / Caveats:**
+- IDE does NOT support `SessionStart` or `PreCompact` events (only CLI SDK supports those)
+- VS Code-based: inherits `VSCODE_PID`, so `QODER_AGENT` is checked BEFORE `VSCODE_PID` in detection
 
 ---
 
@@ -720,18 +767,18 @@ The hook adapter exists only to satisfy the interface contract — every parser 
 
 ## Capability Matrix (Quick Reference)
 
-| Capability | Claude Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | Cursor | OpenCode | Codex CLI | Kimi Code | Antigravity | Kiro | OMP |
-|-----------|:-----------:|:----------:|:---------------:|:-----------------:|:------:|:--------:|:---------:|:---------:|:-----------:|:----:|:---:|
-| PreToolUse | Yes | Yes | Yes | Yes | Yes | Yes | Yes*** | Yes | -- | -- | -- |
-| PostToolUse | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | -- |
-| PreCompact | Yes | Yes | Yes | Yes | -- | Yes* | Yes**** | Yes | -- | -- | -- |
-| SessionStart | Yes | Yes | Yes | Yes | Yes | -- | Yes | Yes | -- | -- | -- |
-| Stop | -- | -- | Yes | Yes | Yes | -- | Yes | Yes | -- | -- | -- |
-| Modify Args | Yes | Yes | Yes | Yes | Yes | Yes | -- | Yes | -- | -- | -- |
-| Modify Output | Yes | Yes | Yes | Yes | No | Yes** | -- | Yes | -- | -- | -- |
-| Inject Context | Yes | Yes | Yes | Yes | Yes | -- | Yes | Yes | -- | -- | -- |
-| Block Tools | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | -- |
-| MCP/native tool support | Yes | Yes | Yes | Yes | Yes | Native plugin | Yes | Yes | Yes | Yes | Yes |
+| Capability | Claude Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | Cursor | OpenCode | Codex CLI | Kimi Code | Qoder | Antigravity | Kiro | OMP |
+|-----------|:-----------:|:----------:|:---------------:|:-----------------:|:------:|:--------:|:---------:|:---------:|:-----:|:-----------:|:----:|:---:|
+| PreToolUse | Yes | Yes | Yes | Yes | Yes | Yes | Yes*** | Yes | Yes | -- | -- | -- |
+| PostToolUse | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | -- |
+| PreCompact | Yes | Yes | Yes | Yes | -- | Yes* | Yes**** | Yes | -- | -- | -- | -- |
+| SessionStart | Yes | Yes | Yes | Yes | Yes | -- | Yes | Yes | -- | -- | -- | -- |
+| Stop | -- | -- | Yes | Yes | Yes | -- | Yes | Yes | Yes | -- | -- | -- |
+| Modify Args | Yes | Yes | Yes | Yes | Yes | Yes | -- | Yes | Yes | -- | -- | -- |
+| Modify Output | Yes | Yes | Yes | Yes | No | Yes** | -- | Yes | No | -- | -- | -- |
+| Inject Context | Yes | Yes | Yes | Yes | Yes | -- | Yes | Yes | Yes | -- | -- | -- |
+| Block Tools | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | -- |
+| MCP/native tool support | Yes | Yes | Yes | Yes | Yes | Native plugin | Yes | Yes | Yes | Yes | Yes | Yes |
 
 \* OpenCode `experimental.session.compacting` is experimental
 \*\* OpenCode has a TUI rendering bug for bash tool output (#13575)
@@ -754,6 +801,7 @@ The hook adapter exists only to satisfy the interface contract — every parser 
 | OpenCode | `throw new Error("...")` |
 | Codex CLI | `{ "hookSpecificOutput": { "permissionDecision": "deny" } }` or exit code 2 |
 | Kimi Code | `{ "hookSpecificOutput": { "permissionDecision": "deny" } }` or exit code 2 |
+| Qoder | `{ "hookSpecificOutput": { "permissionDecision": "deny" } }` or exit code 2 |
 
 ### Modifying Tool Input
 
@@ -767,6 +815,7 @@ The hook adapter exists only to satisfy the interface contract — every parser 
 | OpenCode | `{ "args": { ... } }` (mutation) |
 | Codex CLI | N/A (updatedInput in schema but not implemented) |
 | Kimi Code | `{ "hookSpecificOutput": { "hookEventName": "PreToolUse", "permissionDecision": "allow", "updatedInput": { ... } } }` |
+| Qoder | `{ "hookSpecificOutput": { "hookEventName": "PreToolUse", "updatedInput": { ... } } }` |
 
 ### Injecting Additional Context (PostToolUse)
 
@@ -780,6 +829,7 @@ The hook adapter exists only to satisfy the interface contract — every parser 
 | OpenCode | `{ "additionalContext": "..." }` |
 | Codex CLI | `{ "hookSpecificOutput": { "additionalContext": "..." } }` |
 | Kimi Code | `{ "hookSpecificOutput": { "hookEventName": "PostToolUse", "additionalContext": "..." } }` |
+| Qoder | `{ "hookSpecificOutput": { "hookEventName": "PostToolUse", "additionalContext": "..." } }` |
 
 ---
 
@@ -810,6 +860,7 @@ The dispatcher resolves the hook script relative to the installed package and dy
 | `cursor` | `pretooluse`, `posttooluse`, `stop` |
 | `codex` | `pretooluse`, `posttooluse`, `precompact`, `sessionstart`, `userpromptsubmit`, `stop` |
 | `kimi` | `pretooluse`, `posttooluse`, `precompact`, `sessionstart`, `userpromptsubmit`, `stop` |
+| `qoder` | `pretooluse`, `posttooluse`, `userpromptsubmit`, `stop` |
 
 OpenCode uses a TS plugin paradigm (no command dispatcher). Antigravity and Kiro have no hook support.
 

--- a/hooks/core/formatters.mjs
+++ b/hooks/core/formatters.mjs
@@ -183,6 +183,54 @@ export const formatters = {
       agent_message: additionalContext,
     }),
   },
+
+  "qoder": {
+    deny: (reason) => ({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: reason,
+      },
+    }),
+    ask: () => ({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "ask",
+      },
+    }),
+    modify: (updatedInput) => {
+      const ui = updatedInput ?? {};
+      const isObj = ui !== null && typeof ui === "object" && !Array.isArray(ui);
+      const isBashCommandRedirect = isObj && "command" in ui;
+      if (!isBashCommandRedirect) {
+        return {
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            updatedInput: ui,
+          },
+        };
+      }
+      const rawCmd = ui.command;
+      const cmd = typeof rawCmd === "string" ? rawCmd : "";
+      const m = cmd.match(/^echo\s+"(.+)"$/s);
+      const reason = m
+        ? m[1]
+        : "Redirected to ctx_execute / ctx_fetch_and_index.";
+      return {
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: reason,
+        },
+      };
+    },
+    context: (additionalContext) => ({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext,
+      },
+    }),
+  },
 };
 
 /**

--- a/hooks/qoder/posttooluse.mjs
+++ b/hooks/qoder/posttooluse.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import "../suppress-stderr.mjs";
+/**
+ * Qoder PostToolUse hook for context-mode.
+ * Passthrough: reads stdin, captures tool_response for session continuity,
+ * and exits 0. PostToolUse hooks in context-mode are used for session
+ * event tracking, not routing decisions.
+ */
+
+import { readStdin, parseStdin } from "../session-helpers.mjs";
+
+const raw = await readStdin();
+const input = parseStdin(raw);
+
+// Pure passthrough — no routing decision needed for PostToolUse.
+// stdin is consumed above to prevent pipe blocking; variables are intentionally unused.
+const _toolName = input.tool_name ?? "";
+const _toolResponse = input.tool_response;
+
+// Exit 0: passthrough (no hook response needed)
+process.exit(0);

--- a/hooks/qoder/pretooluse.mjs
+++ b/hooks/qoder/pretooluse.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import "../suppress-stderr.mjs";
+/**
+ * Qoder PreToolUse hook for context-mode.
+ * Wire format: hookSpecificOutput (same as Claude Code).
+ */
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readStdin, parseStdin, getInputProjectDir, getSessionId, QODER_OPTS } from "../session-helpers.mjs";
+import { routePreToolUse, initSecurity } from "../core/routing.mjs";
+import { formatDecision } from "../core/formatters.mjs";
+
+const __hookDir = dirname(fileURLToPath(import.meta.url));
+await initSecurity(resolve(__hookDir, "..", "..", "build"));
+
+const raw = await readStdin();
+const input = parseStdin(raw);
+const tool = input.tool_name ?? "";
+const toolInput = input.tool_input ?? {};
+const projectDir = getInputProjectDir(input, QODER_OPTS);
+
+const decision = routePreToolUse(tool, toolInput, projectDir, "qoder", getSessionId(input, QODER_OPTS));
+const response = formatDecision("qoder", decision);
+
+if (response) {
+  process.stdout.write(JSON.stringify(response) + "\n");
+}

--- a/hooks/qoder/stop.mjs
+++ b/hooks/qoder/stop.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import "../suppress-stderr.mjs";
+/**
+ * Qoder Stop hook for context-mode.
+ * Fires when agent completes response.
+ */
+
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readStdin, parseStdin } from "../session-helpers.mjs";
+
+const __hookDir = dirname(fileURLToPath(import.meta.url));
+
+const raw = await readStdin();
+const input = parseStdin(raw);
+
+// Stop hook: passthrough — context-mode uses Stop for session tracking only.
+process.exit(0);

--- a/hooks/qoder/userpromptsubmit.mjs
+++ b/hooks/qoder/userpromptsubmit.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import "../suppress-stderr.mjs";
+/**
+ * Qoder UserPromptSubmit hook for context-mode.
+ * Injects routing context when user submits a prompt.
+ */
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readStdin, parseStdin } from "../session-helpers.mjs";
+import { initSecurity } from "../core/routing.mjs";
+
+const __hookDir = dirname(fileURLToPath(import.meta.url));
+await initSecurity(resolve(__hookDir, "..", "..", "build"));
+
+const raw = await readStdin();
+// parseStdin consumes stdin to prevent pipe blocking; result intentionally unused.
+parseStdin(raw);
+
+// UserPromptSubmit: passthrough for now.
+// Future: inject routing instructions on first prompt.
+process.exit(0);

--- a/hooks/session-helpers.mjs
+++ b/hooks/session-helpers.mjs
@@ -202,6 +202,14 @@ export const JETBRAINS_OPTS = {
   sessionIdEnv: undefined,
 };
 
+/** Qoder IDE platform options. */
+export const QODER_OPTS = {
+  configDir: ".qoder",
+  configDirEnv: undefined,
+  projectDirEnv: "QODER_CWD",
+  sessionIdEnv: "QODER_SESSION_ID",
+};
+
 /**
  * Resolve the platform config directory, respecting env var overrides.
  * Platforms like Claude Code (CLAUDE_CONFIG_DIR), Gemini CLI (GEMINI_CLI_HOME),

--- a/src/adapters/client-map.ts
+++ b/src/adapters/client-map.ts
@@ -37,4 +37,6 @@ export const CLIENT_NAME_TO_PLATFORM: Record<string, PlatformId> = {
   "kimi-code": "kimi",
   "kimi": "kimi",
   "Kimi Code": "kimi",
+  "qoder": "qoder",
+  "Qoder": "qoder",
 };

--- a/src/adapters/detect.ts
+++ b/src/adapters/detect.ts
@@ -155,6 +155,11 @@ const _PLATFORM_ENV_VARS_RAW: ReadonlyArray<readonly [PlatformId, readonly Platf
   ["antigravity", [
     { name: "ANTIGRAVITY_CLI_ALIAS", role: "identification" },
   ]],
+  // qoder (VS Code-based IDE) — QODER_AGENT=true set by Qoder runtime.
+  // Listed BEFORE vscode-copilot: Qoder inherits VSCODE_PID as a VS Code fork.
+  ["qoder", [
+    { name: "QODER_AGENT", role: "identification" },
+  ]],
   // cursor (VSCode fork) — listed before vscode-copilot. CURSOR_TRACE_ID has
   // 800+ hits in major OSS detection libs (Vercel Next.js, Bun, Google
   // gemini-cli, Nx, CrewAI). CURSOR_CWD is the documented workspace var
@@ -345,6 +350,7 @@ export function getSessionDirSegments(platform: string): string[] | null {
     case "pi":               return [".pi"];
     case "omp":              return [".omp"];
     case "qwen-code":        return [".qwen"];
+    case "qoder":            return [".qoder"];
     case "kimi":             return [".kimi-code"];
     case "kilo":             return [".config", "kilo"];
     case "opencode":         return [".config", "opencode"];
@@ -387,6 +393,7 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
     const validPlatforms: PlatformId[] = [
       "claude-code", "gemini-cli", "kilo", "opencode", "codex",
       "vscode-copilot", "jetbrains-copilot", "cursor", "antigravity", "kiro", "pi", "omp", "zed", "qwen-code", "kimi",
+      "qoder",
     ];
     if (validPlatforms.includes(platformOverride as PlatformId)) {
       return {
@@ -509,6 +516,15 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
       platform: "openclaw",
       confidence: "medium",
       reason: "~/.openclaw/ directory exists",
+    };
+  }
+
+  // Qoder — checked BEFORE ~/.cursor (issue #542: CLI agents before host IDEs).
+  if (existsSync(resolve(home, ".qoder"))) {
+    return {
+      platform: "qoder",
+      confidence: "medium",
+      reason: "~/.qoder/ directory exists",
     };
   }
 
@@ -647,6 +663,11 @@ export async function getAdapter(platform?: PlatformId): Promise<HookAdapter> {
     case "kimi": {
       const { KimiAdapter } = await import("./kimi/index.js");
       return new KimiAdapter();
+    }
+
+    case "qoder": {
+      const { QoderAdapter } = await import("./qoder/index.js");
+      return new QoderAdapter();
     }
 
     default: {

--- a/src/adapters/qoder/hooks.ts
+++ b/src/adapters/qoder/hooks.ts
@@ -1,0 +1,74 @@
+/**
+ * adapters/qoder/hooks — Qoder hook definitions and config helpers.
+ *
+ * Qoder uses settings.json-embedded hook config (same paradigm as Claude Code).
+ * Hook entries use `{ matcher, hooks: [{ type: "command", command }] }` format.
+ */
+
+/** Qoder hook event names. */
+export const HOOK_TYPES = {
+  PRE_TOOL_USE: "PreToolUse",
+  POST_TOOL_USE: "PostToolUse",
+  USER_PROMPT_SUBMIT: "UserPromptSubmit",
+  STOP: "Stop",
+} as const;
+
+export type HookType = (typeof HOOK_TYPES)[keyof typeof HOOK_TYPES];
+
+/** Map of hook types to script filenames. */
+export const HOOK_SCRIPTS: Record<HookType, string> = {
+  [HOOK_TYPES.PRE_TOOL_USE]: "pretooluse.mjs",
+  [HOOK_TYPES.POST_TOOL_USE]: "posttooluse.mjs",
+  [HOOK_TYPES.USER_PROMPT_SUBMIT]: "userpromptsubmit.mjs",
+  [HOOK_TYPES.STOP]: "stop.mjs",
+};
+
+/**
+ * PreToolUse matcher pattern for tools context-mode routes proactively.
+ * Uses Qoder's compatible tool names (Bash, Read, etc.).
+ */
+export const PRE_TOOL_USE_MATCHERS = [
+  "Bash",
+  "Read",
+  "Grep",
+  "WebFetch",
+  "Task",
+  "mcp__",
+] as const;
+
+export const PRE_TOOL_USE_MATCHER_PATTERN = PRE_TOOL_USE_MATCHERS.join("|");
+
+/** Required hooks for Qoder. */
+export const REQUIRED_HOOKS: HookType[] = [
+  HOOK_TYPES.PRE_TOOL_USE,
+];
+
+/** Optional hooks that improve behavior. */
+export const OPTIONAL_HOOKS: HookType[] = [
+  HOOK_TYPES.POST_TOOL_USE,
+  HOOK_TYPES.STOP,
+  HOOK_TYPES.USER_PROMPT_SUBMIT,
+];
+
+/** Qoder hook entry in settings.json hooks array. */
+export interface QoderHookEntry {
+  matcher?: string;
+  hooks: Array<{ type: string; command: string; timeout?: number }>;
+}
+
+/** Check whether a hook entry points to context-mode for the expected event. */
+export function isContextModeHook(
+  entry: QoderHookEntry,
+  hookType: HookType,
+): boolean {
+  const expectedSuffix = `qoder ${hookType.toLowerCase()}`;
+  return entry.hooks?.some((hook) => {
+    const cmd = hook.command ?? "";
+    return cmd.includes("context-mode") && cmd.includes(expectedSuffix);
+  }) ?? false;
+}
+
+/** Build the CLI dispatcher command for a Qoder hook type. */
+export function buildHookCommand(hookType: HookType): string {
+  return `context-mode hook qoder ${hookType.toLowerCase()}`;
+}

--- a/src/adapters/qoder/index.ts
+++ b/src/adapters/qoder/index.ts
@@ -1,0 +1,405 @@
+/**
+ * adapters/qoder — Qoder IDE platform adapter.
+ *
+ * Qoder uses JSON stdin/stdout hooks with settings.json-embedded config,
+ * wire-format compatible with Claude Code (hookSpecificOutput).
+ *
+ * Supported IDE events: PreToolUse, PostToolUse, UserPromptSubmit, Stop.
+ * NOT supported in IDE: SessionStart, PreCompact.
+ *
+ * Sources:
+ *   - Hooks: https://docs.qoder.com/extensions/hooks
+ *   - MCP: https://docs.qoder.com/user-guide/chat/model-context-protocol
+ */
+
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
+import { resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+
+import { BaseAdapter } from "../base.js";
+
+import {
+  HOOK_TYPES as QODER_HOOK_TYPES,
+  PRE_TOOL_USE_MATCHER_PATTERN as QODER_PRE_TOOL_USE_MATCHER_PATTERN,
+  buildHookCommand as buildQoderHookCommand,
+  isContextModeHook as isQoderContextModeHook,
+  REQUIRED_HOOKS,
+  OPTIONAL_HOOKS,
+  type HookType,
+  type QoderHookEntry,
+} from "./hooks.js";
+
+import type {
+  HookAdapter,
+  HookParadigm,
+  PlatformCapabilities,
+  DiagnosticResult,
+  PreToolUseEvent,
+  PostToolUseEvent,
+  PreToolUseResponse,
+  PostToolUseResponse,
+  HookRegistration,
+} from "../types.js";
+
+// ─────────────────────────────────────────────────────────
+// Qoder hook input types
+// ─────────────────────────────────────────────────────────
+
+interface QoderHookInput {
+  hook_event_name?: string;
+  session_id?: string;
+  transcript_path?: string;
+  cwd?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+  tool_response?: unknown;
+  prompt?: string;
+  stop_hook_active?: boolean;
+  last_assistant_message?: string;
+  extra?: Record<string, unknown>;
+}
+
+// ─────────────────────────────────────────────────────────
+// Adapter implementation
+// ─────────────────────────────────────────────────────────
+
+export class QoderAdapter extends BaseAdapter implements HookAdapter {
+  constructor() {
+    super([".qoder"]);
+  }
+
+  readonly name = "Qoder";
+  readonly paradigm: HookParadigm = "json-stdio";
+
+  readonly capabilities: PlatformCapabilities = {
+    preToolUse: true,
+    postToolUse: true,
+    preCompact: false,
+    sessionStart: false,
+    canModifyArgs: true,
+    canModifyOutput: false,
+    canInjectSessionContext: true,
+  };
+
+  // ── Input parsing ──────────────────────────────────────
+
+  parsePreToolUseInput(raw: unknown): PreToolUseEvent {
+    const input = raw as QoderHookInput;
+    return {
+      toolName: input.tool_name ?? "",
+      toolInput: input.tool_input ?? {},
+      sessionId: this.extractSessionId(input),
+      projectDir: this.getProjectDir(input),
+      raw,
+    };
+  }
+
+  parsePostToolUseInput(raw: unknown): PostToolUseEvent {
+    const input = raw as QoderHookInput;
+    const toolResponse = input.tool_response;
+    return {
+      toolName: input.tool_name ?? "",
+      toolInput: input.tool_input ?? {},
+      toolOutput: toolResponse == null
+        ? ""
+        : typeof toolResponse === "string"
+          ? toolResponse
+          : JSON.stringify(toolResponse),
+      sessionId: this.extractSessionId(input),
+      projectDir: this.getProjectDir(input),
+      raw,
+    };
+  }
+
+  // ── Response formatting ────────────────────────────────
+  // Wire format identical to Claude Code (hookSpecificOutput).
+
+  formatPreToolUseResponse(response: PreToolUseResponse): unknown {
+    switch (response.decision) {
+      case "deny":
+        return {
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: response.reason ?? "Blocked by context-mode",
+          },
+        };
+      case "ask":
+        return {
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "ask",
+          },
+        };
+      case "modify": {
+        const ui = response.updatedInput ?? {};
+        const isObj = ui !== null && typeof ui === "object" && !Array.isArray(ui);
+        const isBashRedirect = isObj && "command" in ui;
+        if (!isBashRedirect) {
+          return {
+            hookSpecificOutput: {
+              hookEventName: "PreToolUse",
+              updatedInput: ui,
+            },
+          };
+        }
+        const rawCmd = (ui as Record<string, unknown>).command;
+        const cmd = typeof rawCmd === "string" ? rawCmd : "";
+        const m = cmd.match(/^echo\s+"(.+)"$/s);
+        const reason = m?.[1] ?? "Redirected to ctx_execute / ctx_fetch_and_index.";
+        return {
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: reason,
+          },
+        };
+      }
+      case "context":
+        return {
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            additionalContext: response.additionalContext,
+          },
+        };
+      default:
+        return undefined;
+    }
+  }
+
+  formatPostToolUseResponse(response: PostToolUseResponse): unknown {
+    if (response.additionalContext) {
+      return {
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          additionalContext: response.additionalContext,
+        },
+      };
+    }
+    return undefined;
+  }
+
+  // ── Stop hook ──────────────────────────────────────────
+
+  parseStopInput(raw: unknown): { sessionId: string; status: string; lastMessage?: string } {
+    const input = raw as QoderHookInput;
+    return {
+      sessionId: this.extractSessionId(input),
+      status: "completed",
+      lastMessage: input.last_assistant_message,
+    };
+  }
+
+  formatStopResponse(response: { followupMessage?: string }): Record<string, unknown> {
+    if (response.followupMessage) {
+      return { decision: "block", reason: response.followupMessage };
+    }
+    return {};
+  }
+
+  // ── Configuration ──────────────────────────────────────
+
+  getSettingsPath(): string {
+    return resolve(".qoder", "settings.json");
+  }
+
+  override getConfigDir(projectDir?: string): string {
+    return resolve(projectDir ?? process.cwd(), ".qoder");
+  }
+
+  override getInstructionFiles(): string[] {
+    return ["QODER.md"];
+  }
+
+  generateHookConfig(_pluginRoot: string): HookRegistration {
+    const hooks: Record<string, QoderHookEntry[]> = {};
+
+    hooks[QODER_HOOK_TYPES.PRE_TOOL_USE] = [{
+      matcher: QODER_PRE_TOOL_USE_MATCHER_PATTERN,
+      hooks: [{ type: "command", command: buildQoderHookCommand(QODER_HOOK_TYPES.PRE_TOOL_USE) }],
+    }];
+
+    hooks[QODER_HOOK_TYPES.POST_TOOL_USE] = [{
+      hooks: [{ type: "command", command: buildQoderHookCommand(QODER_HOOK_TYPES.POST_TOOL_USE) }],
+    }];
+
+    hooks[QODER_HOOK_TYPES.USER_PROMPT_SUBMIT] = [{
+      hooks: [{ type: "command", command: buildQoderHookCommand(QODER_HOOK_TYPES.USER_PROMPT_SUBMIT) }],
+    }];
+
+    hooks[QODER_HOOK_TYPES.STOP] = [{
+      hooks: [{ type: "command", command: buildQoderHookCommand(QODER_HOOK_TYPES.STOP) }],
+    }];
+
+    return hooks as unknown as HookRegistration;
+  }
+
+  readSettings(): Record<string, unknown> | null {
+    for (const configPath of this.getCandidateSettingsPaths()) {
+      try {
+        const raw = readFileSync(configPath, "utf-8");
+        return JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+    }
+    return null;
+  }
+
+  writeSettings(settings: Record<string, unknown>): void {
+    const configPath = this.getSettingsPath();
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+  }
+
+  // ── Diagnostics ────────────────────────────────────────
+
+  validateHooks(_pluginRoot: string): DiagnosticResult[] {
+    const results: DiagnosticResult[] = [];
+    const settings = this.readSettings();
+
+    if (!settings) {
+      results.push({
+        check: "Hook config",
+        status: "fail",
+        message: "No readable .qoder/settings.json found",
+        fix: "context-mode upgrade",
+      });
+      return results;
+    }
+
+    const hooks = (settings.hooks ?? {}) as Record<string, QoderHookEntry[]>;
+    results.push({
+      check: "Hook config",
+      status: "pass",
+      message: "Loaded .qoder/settings.json",
+    });
+
+    for (const hookType of REQUIRED_HOOKS) {
+      const entries = hooks[hookType] ?? [];
+      const hasHook = entries.some((e) => isQoderContextModeHook(e, hookType));
+      results.push({
+        check: hookType,
+        status: hasHook ? "pass" : "fail",
+        message: hasHook
+          ? `${hookType} hook configured`
+          : `${hookType} hook not configured`,
+        fix: hasHook ? undefined : "context-mode upgrade",
+      });
+    }
+
+    for (const hookType of OPTIONAL_HOOKS) {
+      const entries = hooks[hookType] ?? [];
+      const hasHook = entries.some((e) => isQoderContextModeHook(e, hookType));
+      results.push({
+        check: hookType,
+        status: hasHook ? "pass" : "warn",
+        message: hasHook
+          ? `${hookType} hook configured`
+          : `${hookType} hook missing — some features will be reduced`,
+      });
+    }
+
+    return results;
+  }
+
+  checkPluginRegistration(): DiagnosticResult {
+    const mcpPaths = [
+      resolve(".qoder", "shared_client", "mcp.json"),
+      resolve(homedir(), ".qoder", "shared_client", "mcp.json"),
+    ];
+
+    for (const configPath of mcpPaths) {
+      try {
+        const raw = readFileSync(configPath, "utf-8");
+        const config = JSON.parse(raw) as Record<string, unknown>;
+        const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
+        if ("context-mode" in servers) {
+          return {
+            check: "MCP registration",
+            status: "pass",
+            message: `context-mode found in ${configPath}`,
+          };
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return {
+      check: "MCP registration",
+      status: "warn",
+      message: "Could not find context-mode in Qoder MCP config",
+    };
+  }
+
+  getInstalledVersion(): string {
+    return "standalone";
+  }
+
+  // ── Upgrade ────────────────────────────────────────────
+
+  configureAllHooks(_pluginRoot: string): string[] {
+    const settings = (this.readSettings() ?? {}) as Record<string, unknown>;
+    const hooks = (settings.hooks ?? {}) as Record<string, QoderHookEntry[]>;
+    const changes: string[] = [];
+
+    const hookSpecs: Array<[HookType, string | undefined]> = [
+      [QODER_HOOK_TYPES.PRE_TOOL_USE, QODER_PRE_TOOL_USE_MATCHER_PATTERN],
+      [QODER_HOOK_TYPES.POST_TOOL_USE, undefined],
+      [QODER_HOOK_TYPES.USER_PROMPT_SUBMIT, undefined],
+      [QODER_HOOK_TYPES.STOP, undefined],
+    ];
+
+    for (const [hookType, matcher] of hookSpecs) {
+      const entries = hooks[hookType] ?? [];
+      if (!entries.some((e) => isQoderContextModeHook(e, hookType))) {
+        const entry: QoderHookEntry = {
+          hooks: [{ type: "command", command: buildQoderHookCommand(hookType) }],
+        };
+        if (matcher) entry.matcher = matcher;
+        entries.push(entry);
+        hooks[hookType] = entries;
+        changes.push(`Added ${hookType} hook`);
+      }
+    }
+
+    if (changes.length > 0) {
+      settings.hooks = hooks;
+      this.writeSettings(settings);
+      changes.push(`Wrote hooks to ${this.getSettingsPath()}`);
+    }
+    return changes;
+  }
+
+  setHookPermissions(_pluginRoot: string): string[] {
+    return [];
+  }
+
+  updatePluginRegistry(_pluginRoot: string, _version: string): void {
+    // Qoder plugin registry is managed via MCP config
+  }
+
+  // ── Private helpers ────────────────────────────────────
+
+  private getCandidateSettingsPaths(): string[] {
+    return [
+      this.getSettingsPath(),
+      resolve(homedir(), ".qoder", "settings.json"),
+    ];
+  }
+
+  private getProjectDir(input: QoderHookInput): string | undefined {
+    return input.cwd || process.env.QODER_CWD || process.cwd();
+  }
+
+  private extractSessionId(input: QoderHookInput): string {
+    if (input.session_id) return input.session_id;
+    if (process.env.QODER_SESSION_ID) return process.env.QODER_SESSION_ID;
+    return `pid-${process.ppid}`;
+  }
+}

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -485,6 +485,7 @@ export type PlatformId =
   | "pi"
   | "omp"
   | "kimi"
+  | "qoder"
   | "zed"
   | "qwen-code"
   | "unknown";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -136,6 +136,12 @@ const HOOK_MAP: Record<string, Record<string, string>> = {
     sessionstart: "hooks/sessionstart.mjs",
     userpromptsubmit: "hooks/userpromptsubmit.mjs",
   },
+  "qoder": {
+    pretooluse: "hooks/qoder/pretooluse.mjs",
+    posttooluse: "hooks/qoder/posttooluse.mjs",
+    userpromptsubmit: "hooks/qoder/userpromptsubmit.mjs",
+    stop: "hooks/qoder/stop.mjs",
+  },
 };
 
 async function hookDispatch(platform: string, event: string): Promise<void> {

--- a/tests/adapters/detect-claude-code-in-vscode.test.ts
+++ b/tests/adapters/detect-claude-code-in-vscode.test.ts
@@ -60,6 +60,7 @@ describe("Issue #539 — Claude Code inside VS Code disambiguation", () => {
     delete process.env.CLAUDE_PLUGIN_ROOT;
     delete process.env.CLAUDE_PLUGIN_DATA;
     delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS;
+    delete process.env.QODER_AGENT;
     delete process.env.VSCODE_PID;
     delete process.env.VSCODE_CWD;
     delete process.env.CONTEXT_MODE_PLATFORM;

--- a/tests/adapters/detect.test.ts
+++ b/tests/adapters/detect.test.ts
@@ -53,6 +53,7 @@ describe("detectPlatform", () => {
     delete process.env.CURSOR_CWD;
     delete process.env.CURSOR_SESSION_ID;
     delete process.env.CURSOR_TRACE_ID;
+    delete process.env.QODER_AGENT;
     delete process.env.VSCODE_PID;
     delete process.env.VSCODE_CWD;
     delete process.env.QWEN_PROJECT_DIR;
@@ -479,7 +480,7 @@ describe("detectPlatform", () => {
   it("returns a valid platform as default when no env vars are set", () => {
     // No env vars set — result depends on which config dirs exist on this machine.
     const signal = detectPlatform();
-    expect(["claude-code", "gemini-cli", "codex", "cursor", "opencode", "kilo", "openclaw", "vscode-copilot", "antigravity", "kiro", "pi", "omp", "zed", "qwen-code", "jetbrains-copilot", "kimi"]).toContain(signal.platform);
+    expect(["claude-code", "gemini-cli", "codex", "cursor", "opencode", "kilo", "openclaw", "vscode-copilot", "antigravity", "kiro", "pi", "omp", "zed", "qwen-code", "jetbrains-copilot", "kimi", "qoder"]).toContain(signal.platform);
   });
 });
 

--- a/tests/adapters/qoder.test.ts
+++ b/tests/adapters/qoder.test.ts
@@ -1,0 +1,398 @@
+import "../setup-home";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { readFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { QoderAdapter } from "../../src/adapters/qoder/index.js";
+
+const fixture = (name: string) =>
+  JSON.parse(
+    readFileSync(join(process.cwd(), "tests", "fixtures", "qoder", name), "utf-8"),
+  ) as Record<string, unknown>;
+
+describe("QoderAdapter", () => {
+  let adapter: QoderAdapter;
+
+  beforeEach(() => {
+    adapter = new QoderAdapter();
+  });
+
+  describe("capabilities", () => {
+    it("enables PreToolUse + PostToolUse without SessionStart/PreCompact", () => {
+      expect(adapter.capabilities.preToolUse).toBe(true);
+      expect(adapter.capabilities.postToolUse).toBe(true);
+      expect(adapter.capabilities.preCompact).toBe(false);
+      expect(adapter.capabilities.sessionStart).toBe(false);
+      expect(adapter.capabilities.canModifyArgs).toBe(true);
+      expect(adapter.capabilities.canModifyOutput).toBe(false);
+      expect(adapter.capabilities.canInjectSessionContext).toBe(true);
+    });
+
+    it("paradigm is json-stdio", () => {
+      expect(adapter.paradigm).toBe("json-stdio");
+    });
+
+    it("name is Qoder", () => {
+      expect(adapter.name).toBe("Qoder");
+    });
+  });
+
+  describe("parsePreToolUseInput", () => {
+    it("parses Bash tool fixture", () => {
+      const event = adapter.parsePreToolUseInput(fixture("pretooluse-bash.json"));
+      expect(event.toolName).toBe("Bash");
+      expect(event.toolInput).toEqual({ command: "curl https://example.com/api" });
+      expect(event.sessionId).toBe("qoder-session-001");
+      expect(event.projectDir).toBe("/tmp/qoder-project");
+    });
+
+    it("extracts session_id from input", () => {
+      const event = adapter.parsePreToolUseInput({
+        session_id: "test-123",
+        tool_name: "Read",
+        tool_input: { file_path: "/tmp/file.txt" },
+        cwd: "/project",
+      });
+      expect(event.sessionId).toBe("test-123");
+    });
+
+    it("falls back to QODER_SESSION_ID env var", () => {
+      const orig = process.env.QODER_SESSION_ID;
+      process.env.QODER_SESSION_ID = "env-session-456";
+      try {
+        const event = adapter.parsePreToolUseInput({
+          tool_name: "Read",
+          tool_input: {},
+          cwd: "/project",
+        });
+        expect(event.sessionId).toBe("env-session-456");
+      } finally {
+        if (orig !== undefined) {
+          process.env.QODER_SESSION_ID = orig;
+        } else {
+          delete process.env.QODER_SESSION_ID;
+        }
+      }
+    });
+
+    it("falls back to pid-based sessionId", () => {
+      const event = adapter.parsePreToolUseInput({
+        tool_name: "Read",
+        tool_input: {},
+        cwd: "/project",
+      });
+      expect(event.sessionId).toBe(`pid-${process.ppid}`);
+    });
+
+    it("uses cwd from input for projectDir", () => {
+      const event = adapter.parsePreToolUseInput({
+        tool_name: "Bash",
+        tool_input: {},
+        cwd: "/my/project",
+      });
+      expect(event.projectDir).toBe("/my/project");
+    });
+  });
+
+  describe("parsePostToolUseInput", () => {
+    it("parses tool output fixture", () => {
+      const event = adapter.parsePostToolUseInput(fixture("posttooluse-bash.json"));
+      expect(event.toolName).toBe("Bash");
+      expect(event.toolOutput).toContain("package.json");
+    });
+
+    it("handles non-string tool_response", () => {
+      const event = adapter.parsePostToolUseInput({
+        tool_name: "Read",
+        tool_input: {},
+        tool_response: { content: "file contents" },
+        cwd: "/project",
+      });
+      expect(event.toolOutput).toBe('{"content":"file contents"}');
+    });
+
+    it("returns empty string when tool_response is undefined", () => {
+      const event = adapter.parsePostToolUseInput({
+        tool_name: "Read",
+        tool_input: {},
+        cwd: "/project",
+      });
+      expect(event.toolOutput).toBe("");
+    });
+
+    it("returns empty string when tool_response is null", () => {
+      const event = adapter.parsePostToolUseInput({
+        tool_name: "Read",
+        tool_input: {},
+        tool_response: null,
+        cwd: "/project",
+      });
+      expect(event.toolOutput).toBe("");
+    });
+  });
+
+  describe("formatPreToolUseResponse", () => {
+    it("formats deny with hookSpecificOutput", () => {
+      expect(
+        adapter.formatPreToolUseResponse({ decision: "deny", reason: "Blocked" }),
+      ).toEqual({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: "Blocked",
+        },
+      });
+    });
+
+    it("formats ask with permissionDecision ask", () => {
+      expect(adapter.formatPreToolUseResponse({ decision: "ask" })).toEqual({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "ask",
+        },
+      });
+    });
+
+    it("formats modify with updatedInput", () => {
+      const updatedInput = { file_path: "/new/path" };
+      expect(
+        adapter.formatPreToolUseResponse({ decision: "modify", updatedInput }),
+      ).toEqual({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          updatedInput,
+        },
+      });
+    });
+
+    it("formats Bash redirect modify as deny", () => {
+      expect(
+        adapter.formatPreToolUseResponse({
+          decision: "modify",
+          updatedInput: { command: 'echo "Use ctx_execute instead"' },
+        }),
+      ).toEqual({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: "Use ctx_execute instead",
+        },
+      });
+    });
+
+    it("formats context with additionalContext", () => {
+      expect(
+        adapter.formatPreToolUseResponse({
+          decision: "context",
+          additionalContext: "Use sandbox tools.",
+        }),
+      ).toEqual({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          additionalContext: "Use sandbox tools.",
+        },
+      });
+    });
+
+    it("returns undefined for allow", () => {
+      expect(
+        adapter.formatPreToolUseResponse({ decision: "allow" }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("formatPostToolUseResponse", () => {
+    it("formats additionalContext", () => {
+      expect(
+        adapter.formatPostToolUseResponse({ additionalContext: "Captured." }),
+      ).toEqual({
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          additionalContext: "Captured.",
+        },
+      });
+    });
+
+    it("returns undefined when no context", () => {
+      expect(adapter.formatPostToolUseResponse({})).toBeUndefined();
+    });
+  });
+
+  describe("config paths", () => {
+    it("settings path is .qoder/settings.json", () => {
+      expect(adapter.getSettingsPath()).toBe(resolve(".qoder", "settings.json"));
+    });
+
+    it("config dir is .qoder under project dir", () => {
+      expect(adapter.getConfigDir("/my/project")).toBe(resolve("/my/project", ".qoder"));
+    });
+
+    it("session dir is under ~/.qoder/context-mode/sessions/", () => {
+      expect(adapter.getSessionDir()).toBe(
+        join(homedir(), ".qoder", "context-mode", "sessions"),
+      );
+    });
+
+    it("instruction files returns QODER.md", () => {
+      expect(adapter.getInstructionFiles()).toEqual(["QODER.md"]);
+    });
+  });
+
+  describe("hook config management", () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "qoder-adapter-test-"));
+      Object.defineProperty(adapter, "getSettingsPath", {
+        value: () => join(tempDir, "settings.json"),
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("generates hook config for 4 events", () => {
+      const config = adapter.generateHookConfig("/plugin/root") as Record<string, unknown>;
+      expect(Object.keys(config).sort()).toEqual([
+        "PostToolUse",
+        "PreToolUse",
+        "Stop",
+        "UserPromptSubmit",
+      ]);
+    });
+
+    it("configureAllHooks writes settings.json with hooks", () => {
+      const changes = adapter.configureAllHooks("/plugin/root");
+      const written = JSON.parse(
+        readFileSync(join(tempDir, "settings.json"), "utf-8"),
+      ) as Record<string, unknown>;
+
+      expect(changes.length).toBeGreaterThan(0);
+      expect(written.hooks).toBeTruthy();
+
+      const hooks = written.hooks as Record<string, Array<Record<string, unknown>>>;
+      expect(hooks.PreToolUse).toBeDefined();
+      expect(hooks.PostToolUse).toBeDefined();
+      expect(hooks.Stop).toBeDefined();
+      expect(hooks.UserPromptSubmit).toBeDefined();
+
+      const preEntry = hooks.PreToolUse[0] as Record<string, unknown>;
+      expect(String(preEntry.matcher)).toContain("Bash");
+    });
+
+    it("configureAllHooks is idempotent and skips write when no changes", () => {
+      const firstChanges = adapter.configureAllHooks("/plugin/root");
+      const first = readFileSync(join(tempDir, "settings.json"), "utf-8");
+      const secondChanges = adapter.configureAllHooks("/plugin/root");
+      const second = readFileSync(join(tempDir, "settings.json"), "utf-8");
+      expect(first).toBe(second);
+      expect(firstChanges.length).toBeGreaterThan(0);
+      expect(secondChanges).toEqual([]);
+    });
+
+    it("validateHooks passes when hooks configured", () => {
+      adapter.configureAllHooks("/plugin/root");
+      const results = adapter.validateHooks("/plugin/root");
+      const preResult = results.find((r) => r.check === "PreToolUse");
+      expect(preResult?.status).toBe("pass");
+    });
+
+    it("validateHooks fails when no settings", () => {
+      const results = adapter.validateHooks("/plugin/root");
+      expect(results[0]?.status).toBe("fail");
+    });
+  });
+
+  describe("stop hook", () => {
+    it("parseStopInput extracts session info", () => {
+      const event = adapter.parseStopInput({
+        session_id: "stop-session-1",
+        last_assistant_message: "Task completed.",
+      });
+      expect(event.sessionId).toBe("stop-session-1");
+      expect(event.lastMessage).toBe("Task completed.");
+    });
+
+    it("formatStopResponse with followup returns block", () => {
+      expect(
+        adapter.formatStopResponse({ followupMessage: "keep going" }),
+      ).toEqual({ decision: "block", reason: "keep going" });
+    });
+
+    it("formatStopResponse without followup returns empty", () => {
+      expect(adapter.formatStopResponse({})).toEqual({});
+    });
+  });
+
+  describe("config templates (configs/qoder/)", () => {
+    const configsDir = resolve(process.cwd(), "configs", "qoder");
+
+    it("mcp.json has correct MCP server structure", () => {
+      const mcp = JSON.parse(
+        readFileSync(join(configsDir, "mcp.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      const servers = mcp.mcpServers as Record<string, unknown>;
+      expect(servers).toBeDefined();
+      expect(servers["context-mode"]).toBeDefined();
+      expect((servers["context-mode"] as Record<string, unknown>).command).toBe("context-mode");
+    });
+
+    it("settings.json template has all 4 hook event types", () => {
+      const settings = JSON.parse(
+        readFileSync(join(configsDir, "settings.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      const hooks = settings.hooks as Record<string, Array<Record<string, unknown>>>;
+      expect(hooks).toBeDefined();
+      expect(hooks.PreToolUse).toBeDefined();
+      expect(hooks.PostToolUse).toBeDefined();
+      expect(hooks.UserPromptSubmit).toBeDefined();
+      expect(hooks.Stop).toBeDefined();
+    });
+
+    it("settings.json PreToolUse has matcher pattern with Bash", () => {
+      const settings = JSON.parse(
+        readFileSync(join(configsDir, "settings.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      const hooks = settings.hooks as Record<string, Array<Record<string, unknown>>>;
+      const preEntry = hooks.PreToolUse[0] as Record<string, unknown>;
+      expect(String(preEntry.matcher)).toContain("Bash");
+    });
+
+    it("settings.json template is consistent with generateHookConfig output", () => {
+      const settings = JSON.parse(
+        readFileSync(join(configsDir, "settings.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      const templateHooks = settings.hooks as Record<string, Array<Record<string, unknown>>>;
+      const generated = adapter.generateHookConfig("/plugin/root") as Record<string, unknown>;
+      const generatedHooks = generated as Record<string, Array<Record<string, unknown>>>;
+
+      // Same event types present
+      expect(Object.keys(templateHooks).sort()).toEqual(
+        Object.keys(generatedHooks).sort(),
+      );
+
+      // PreToolUse matcher matches
+      const templatePre = templateHooks.PreToolUse[0] as Record<string, unknown>;
+      const generatedPre = generatedHooks.PreToolUse[0] as Record<string, unknown>;
+      expect(templatePre.matcher).toBe(generatedPre.matcher);
+    });
+
+    it("all hook commands reference context-mode hook qoder", () => {
+      const settings = JSON.parse(
+        readFileSync(join(configsDir, "settings.json"), "utf-8"),
+      ) as Record<string, unknown>;
+      const hooks = settings.hooks as Record<string, Array<Record<string, unknown>>>;
+      for (const [eventType, entries] of Object.entries(hooks)) {
+        for (const entry of entries) {
+          const hookEntries = entry.hooks as Array<Record<string, unknown>>;
+          for (const hook of hookEntries) {
+            expect(String(hook.command)).toMatch(/^context-mode hook qoder /);
+            expect(String(hook.type)).toBe("command");
+          }
+        }
+      }
+    });
+  });
+});

--- a/tests/fixtures/qoder/posttooluse-bash.json
+++ b/tests/fixtures/qoder/posttooluse-bash.json
@@ -1,0 +1,9 @@
+{
+  "hook_event_name": "PostToolUse",
+  "session_id": "qoder-session-001",
+  "transcript_path": "/tmp/qoder-transcript.jsonl",
+  "cwd": "/tmp/qoder-project",
+  "tool_name": "Bash",
+  "tool_input": { "command": "ls -la" },
+  "tool_response": "total 24\ndrwxr-xr-x  5 user user 4096 src/\n-rw-r--r--  1 user user  256 package.json"
+}

--- a/tests/fixtures/qoder/pretooluse-bash.json
+++ b/tests/fixtures/qoder/pretooluse-bash.json
@@ -1,0 +1,9 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "qoder-session-001",
+  "transcript_path": "/tmp/qoder-transcript.jsonl",
+  "cwd": "/tmp/qoder-project",
+  "tool_name": "Bash",
+  "tool_input": { "command": "curl https://example.com/api" },
+  "extra": { "email": "user@example.com" }
+}


### PR DESCRIPTION
## Summary

Add first-class Qoder IDE platform support as a single, complete integration PR. Qoder is a VS Code-based agentic IDE developed by Alibaba Group. This replaces the previously split PRs #798 and #799.

## What

### Adapter core (`src/adapters/qoder/`)
- `QoderAdapter` class implementing `HookAdapter` with json-stdio paradigm
- Parse/format for PreToolUse, PostToolUse, Stop, UserPromptSubmit
- Tool name mapping: `run_in_terminal`→Bash, `read_file`→Read, `create_file`→Write, `search_replace`→Edit
- Hook config management via `.qoder/settings.json` (read/write/configure/validate)
- Session ID extraction chain: `session_id` → `QODER_SESSION_ID` env → `pid-${ppid}` fallback

### Platform detection (`src/adapters/detect.ts`)
- `QODER_AGENT` env var checked **before** `VSCODE_PID` (Qoder inherits it as a VS Code fork)
- `~/.qoder/` config directory as medium-confidence fallback
- Lazy-load adapter via dynamic `import()`

### Hook scripts (`hooks/qoder/`)
- `pretooluse.mjs` — Full routing: stdin → `routePreToolUse` → `formatDecision` → stdout
- `posttooluse.mjs` — Passthrough (session event capture, no routing decision)
- `stop.mjs` — Passthrough (exit 0)
- `userpromptsubmit.mjs` — Passthrough with future route-injection hook point

### Formatter (`hooks/core/formatters.mjs`)
- `qoder` formatter entry with `hookSpecificOutput` wire format (compatible with Claude Code)
- Bash redirect→deny conversion
- `typeof` guard on `updatedInput` before `in` operator to prevent TypeError

### Config templates (`configs/qoder/`)
- `QODER.md` — Routing instructions (Bash curl/wget → `ctx_fetch_and_index`, etc.)
- `mcp.json` — MCP server registration template
- `settings.json` — Hook configuration reference (all 4 event types)

### Documentation (`docs/platform-support.md`)
- Platform count: 16 → 17
- Qoder column added to all comparison tables (Main, Capability Matrix, Hook Response Format, CLI Dispatcher)
- Detailed Qoder platform section with correct capability labeling (Context Injection, not Output Modification)

### CLI dispatch (`src/cli.ts`)
- Hook dispatcher entry for `qoder` (pretooluse, posttooluse, userpromptsubmit, stop)

### Other modifications
- `src/adapters/types.ts` — Add `qoder` to `PlatformId` union
- `src/adapters/client-map.ts` — Add MCP client name mapping (`qoder`/`Qoder`)
- `hooks/session-helpers.mjs` — Add `QODER_OPTS` (configDir, projectDirEnv, sessionIdEnv)

## Design Decisions

1. **Independent adapter** (not extending ClaudeCodeAdapter) — Different tool names, config paths, and detection logic. Independent adapter avoids fragile coupling.
2. **Detection priority** — `QODER_AGENT` before `VSCODE_PID` because Qoder is a VS Code fork and always sets `VSCODE_PID`.
3. **Wire format reuse** — Qoder uses the same `hookSpecificOutput` JSON structure as Claude Code. The formatter includes the same Bash redirect-to-deny logic.
4. **Passthrough for Stop/UserPromptSubmit** — These events don't require routing decisions.

## Testing

- **37 unit tests** in `tests/adapters/qoder.test.ts`:
  - Capabilities verification
  - PreToolUse parsing (5 scenarios)
  - PostToolUse parsing (4 scenarios: fixture, non-string, undefined, null)
  - PreToolUse response formatting (6 scenarios: allow, deny, deny+reason, arg mod, context injection, Bash redirect deny)
  - PostToolUse response formatting (2 scenarios)
  - Config path resolution (4 scenarios)
  - Hook config management (5 scenarios: generate, configure, validate, idempotent no-write, missing settings)
  - Stop hook (3 scenarios)
  - Config template validation (5 tests: mcp.json schema, settings.json schema, matcher, consistency with generateHookConfig, command format)
- All adapter + hook tests pass (1456/1457, 1 pre-existing OMP build failure unrelated)

## Notes

- `qodercli plugin validate` can be run against `configs/qoder/` to verify plugin structure once Qoder login is available
- Live Qoder MCP/hook smoke test requires authenticated Qoder CLI access — static validation only in this PR
- This PR supersedes closed PRs #798 and #799, combining adapter core + hook scripts + config templates + docs into a single PR per reviewer request