### PR TITLE
test: isolate next full-suite env assumptions

### DIFF
--- a/tests/adapters/detect-claude-code-in-vscode.test.ts
+++ b/tests/adapters/detect-claude-code-in-vscode.test.ts
@@ -45,23 +45,28 @@ vi.mock("node:os", async () => {
 
 const {
   detectPlatform,
+  PLATFORM_ENV_VARS,
   __resetClaudeCodePluginCacheForTests,
 } = await import("../../src/adapters/detect.js");
+
+function clearPlatformDetectionEnv() {
+  for (const vars of PLATFORM_ENV_VARS.values()) {
+    for (const { name } of vars) {
+      delete process.env[name];
+    }
+  }
+}
 
 describe("Issue #539 — Claude Code inside VS Code disambiguation", () => {
   let savedEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
     savedEnv = { ...process.env };
-    // Wipe every marker so each test starts from a clean slate.
-    delete process.env.CLAUDE_PROJECT_DIR;
-    delete process.env.CLAUDE_SESSION_ID;
-    delete process.env.CLAUDE_CODE_ENTRYPOINT;
-    delete process.env.CLAUDE_PLUGIN_ROOT;
+    // Wipe every platform marker so each test starts from a clean slate even
+    // when Vitest is launched from another supported agent such as Codex.
+    clearPlatformDetectionEnv();
     delete process.env.CLAUDE_PLUGIN_DATA;
     delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS;
-    delete process.env.VSCODE_PID;
-    delete process.env.VSCODE_CWD;
     delete process.env.CONTEXT_MODE_PLATFORM;
     homedirMock.current = "";
     __resetClaudeCodePluginCacheForTests();

--- a/tests/util/postinstall-heal.test.ts
+++ b/tests/util/postinstall-heal.test.ts
@@ -47,8 +47,12 @@ function stagePostinstallPackage(): {
   scriptPath: string;
   packageDir: string;
 } {
-  const root = mkdtempSync(join(tmpdir(), "ctx-postinstall-pkg-"));
-  cleanups.push(root);
+  const base = mkdtempSync(join(tmpdir(), "ctx-postinstall-global-root-"));
+  cleanups.push(base);
+  // Keep the fake package several levels below tmpdir. isGlobalInstall() only
+  // scans four ancestors; this prevents ambient markers like /tmp/.git from
+  // making the staged global-install fixture look like a contributor checkout.
+  const root = join(base, "npm", "lib", "node_modules", "context-mode");
   const scriptsDir = join(root, "scripts");
   const hooksDir = join(root, "hooks");
   mkdirSync(scriptsDir, { recursive: true });


### PR DESCRIPTION
## What / Why / How

`upstream/next` full suite was failing from two test-isolation assumptions:

- `detect-claude-code-in-vscode.test.ts` cleared Claude/VSCODE env markers, but not other platform markers. When the suite runs under Codex, `CODEX_THREAD_ID` / `CODEX_CI` remain set, so `detectPlatform()` returns `codex` before the test reaches the intended VS Code / Claude Code paths.
- `postinstall-heal.test.ts` staged its fake global install directly under `tmpdir()`. In environments where `tmpdir()` has an ambient `.git` ancestor, such as `/tmp/.git`, `isGlobalInstall()` treats the staged package as a contributor checkout and skips the heal path.

This PR keeps runtime code unchanged and fixes only the test setup:

- clear all platform detection env vars from `PLATFORM_ENV_VARS` before each #539 detection test
- stage the fake global postinstall package several levels below `tmpdir()` so ambient parent `.git` markers cannot affect the fixture
- preserve the existing #531 guard: real contributor / CI installs still must not mutate source-tracked plugin files

## Affected platforms

OS scope:

- [x] Linux
- [x] macOS
- [x] Windows
- [x] All operating systems

Scope notes:

- Test-only patch. No runtime adapter, hook, MCP, agent CLI, or postinstall behavior changes.
- No Agent / CLI runtime scope is listed because this PR only makes tests hermetic.
- The adapter test failure was exposed when the suite ran under Codex, because Codex-provided env (`CODEX_THREAD_ID` / `CODEX_CI`) leaked into a Claude Code / VS Code detection test.
- The postinstall test failure was exposed by the local temp directory shape (`/tmp/.git`), not by a production install path.

## Root Cause

Git archaeology:

- `734bdbc` added Codex detection via `CODEX_THREAD_ID` / `CODEX_CI`.
- `466d5b5` / `f8913ea` / `14b042a` / `8b9d13a` added the #539 Claude Code inside VS Code tests, but those tests only cleared Claude/VSCODE env markers.
- `8c045f9` added `postinstall-heal.test.ts` with a fake global-install fixture that assumes no `.git` ancestor under `tmpdir()`.
- `ceaec16` made `isGlobalInstall()` protect contributor / CI installs from source file mutation for #531.

The failures were caused by non-hermetic test setup, not by the runtime paths under test.

## Validation

| Environment | Command / check | Result |
| --- | --- | --- |
| Linux local | `npm run typecheck` | passed |
| Linux local | failing files: adapter + postinstall | passed: 14 tests |
| Linux local | `npx vitest run tests/adapters --reporter=dot` | passed: 42 files, 942 tests |
| Linux local | postinstall/heal adjacent set | passed: 5 files, 91 tests |
| Linux local | `npm test -- --reporter=dot` | passed: 186 files, 4275 tests, 37 skipped |
| macOS `ssh my-mac` | failing files: adapter + postinstall | passed: 14 tests |
| macOS `ssh my-mac` | adjacent adapter/postinstall set | passed: 5 files, 100 tests |
| macOS `ssh my-mac` | `npm run typecheck` | passed |
| Windows `ssh my-window` | failing files: adapter + postinstall | passed: 14 tests |
| Windows `ssh my-window` | adjacent adapter/postinstall set | passed: 5 files, 100 tests |
| Windows `ssh my-window` | `npm run typecheck` | passed |

## Checklist

- [x] Existing test files updated; no new test file
- [x] Runtime code unchanged
- [x] Targeted tests pass
- [x] Broader related tests pass
- [x] Full Linux suite passes
- [x] 3OS validation completed
- [x] Targets `next`
