### PR TITLE
fix(hooks): respect subagent ctx tool availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1482,7 +1482,6 @@ That blocks loopback + RFC1918 + ULA in addition to the always-blocked ranges. U
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `CONTEXT_MODE_DISABLE_AGENT_INJECTION` | unset | Set to `1`, `true`, `yes`, or `on` to disable Claude Code `Agent` prompt injection. Main-session routing guidance and MCP redirects stay active; this only skips the extra routing block appended to spawned `Agent` prompts. Useful when foreground subagents should not be forced into `ctx_*` calls. |
 | `CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY` | `10` | Cadence (in tool calls) at which the PreToolUse hook re-injects the "wrap large external-MCP payloads in `ctx_execute`" guidance. The original implementation ([#529](https://github.com/mksglu/context-mode/pull/529)) fired only once per session, which got lost after context compaction in MCP-heavy sessions (e.g. 50+ Jira/Slack/Notion calls — see [#567](https://github.com/mksglu/context-mode/issues/567) follow-up). The default re-fires every 10th matching call, keeping the guidance in the model's recent window. Range `[1, 100]`; invalid values fall back to `10`. Set to `1` for "every call" (most aggressive — adds ~250 tokens/call) or to a larger value for less frequent reminders. |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1482,6 +1482,7 @@ That blocks loopback + RFC1918 + ULA in addition to the always-blocked ranges. U
 
 | Variable | Default | Purpose |
 |---|---|---|
+| `CONTEXT_MODE_DISABLE_AGENT_INJECTION` | unset | Set to `1`, `true`, `yes`, or `on` to disable Claude Code `Agent` prompt injection. Main-session routing guidance and MCP redirects stay active; this only skips the extra routing block appended to spawned `Agent` prompts. Useful when foreground subagents should not be forced into `ctx_*` calls. |
 | `CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY` | `10` | Cadence (in tool calls) at which the PreToolUse hook re-injects the "wrap large external-MCP payloads in `ctx_execute`" guidance. The original implementation ([#529](https://github.com/mksglu/context-mode/pull/529)) fired only once per session, which got lost after context compaction in MCP-heavy sessions (e.g. 50+ Jira/Slack/Notion calls — see [#567](https://github.com/mksglu/context-mode/issues/567) follow-up). The default re-fires every 10th matching call, keeping the guidance in the model's recent window. Range `[1, 100]`; invalid values fall back to `10`. Set to `1` for "every call" (most aggressive — adds ~250 tokens/call) or to a larger value for less frequent reminders. |
 
 ## Contributing

--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -76,11 +76,6 @@ function getExternalMcpNudgeEvery() {
   return parsed;
 }
 
-function isTruthyEnv(name) {
-  const raw = process.env[name];
-  return raw === "1" || /^(true|yes|on)$/i.test(raw ?? "");
-}
-
 function defaultGuidanceId() {
   return process.env.VITEST_WORKER_ID
     ? `${process.ppid}-w${process.env.VITEST_WORKER_ID}`
@@ -829,8 +824,6 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
   // ─── Agent: inject context-mode routing into subagent prompts ───
   // Subagents cannot use ctx commands (stats/doctor/upgrade/purge) — omit that section (#233)
   if (canonical === "Agent") {
-    if (isTruthyEnv("CONTEXT_MODE_DISABLE_AGENT_INJECTION")) return null;
-
     const subagentType = toolInput.subagent_type ?? "";
     // Detect the correct field name for the prompt/request/objective/question/query
     const fieldName = ["prompt", "request", "objective", "question", "query", "task"].find(f => f in toolInput) ?? "prompt";

--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -25,7 +25,8 @@ import { existsSync, mkdirSync, rmSync, rmdirSync, readdirSync, unlinkSync, open
  * redirect action — prevents agent from getting stuck when MCP tools
  * are unavailable. Applies to deny and modify actions that mention MCP alternatives.
  */
-function mcpRedirect(result) {
+function mcpRedirect(result, mcpToolsAvailable = true) {
+  if (!mcpToolsAvailable) return null;
   if (!isMCPReady()) return null;
   return result;
 }
@@ -73,6 +74,11 @@ function getExternalMcpNudgeEvery() {
     return EXTERNAL_MCP_NUDGE_DEFAULT;
   }
   return parsed;
+}
+
+function isTruthyEnv(name) {
+  const raw = process.env[name];
+  return raw === "1" || /^(true|yes|on)$/i.test(raw ?? "");
 }
 
 function defaultGuidanceId() {
@@ -604,8 +610,14 @@ function getPlatformSettingsPath(platform) {
  * @param {string} [sessionId] - Stable session identifier from hook payload. When
  *   provided, the guidance throttle uses it to scope marker files across hook
  *   invocations even when process.ppid shifts (Windows/Git Bash — see #298).
+ * @param {object} [options] - Runtime routing context from the adapter.
+ * @param {boolean} [options.mcpToolsAvailable=true] - False when the current
+ *   caller context cannot invoke ctx_* MCP tools even though an MCP server is
+ *   live on the machine (Claude Code fixed-tool subagents — #794).
  */
-export function routePreToolUse(toolName, toolInput, projectDir, platform, sessionId) {
+export function routePreToolUse(toolName, toolInput, projectDir, platform, sessionId, options = {}) {
+  const mcpToolsAvailable = options.mcpToolsAvailable !== false;
+
   // ─── Opt-in fail-closed gate (#468 follow-up) ───
   // Default behavior on security-module load failure is fail-OPEN (a stderr
   // warning is emitted but routing continues). Security-conscious users can
@@ -715,7 +727,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
             bytesAvoided: 8192,
             commandSummary: command.slice(0, 200),
           },
-        });
+        }, mcpToolsAvailable);
       }
       // All segments safe → allow through
       return null;
@@ -737,7 +749,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
         updatedInput: {
           command: `echo "context-mode: Inline HTTP redirected. Call ${t("ctx_execute")}(language, code) to fetch, derive your answer in code, and console.log() only the result — the raw response body stays in the sandbox instead of entering your conversation. Full network access. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
         },
-      });
+      }, mcpToolsAvailable);
     }
 
     // Build tools (gradle, maven, sbt) → redirect to execute sandbox (Issue #38, #406).
@@ -750,7 +762,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
         updatedInput: {
           command: `echo "context-mode: Build tool redirected. Call ${t("ctx_execute")}(language: \\"shell\\", code: \\"${safeCmd} 2>&1 | tail -30\\") to run the build and print only the tail — the verbose build log stays in the sandbox instead of entering your conversation. For more targeted output, replace \\"tail -30\\" with \\"grep -E '(error|warning|FAIL|✗|×)'\\" or similar, so only the lines that matter come back."`,
         },
-      });
+      }, mcpToolsAvailable);
     }
 
     // Skip the routing nudge for commands whose output is structurally
@@ -811,12 +823,14 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
         bytesAvoided: 16384,
         commandSummary: String(url).slice(0, 200),
       },
-    });
+    }, mcpToolsAvailable);
   }
 
   // ─── Agent: inject context-mode routing into subagent prompts ───
   // Subagents cannot use ctx commands (stats/doctor/upgrade/purge) — omit that section (#233)
   if (canonical === "Agent") {
+    if (isTruthyEnv("CONTEXT_MODE_DISABLE_AGENT_INJECTION")) return null;
+
     const subagentType = toolInput.subagent_type ?? "";
     // Detect the correct field name for the prompt/request/objective/question/query
     const fieldName = ["prompt", "request", "objective", "question", "query", "task"].find(f => f in toolInput) ?? "prompt";

--- a/hooks/pretooluse.mjs
+++ b/hooks/pretooluse.mjs
@@ -164,9 +164,12 @@ await runHook(async () => {
   const tool = input.tool_name ?? "";
   const toolInput = input.tool_input ?? {};
   const projectDir = getInputProjectDir(input);
+  const isSubagentContext = input.agent_id != null || input.agent_type != null;
 
   // ─── Route and format response ───
-  const decision = routePreToolUse(tool, toolInput, projectDir, "claude-code", getSessionId(input));
+  const decision = routePreToolUse(tool, toolInput, projectDir, "claude-code", getSessionId(input), {
+    mcpToolsAvailable: !isSubagentContext,
+  });
   const response = formatDecision("claude-code", decision);
 
   // ─── Write latency marker for cross-hook timing (Category 27) ───

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -410,10 +410,25 @@ describe("routePreToolUse", () => {
       expect(result).toBeNull();
     });
 
-    it("Claude Code pretooluse marks subagent hook payloads as ctx_* unavailable (#794)", () => {
-      const src = readFileSync(resolve("hooks", "pretooluse.mjs"), "utf-8");
-      expect(src).toContain("input.agent_id != null || input.agent_type != null");
-      expect(src).toContain("mcpToolsAvailable: !isSubagentContext");
+    it("Claude Code pretooluse treats subagent hook payloads as ctx_* unavailable (#794)", async () => {
+      const main = await spawnPreToolUseHook({
+        tool_name: "WebFetch",
+        tool_input: { url: "https://example.com" },
+        session_id: "core-routing-main-webfetch",
+      });
+      expect(main.status).toBe(0);
+      expect(main.parsed?.hookSpecificOutput?.permissionDecision).toBe("deny");
+      expect(main.parsed?.hookSpecificOutput?.permissionDecisionReason).toContain("ctx_fetch_and_index");
+
+      const subagent = await spawnPreToolUseHook({
+        tool_name: "WebFetch",
+        tool_input: { url: "https://example.com" },
+        session_id: "core-routing-subagent-webfetch",
+        agent_id: "agent-794",
+        agent_type: "claude-code-guide",
+      });
+      expect(subagent.status).toBe(0);
+      expect(subagent.stdout).toBe("");
     });
   });
 
@@ -436,6 +451,26 @@ describe("routePreToolUse", () => {
       try { unlinkSync(mcpSentinel); } catch {}
       const result = routePreToolUse("Bash", { command: "./gradlew build" });
       expect(result).toBeNull();
+    });
+
+    it("allows MCP-backed redirects when the caller context cannot invoke ctx_* tools", () => {
+      const cases = [
+        ["Bash", { command: "curl https://example.com" }],
+        ["Bash", { command: "node -e \"fetch('https://example.com')\"" }],
+        ["Bash", { command: "./gradlew build" }],
+      ] as const;
+
+      for (const [tool, input] of cases) {
+        const result = routePreToolUse(
+          tool,
+          input,
+          undefined,
+          "claude-code",
+          `subagent-${tool}`,
+          { mcpToolsAvailable: false },
+        );
+        expect(result).toBeNull();
+      }
     });
   });
 
@@ -1175,6 +1210,25 @@ async function spawnRoutingProbe(
 ): Promise<{ status: number | null; stdout: string; parsed: any }> {
   const { spawnSync } = await import("node:child_process");
   const r = spawnSync("node", ["--input-type=module", "-e", code], {
+    encoding: "utf-8",
+    timeout: 15_000,
+    env: { ...process.env, ...env },
+  });
+  const stdout = (r.stdout ?? "").trim();
+  let parsed: any = null;
+  try { parsed = JSON.parse(stdout); } catch { /* surface raw */ }
+  return { status: r.status, stdout, parsed };
+}
+
+async function spawnPreToolUseHook(
+  input: Record<string, unknown>,
+  env: Record<string, string> = {},
+): Promise<{ status: number | null; stdout: string; parsed: any }> {
+  const { spawnSync } = await import("node:child_process");
+  const repoRoot = resolve(SLICE4_DIRNAME, "..", "..");
+  const r = spawnSync(process.execPath, ["hooks/pretooluse.mjs"], {
+    cwd: repoRoot,
+    input: JSON.stringify(input),
     encoding: "utf-8",
     timeout: 15_000,
     env: { ...process.env, ...env },

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -504,7 +504,6 @@ describe("routePreToolUse", () => {
     });
 
     it("injects Claude Code Agent routing and ToolSearch bootstrap by default", () => {
-      delete process.env.CONTEXT_MODE_DISABLE_AGENT_INJECTION;
       const result = routePreToolUse("Agent", {
         prompt: "Research this repository",
         subagent_type: "general-purpose",
@@ -533,21 +532,6 @@ describe("routePreToolUse", () => {
       const t = (name: string) => `mcp__test__${name}`;
       const block = createRoutingBlock(t);
       expect(block).toContain("<ctx_commands>");
-    });
-
-    it("passes Agent through when Agent prompt injection is disabled (#832)", () => {
-      const previous = process.env.CONTEXT_MODE_DISABLE_AGENT_INJECTION;
-      process.env.CONTEXT_MODE_DISABLE_AGENT_INJECTION = "1";
-      try {
-        const result = routePreToolUse("Agent", {
-          prompt: "Research this repository",
-          subagent_type: "general-purpose",
-        });
-        expect(result).toBeNull();
-      } finally {
-        if (previous === undefined) delete process.env.CONTEXT_MODE_DISABLE_AGENT_INJECTION;
-        else process.env.CONTEXT_MODE_DISABLE_AGENT_INJECTION = previous;
-      }
     });
   });
 

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -26,6 +26,7 @@ let routePreToolUse: (
   projectDir?: string,
   platform?: string,
   sessionId?: string,
+  options?: { mcpToolsAvailable?: boolean },
 ) => {
   action: string;
   reason?: string;
@@ -396,6 +397,24 @@ describe("routePreToolUse", () => {
       const result = routePreToolUse("mcp_web_fetch", { url: "https://example.com" });
       expect(result).toBeNull();
     });
+
+    it("passes WebFetch through when the caller context cannot invoke ctx_* tools (#794)", () => {
+      const result = routePreToolUse(
+        "WebFetch",
+        { url: "https://example.com" },
+        undefined,
+        "claude-code",
+        "subagent-webfetch",
+        { mcpToolsAvailable: false },
+      );
+      expect(result).toBeNull();
+    });
+
+    it("Claude Code pretooluse marks subagent hook payloads as ctx_* unavailable (#794)", () => {
+      const src = readFileSync(resolve("hooks", "pretooluse.mjs"), "utf-8");
+      expect(src).toContain("input.agent_id != null || input.agent_type != null");
+      expect(src).toContain("mcpToolsAvailable: !isSubagentContext");
+    });
   });
 
   // ─── MCP readiness: all redirects degrade gracefully (#230) ───
@@ -451,6 +470,21 @@ describe("routePreToolUse", () => {
       const t = (name: string) => `mcp__test__${name}`;
       const block = createRoutingBlock(t);
       expect(block).toContain("<ctx_commands>");
+    });
+
+    it("passes Agent through when Agent prompt injection is disabled (#832)", () => {
+      const previous = process.env.CONTEXT_MODE_DISABLE_AGENT_INJECTION;
+      process.env.CONTEXT_MODE_DISABLE_AGENT_INJECTION = "1";
+      try {
+        const result = routePreToolUse("Agent", {
+          prompt: "Research this repository",
+          subagent_type: "general-purpose",
+        });
+        expect(result).toBeNull();
+      } finally {
+        if (previous === undefined) delete process.env.CONTEXT_MODE_DISABLE_AGENT_INJECTION;
+        else process.env.CONTEXT_MODE_DISABLE_AGENT_INJECTION = previous;
+      }
     });
   });
 

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -37,7 +37,7 @@ let routePreToolUse: (
 let resetGuidanceThrottle: () => void;
 let initSecurity: (buildDir: string) => Promise<boolean>;
 let ROUTING_BLOCK: string;
-let createRoutingBlock: (t: any, options?: { includeCommands?: boolean }) => string;
+let createRoutingBlock: (t: any, options?: { includeCommands?: boolean; toolSearchBootstrap?: boolean }) => string;
 let READ_GUIDANCE: string;
 let GREP_GUIDANCE: string;
 
@@ -410,6 +410,19 @@ describe("routePreToolUse", () => {
       expect(result).toBeNull();
     });
 
+    it("keeps WebFetch redirected when options are omitted", () => {
+      const result = routePreToolUse(
+        "WebFetch",
+        { url: "https://example.com" },
+        undefined,
+        "claude-code",
+        "main-webfetch-default-options",
+      );
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("deny");
+      expect(result!.reason).toContain("ctx_fetch_and_index");
+    });
+
     it("Claude Code pretooluse treats subagent hook payloads as ctx_* unavailable (#794)", async () => {
       const main = await spawnPreToolUseHook({
         tool_name: "WebFetch",
@@ -458,6 +471,7 @@ describe("routePreToolUse", () => {
         ["Bash", { command: "curl https://example.com" }],
         ["Bash", { command: "node -e \"fetch('https://example.com')\"" }],
         ["Bash", { command: "./gradlew build" }],
+        ["WebFetch", { url: "https://example.com" }],
       ] as const;
 
       for (const [tool, input] of cases) {
@@ -487,6 +501,20 @@ describe("routePreToolUse", () => {
       const prompt = (result!.updatedInput as Record<string, string>).prompt;
       expect(prompt).not.toContain("<ctx_commands>");
       expect(prompt).toContain("<tool_selection_hierarchy>");
+    });
+
+    it("injects Claude Code Agent routing and ToolSearch bootstrap by default", () => {
+      delete process.env.CONTEXT_MODE_DISABLE_AGENT_INJECTION;
+      const result = routePreToolUse("Agent", {
+        prompt: "Research this repository",
+        subagent_type: "general-purpose",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("modify");
+      const prompt = (result!.updatedInput as Record<string, string>).prompt;
+      expect(prompt).toContain("<context_window_protection>");
+      expect(prompt).toContain("ToolSearch");
+      expect(prompt).not.toContain("<ctx_commands>");
     });
 
     it("ROUTING_BLOCK constant includes ctx_commands for main session", () => {


### PR DESCRIPTION
## What / Why / How

Fixes #794.
Fixes #832.

Claude Code subagent-originated `WebFetch` calls can be blocked by the main-session MCP readiness check even when that subagent cannot invoke any `ctx_*` MCP tools. In that state the hook denies `WebFetch` and tells the subagent to call `ctx_fetch_and_index`, but the suggested tool is not available in the subagent's tool surface.

Claude Code `Agent` prompt injection also had no supported opt-out. The default injection is useful for subagents that can use context-mode tools, but foreground subagents can hang or become unusable when forced into `ctx_*` calls that are unavailable or blocking.

With this PR applied, Claude Code PreToolUse distinguishes machine-global MCP readiness from the current caller's `ctx_*` availability:

- main-session `WebFetch` still redirects to `ctx_fetch_and_index`
- subagent-originated `WebFetch` passes through when the hook payload has `agent_id` or `agent_type`
- default `Agent` prompt injection remains unchanged
- `CONTEXT_MODE_DISABLE_AGENT_INJECTION=1` disables only `Agent` prompt injection
- existing subagent invariants are preserved: ToolSearch bootstrap remains present, and `<ctx_commands>` remains omitted
- regression coverage is added to the existing `tests/hooks/core-routing.test.ts`
- the new env var is documented in `README.md`

## Affected platforms

Agent / CLI scope:

- [x] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw / Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All standalone MCP server launchers
- [ ] All platforms

OS scope:

- [x] Linux
- [x] macOS
- [x] Windows
- [x] All operating systems

Scope notes:

- This is a Claude Code PreToolUse hook-routing change. The `agent_id` / `agent_type` discriminator is Claude Code-specific, so other adapters are not changed to infer subagent tool availability.
- `routePreToolUse()` keeps `mcpToolsAvailable` defaulting to `true`, so existing callers preserve the current redirect behavior unless an adapter explicitly marks the caller as unable to invoke `ctx_*`.
- The `CONTEXT_MODE_DISABLE_AGENT_INJECTION` opt-out affects `Agent` prompt injection only. It does not disable SessionStart routing guidance, MCP redirects in the main session, or the context-mode MCP server.

## Root Cause

Git archaeology:

- `9e29a94` / PR #683 introduced the WebFetch redirect/refusal path and the current "redirect, not restriction" wording.
- `b1ba5cc` / PR #725 added the Claude Code ToolSearch bootstrap to subagent prompts so deferred `ctx_*` schemas can be loaded before use.
- `245cd8a` / PR #233 made subagent routing blocks omit `<ctx_commands>`, because subagents cannot use meta commands such as stats/doctor/upgrade/purge.

The failure happens because `isMCPReady()` is machine-global. It answers whether a context-mode MCP server process is alive on the machine, not whether the current Claude Code caller context can invoke `ctx_*` tools. Claude Code PreToolUse payloads include `agent_id` / `agent_type` for subagent-originated calls, so the adapter can pass that caller context into shared routing.

The PR preserves these older invariants:

- main-session WebFetch continues to redirect to `ctx_fetch_and_index`
- default Claude Code `Agent` prompt injection remains enabled
- the #725 ToolSearch bootstrap remains in default Claude Code subagent prompts
- the #233 `<ctx_commands>` omission remains in subagent routing blocks

Related prior work checked:

- #680 was a closed, unmerged #641 proposal using a subagent-name skip-list for routing-block token cost. It is not a duplicate of this PR because it does not address #794 WebFetch denial and is not present on `next`.
- #207 was a closed OpenCode AGENTS.md global-injection-location toggle. It does not affect Claude Code `Agent` prompt injection.

## Cross-agent / cross-OS risk

This PR is intentionally scoped to Claude Code's hook adapter because `agent_id` and `agent_type` are Claude Code PreToolUse payload fields. The shared routing API keeps the previous default for all other adapters, so Cursor, VS Code Copilot, JetBrains Copilot, Gemini CLI, Qwen Code, OpenCode/Kilo, Codex CLI, OpenClaw/Pi, Kiro, Antigravity, Zed, and standalone MCP launchers do not get new subagent tool-availability behavior unless their adapter explicitly opts in later.

The runtime code is plain Node.js hook code and was validated on Linux, macOS, and Windows. No platform-specific path handling, shell parsing, or generated server bundle path is changed.

## Validation

Detailed maintainer-style validation results are reported in a PR comment rather than kept in the body.
