### PR TITLE
fix(lifecycle): reap idle MCP bridge children to stop pi/omp accumulation (#854)

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -11,6 +11,12 @@
  * next poll tick), which closes the multi-day CPU-spin window seen in
  * #311/#388 without reintroducing the false-positive shutdowns of #236.
  *
+ * Additionally, for MCP BRIDGE CHILDREN only (CONTEXT_MODE_BRIDGE_DEPTH>0), a
+ * request-idle self-shutdown reaps a child that a pi/omp sub-context abandoned
+ * while its long-lived parent keeps running (#854) — gated so the depth-0
+ * keep-alive servers #602 restored are never reaped, never via stdin EOF, and
+ * never while a tool call is in flight (#643).
+ *
  * Cross-platform: macOS, Linux, Windows.
  */
 
@@ -23,6 +29,12 @@ export interface LifecycleGuardOptions {
   onShutdown: () => void;
   /** Injectable parent-alive check (for testing). Default: ppid-based check. */
   isParentAlive?: () => boolean;
+  /**
+   * #854: request-idle shutdown timeout (ms) for MCP bridge children. Default:
+   * {@link bridgeChildIdleTimeoutMs}() — 0 (disabled) unless CONTEXT_MODE_BRIDGE_DEPTH>0.
+   * Exposed for testing.
+   */
+  bridgeIdleMs?: number;
 }
 
 /** Read grandparent PID via `ps -o ppid= -p $PPID`. Returns NaN on failure or Windows. */
@@ -115,6 +127,81 @@ export function lifecycleGuardIntervalForEnv(
 }
 
 /**
+ * #854: idle-shutdown timeout (ms) for an MCP BRIDGE CHILD. Returns 0 (disabled)
+ * unless this process is a bridge child (CONTEXT_MODE_BRIDGE_DEPTH>0). depth-0 /
+ * absent always returns 0, so the long-lived keep-alive servers that #602
+ * restored are NEVER reaped on idle. Default for bridge children is 3 min;
+ * override with CONTEXT_MODE_BRIDGE_IDLE_MS (a non-positive value disables it).
+ * The reaper additionally never fires while a tool call is in flight (see
+ * {@link noteRequestStart}), so the window only bounds how fast *abandoned*
+ * children drain — it does not cap legitimate long-running calls.
+ *
+ * Exported for unit-testing.
+ */
+export function bridgeChildIdleTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const depth = Number.parseInt(env.CONTEXT_MODE_BRIDGE_DEPTH ?? "", 10);
+  if (!Number.isFinite(depth) || depth <= 0) return 0;
+  const raw = env.CONTEXT_MODE_BRIDGE_IDLE_MS;
+  if (raw !== undefined) {
+    const v = Number.parseInt(raw, 10);
+    return Number.isFinite(v) && v > 0 ? v : 0;
+  }
+  return 180_000;
+}
+
+// #854 idle-reaper state, module-level by design: an MCP server is exactly one
+// process (one StdioServerTransport + one lifecycle guard), so these are never
+// shared across concurrent servers in production. Multiple startLifecycleGuard()
+// instances arise only in tests, which pair/reset these explicitly.
+/** Last MCP activity timestamp (inbound message, tool-call start/end, or response). */
+let _lastMcpActivity = Date.now();
+/** In-flight tool-call count — the reaper never fires while this is > 0. */
+let _inFlight = 0;
+
+/**
+ * #854: record MCP activity (inbound message or response). The server calls this
+ * so the bridge-child idle reaper in {@link startLifecycleGuard} can distinguish
+ * an actively-used child from an abandoned one. Cheap; safe on the hot path.
+ */
+export function noteMcpActivity(): void {
+  _lastMcpActivity = Date.now();
+}
+
+/**
+ * #854: mark a tool call as started. Suppresses the bridge-child idle reaper so a
+ * single long-running ctx_execute / ctx_batch_execute (which sends one inbound
+ * frame then runs unbounded, #643) is never reaped mid-execution.
+ */
+export function noteRequestStart(): void {
+  _inFlight++;
+  _lastMcpActivity = Date.now();
+}
+
+/** #854: mark a tool call as finished (success or error). */
+export function noteRequestEnd(): void {
+  if (_inFlight > 0) _inFlight--;
+  _lastMcpActivity = Date.now();
+}
+
+/**
+ * #854: wrap an MCP stdio transport's `onmessage` so each inbound message
+ * refreshes the idle clock. Best-effort: call after `connect()` (onmessage set);
+ * a no-op if it isn't a function, and a throw in noteMcpActivity never breaks
+ * dispatch. No stdin touch (preserves the #236 contract). Exported for testing.
+ */
+export function attachMcpActivityTap(
+  transport: { onmessage?: (message: unknown, extra?: unknown) => unknown } | null | undefined,
+): void {
+  if (!transport) return;
+  const prev = typeof transport.onmessage === "function" ? transport.onmessage.bind(transport) : null;
+  if (!prev) return;
+  transport.onmessage = (message: unknown, extra?: unknown) => {
+    try { noteMcpActivity(); } catch { /* never break message dispatch */ }
+    return prev(message, extra);
+  };
+}
+
+/**
  * Start the lifecycle guard. Returns a cleanup function.
  * Skipped automatically when stdin is a TTY (e.g. OpenCode ts-plugin).
  */
@@ -162,9 +249,42 @@ export function startLifecycleGuard(opts: LifecycleGuardOptions): () => void {
     process.stdin.on("end", onStdinEnd);
   }
 
+  // #854: request-idle self-shutdown for MCP BRIDGE CHILDREN only
+  // (CONTEXT_MODE_BRIDGE_DEPTH>0). Pi/omp loads the extension once per
+  // sub-context and spawns one bridge child each, tearing them down only at
+  // session_shutdown — which never fires for sub-contexts while the long-lived
+  // parent stays alive, so idle children accumulate (#854, same class as #565).
+  // A bridge child that receives no inbound MCP message for `idleMs` exits
+  // itself; the extension's single-flight path respawns one on the next call.
+  //
+  // Scoped strictly to depth>0 so the depth-0 keep-alive servers that #602
+  // restored are never reaped on idle. The trigger is idle TIME via
+  // noteMcpActivity() (NOT stdin EOF), so the #236 contract — and lifecycle's
+  // hands-off-stdin invariant — are untouched.
+  const idleMs = opts.bridgeIdleMs ?? bridgeChildIdleTimeoutMs();
+  let idleTimer: ReturnType<typeof setInterval> | undefined;
+  if (idleMs > 0) {
+    _lastMcpActivity = Date.now();
+    idleTimer = setInterval(() => {
+      // Reap only when truly quiescent: NO tool call in flight AND no MCP
+      // activity for `idleMs`. The in-flight guard prevents reaping a child
+      // mid-execution during a long single ctx_execute/batch that sends no
+      // further messages (#643 unbounded calls) — the false-reap regression the
+      // adversarial review flagged.
+      if (_inFlight === 0 && Date.now() - _lastMcpActivity >= idleMs) {
+        process.stderr.write(
+          `[context-mode] idle MCP bridge child self-shutdown after ${idleMs}ms with no activity (#854)\n`,
+        );
+        shutdown();
+      }
+    }, Math.max(1000, Math.min(Math.floor(idleMs / 4), 30_000)));
+    idleTimer.unref();
+  }
+
   return () => {
     stopped = true;
     clearInterval(timer);
+    if (idleTimer) clearInterval(idleTimer);
     for (const sig of signals) process.removeListener(sig, shutdown);
     process.stdin.removeListener("end", onStdinEnd);
   };

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,7 +28,7 @@ import {
   hasBunRuntime,
 } from "./runtime.js";
 import { classifyNonZeroExit } from "./exit-classify.js";
-import { startLifecycleGuard } from "./lifecycle.js";
+import { startLifecycleGuard, noteMcpActivity, noteRequestStart, noteRequestEnd, attachMcpActivityTap } from "./lifecycle.js";
 import { charSafePrefix } from "./truncate.js";
 import {
   describeStorageDirectorySource,
@@ -293,6 +293,10 @@ function wrapToolHandler(
   handler: (toolArgs: Record<string, unknown>) => Promise<unknown> | unknown,
 ): (toolArgs: Record<string, unknown>) => Promise<unknown> {
   return async (toolArgs: Record<string, unknown>) => {
+    // #854: mark a tool call in-flight so the bridge-child idle reaper never
+    // shuts the server down mid-execution during a long ctx_execute/batch that
+    // emits no further inbound messages. Symmetric end in finally (success+error).
+    noteRequestStart();
     try {
       return await handler(toolArgs);
     } catch (err) {
@@ -306,6 +310,8 @@ function wrapToolHandler(
         }
       }
       throw err;
+    } finally {
+      noteRequestEnd();
     }
   };
 }
@@ -874,6 +880,9 @@ function healCacheMidSession(): void {
 }
 
 function trackResponse(toolName: string, response: ToolResult): ToolResult {
+  // #854: a response is activity too — refresh the bridge-child idle clock so a
+  // chatty/streaming call keeps its server alive even between inbound frames.
+  noteMcpActivity();
   // Mid-session cache heal — one-shot, first tool call
   healCacheMidSession();
   // Prepend version outdated warning if needed
@@ -4803,6 +4812,13 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+
+  // #854: refresh the bridge-child idle clock on each inbound MCP message so an
+  // abandoned bridge child (CONTEXT_MODE_BRIDGE_DEPTH>0) self-terminates instead
+  // of accumulating under a long-lived Pi/omp parent. Best-effort; no stdin touch.
+  attachMcpActivityTap(
+    transport as unknown as { onmessage?: (message: unknown, extra?: unknown) => unknown },
+  );
 
   // Write MCP readiness sentinel (#230)
   try { writeFileSync(mcpSentinel, String(process.pid)); } catch { /* best effort */ }

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -11,7 +11,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
-import { startLifecycleGuard, makeDefaultIsParentAlive } from "../src/lifecycle.js";
+import { startLifecycleGuard, makeDefaultIsParentAlive, bridgeChildIdleTimeoutMs, noteMcpActivity, noteRequestStart, noteRequestEnd, attachMcpActivityTap } from "../src/lifecycle.js";
 
 // Resolve the tsx binary. Prefer the local devDep so the test doesn't depend
 // on a global tsx install or on Git Bash's `which` being on PATH; the PATH
@@ -413,4 +413,107 @@ describe.skipIf(isWindows)("Lifecycle Guard — Integration (real process)", () 
 
     assert.equal(code, 43, "Child should exit with code 43 on SIGTERM");
   }, 10_000);
+});
+
+// #854 — bridge-child request-idle reaper. Pi/omp loads the extension per
+// sub-context and spawns one bridge child each, reaping them only at
+// session_shutdown (which never fires for sub-contexts), so idle children
+// accumulate under one long-lived parent. A depth>0 child with no MCP activity
+// self-exits; depth-0 (the #602 keep-alive class) is never touched, and the
+// trigger is idle time (not stdin EOF) so the #236 contract holds.
+describe("bridgeChildIdleTimeoutMs (#854)", () => {
+  test("returns 0 (disabled) for depth-0 / absent / malformed", () => {
+    assert.equal(bridgeChildIdleTimeoutMs({}), 0, "absent depth → disabled");
+    assert.equal(bridgeChildIdleTimeoutMs({ CONTEXT_MODE_BRIDGE_DEPTH: "0" }), 0);
+    assert.equal(bridgeChildIdleTimeoutMs({ CONTEXT_MODE_BRIDGE_DEPTH: "-1" }), 0);
+    assert.equal(bridgeChildIdleTimeoutMs({ CONTEXT_MODE_BRIDGE_DEPTH: "x" }), 0);
+  });
+
+  test("returns the 3-min default for bridge children (depth>0)", () => {
+    assert.equal(bridgeChildIdleTimeoutMs({ CONTEXT_MODE_BRIDGE_DEPTH: "1" }), 180_000);
+    assert.equal(bridgeChildIdleTimeoutMs({ CONTEXT_MODE_BRIDGE_DEPTH: "2" }), 180_000);
+  });
+
+  test("honors CONTEXT_MODE_BRIDGE_IDLE_MS override (positive only)", () => {
+    assert.equal(bridgeChildIdleTimeoutMs({ CONTEXT_MODE_BRIDGE_DEPTH: "1", CONTEXT_MODE_BRIDGE_IDLE_MS: "5000" }), 5000);
+    assert.equal(bridgeChildIdleTimeoutMs({ CONTEXT_MODE_BRIDGE_DEPTH: "1", CONTEXT_MODE_BRIDGE_IDLE_MS: "0" }), 0, "non-positive override disables");
+    assert.equal(bridgeChildIdleTimeoutMs({ CONTEXT_MODE_BRIDGE_DEPTH: "1", CONTEXT_MODE_BRIDGE_IDLE_MS: "-5" }), 0);
+    assert.equal(bridgeChildIdleTimeoutMs({ CONTEXT_MODE_BRIDGE_IDLE_MS: "5000" }), 0, "override ignored when not a bridge child");
+  });
+});
+
+describe("Lifecycle Guard — bridge-child idle reaper (#854)", () => {
+  test("reaps a bridge child with no MCP activity (parent stays alive)", async () => {
+    let shutdownCalled = false;
+    const cleanup = startLifecycleGuard({
+      checkIntervalMs: 60_000,     // keep the parent-death poll out of the way
+      isParentAlive: () => true,    // parent ALIVE — only the idle path can fire
+      bridgeIdleMs: 50,             // tiny idle window (idle-tick floor is 1s)
+      onShutdown: () => { shutdownCalled = true; },
+    });
+    await new Promise((r) => setTimeout(r, 1300)); // > one 1s idle tick, no activity
+    cleanup();
+    assert.equal(shutdownCalled, true, "an idle bridge child must self-shut-down (#854)");
+  });
+
+  test("does NOT reap while MCP activity continues", async () => {
+    let shutdownCalled = false;
+    const cleanup = startLifecycleGuard({
+      checkIntervalMs: 60_000,
+      isParentAlive: () => true,
+      bridgeIdleMs: 5000,           // 5s window; idle-tick ~1.25s
+      onShutdown: () => { shutdownCalled = true; },
+    });
+    for (let i = 0; i < 4; i++) { noteMcpActivity(); await new Promise((r) => setTimeout(r, 400)); }
+    cleanup();
+    assert.equal(shutdownCalled, false, "an actively-used bridge child must not be reaped");
+  });
+
+  test("depth-0 servers are NEVER reaped on idle (#602 guard)", async () => {
+    let shutdownCalled = false;
+    const cleanup = startLifecycleGuard({
+      checkIntervalMs: 60_000,
+      isParentAlive: () => true,
+      bridgeIdleMs: 0,              // depth-0 / disabled → no idle reaper installed
+      onShutdown: () => { shutdownCalled = true; },
+    });
+    await new Promise((r) => setTimeout(r, 1300));
+    cleanup();
+    assert.equal(shutdownCalled, false, "depth-0 keep-alive servers must never idle-reap (#602)");
+  });
+
+  test("does NOT reap while a tool call is in flight (#854 in-flight guard)", async () => {
+    let shutdownCalled = false;
+    const cleanup = startLifecycleGuard({
+      checkIntervalMs: 60_000,
+      isParentAlive: () => true,
+      bridgeIdleMs: 50,                 // tiny window; idle-tick floor is 1s
+      onShutdown: () => { shutdownCalled = true; },
+    });
+    noteRequestStart();                 // a long tool call is running…
+    try {
+      await new Promise((r) => setTimeout(r, 1300)); // …past the idle window, no inbound msgs
+      assert.equal(shutdownCalled, false, "must NOT reap a bridge child with a call in flight (#643)");
+    } finally {
+      noteRequestEnd();                 // always balance the counter — no cross-test leak of module-global state
+    }
+    await new Promise((r) => setTimeout(r, 1300)); // now genuinely idle
+    cleanup();
+    assert.equal(shutdownCalled, true, "reaps once the in-flight call ends and it goes idle");
+  });
+
+  test("attachMcpActivityTap delegates to the prior onmessage; no-op when absent/null", () => {
+    const calls: Array<[unknown, unknown]> = [];
+    const t: { onmessage?: (m: unknown, e?: unknown) => unknown } = {
+      onmessage: (m: unknown, e?: unknown) => { calls.push([m, e]); return "ok"; },
+    };
+    attachMcpActivityTap(t);
+    const ret = t.onmessage!({ a: 1 }, { b: 2 });
+    assert.equal(ret, "ok", "wrapped onmessage must return the prior handler's result");
+    assert.deepEqual(calls, [[{ a: 1 }, { b: 2 }]], "wrapped onmessage must delegate args");
+    const empty: { onmessage?: (m: unknown, e?: unknown) => unknown } = {};
+    attachMcpActivityTap(empty);
+    assert.equal(empty.onmessage, undefined, "no onmessage → no-op (does not synthesize one)");
+    attachMcpActivityTap(null); // must not throw
+  });
 });


### PR DESCRIPTION
## What / Why / How

Fixes #854.

On hosts that spawn **one MCP server per sub-context/subagent under a single long-lived parent** (pi / oh-my-pi `omp`), context-mode servers never self-terminate and accumulate for the parent's whole lifetime (reporter: 188 procs / ~8.8 GB over a multi-day session).

With this PR applied, an MCP **bridge child** that receives no MCP activity for an idle window self-terminates, so accumulation is bounded; the pi extension's single-flight path respawns one transparently on the next tool call.

This PR:

- **`src/lifecycle.ts`** — a request-idle self-shutdown timer, installed **only for MCP bridge children** (`CONTEXT_MODE_BRIDGE_DEPTH>0`). It shuts the child down after no MCP activity for `bridgeChildIdleTimeoutMs()` (default 3 min; override `CONTEXT_MODE_BRIDGE_IDLE_MS`, non-positive disables) **and only while no tool call is in flight** — a long single `ctx_execute`/`ctx_batch_execute` (one inbound frame, then unbounded #643) is never reaped mid-flight. New exports `bridgeChildIdleTimeoutMs()`, `noteMcpActivity()`, `noteRequestStart()/noteRequestEnd()`, `attachMcpActivityTap()`.
- **`src/server.ts`** — `attachMcpActivityTap(transport)` refreshes the idle clock on each inbound message; `wrapToolHandler` brackets every tool call with `noteRequestStart/End` (try/finally, success+error); `trackResponse` also bumps activity. No stdin touch.
- **tests** — `bridgeChildIdleTimeoutMs` table tests; idle-reaper behavior (reaps when idle, not while active, **not while a call is in flight**, depth-0 no-reap guard for #602); `attachMcpActivityTap` delegation.
- preserved invariants: depth-0/absent installs no reaper (#602); trigger is idle time via the MCP message layer, never stdin EOF (#236); in-flight guard (#643).

> Note: a complementary change to dedupe the per-sub-context spawn in the pi extension was prototyped but **reverted** — module-level bridge state can be stale (point at a dead child), so reusing it is unsafe. The depth-scoped idle reaper bounds the leak robustly on its own and is the focused fix here.

## Affected platforms

Agent / CLI scope:

- [x] OpenClaw / Pi  *(pi / oh-my-pi `omp` — the bridge-child path; this is where servers accumulate)*
- [ ] All other agents — `lifecycle.ts`/`server.ts` are shared, but the reaper is gated to `CONTEXT_MODE_BRIDGE_DEPTH>0` (only the pi MCP bridge sets that), so depth-0 servers on every other host are behavior-unchanged.

OS scope:

- [x] Linux *(build/typecheck/tests; mechanism verified)*
- [x] macOS *(leak reproduced on real omp+Claude; patched-server idle-reap verified end-to-end)*
- [ ] Windows *(OS-agnostic change — no platform-specific code path; not separately run)*

Scope notes:

- The fix only ever runs in a process launched as a context-mode MCP **bridge child** (`CONTEXT_MODE_BRIDGE_DEPTH>0`). Standalone MCP servers and all non-pi adapters run at depth 0 and never install the idle reaper.

## Root Cause

Git / changelog archaeology:

- The pi extension (`src/adapters/pi/extension.ts`) starts a bridge child (`node …/server.bundle.mjs`, `BRIDGE_DEPTH=1`) from `before_agent_start` — which fires per sub-context/subagent — but tears it down only at `session_shutdown`, which never fires for sub-contexts while the parent process lives.
- `src/lifecycle.ts` reaps only on **parent-process death** (ppid poll + signals + a stdin-EOF assist itself gated on parent-death). The stdin-EOF gating is deliberate — `ac11f10`/#236 removed unconditional stdin-EOF shutdown because transient pipe events caused spurious `-32000` shutdowns. So with the `omp` parent alive, none of the three triggers fire.
- Same class as #565 (OpenCode accumulation); its generic idle-shutdown (`ac11f10`) was narrowed (`5bcff7e`/#592) then fully reverted (`a888cac`/#602, "restore tools on 12 hosts"), so this path has had no defense.

Preserved invariants: #236 (no stdin-EOF shutdown), #311/#388 (orphan fast-detect), #602 (depth-0 keep-alive servers not reaped on idle), #534 (bridge-child 1 s poll).

## Validation

| Environment | Command / check | Result |
| --- | --- | --- |
| Linux local | `npm run build` | passed (assert-bundle + assert-asymmetric-drift OK) |
| Linux local | `npx tsc --noEmit` | passed |
| Linux local | `npx vitest run tests/lifecycle.test.ts` | 23 passed (incl. 9 new #854 + the #236/#311/#388 guards) |
| Linux local | `npx vitest run tests/adapters/pi-mcp-bridge.test.ts tests/adapters/pi-bridge-parent-death.test.ts tests/pi-extension.test.ts` | 99 passed |
| macOS (`ssh my-mac`) | real omp 16.1.11 + Claude, extension loaded, 6-subagent turn | **leak reproduced pre-fix**: 13 `server.bundle.mjs` (depth=1) accumulated under one `omp` parent, none reaped |
| macOS (`ssh my-mac`) | **patched** vs original `server.bundle.mjs` as a depth=1 bridge child under a live parent, `CONTEXT_MODE_BRIDGE_IDLE_MS=3000`, idle | original `ALIVE after 6000ms` (leak); **patched `EXITED at ~3297ms` (idle-reaped)** ✅ |

Behavioral evidence:

- BEFORE: depth-1 bridge children with a live parent persist indefinitely (timer/signals/stdin-EOF all gated on parent-death; parent alive ⇒ never reap). Confirmed on macOS: the original `server.bundle.mjs` stayed `ALIVE after 6000ms`.
- AFTER: a depth>0 child with no activity for the idle window self-exits (macOS: patched `server.bundle.mjs` `EXITED at ~3297ms` ≈ the 3000 ms window). With activity, or while a tool call is in flight, it does not; depth-0 never installs the reaper.

Agent-working smoke:

- omp 16.1.11 + Claude (macOS) reproduced the leak shape (13 depth=1 `server.bundle.mjs` under one omp parent); the patched binary self-reaps an abandoned/idle child while the parent stays alive, so accumulation is bounded. The pi single-flight path (`mcp-bridge.ts`) respawns one transparently on the next tool call.

Additional adversarial invariants covered:

- in-flight guard: a long single tool call (one inbound frame, then unbounded) is not reaped mid-flight (#643).
- depth-0 / absent: the reaper is never installed (#602 keep-alive hosts untouched).
- no stdin listener added; idle trigger is the MCP message layer, not stdin EOF (#236).

## Cross-agent / cross-OS risk

`lifecycle.ts` and `server.ts` are shared by every adapter's MCP server, but the new behavior is gated to `CONTEXT_MODE_BRIDGE_DEPTH>0` (only the pi bridge), and the `onmessage` wrap is a no-op beyond bumping a timestamp. Depth-0 servers on Claude Code, Codex, Cursor, Gemini, Copilot, Qwen/Kimi, Kiro, Antigravity, Zed, and standalone launchers are unchanged. OS-agnostic (no platform-specific code).

## Checklist

- [x] Tests added with a real behavioral regression guard (idle-reaper behavior + depth-0 #602 guard + #236 stdin invariant stays green)
- [x] Regression coverage integrated into the existing `tests/lifecycle.test.ts`
- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] Targeted tests pass (lifecycle 23, pi 99)
- [x] Generated bundles updated when source changes require it — **CI (`bundle.yml`) regenerates + commits**; local bundle diffs not included
- [x] Docs: behavior is internal (no user-facing doc change); env knob `CONTEXT_MODE_BRIDGE_IDLE_MS` documented in code
- [x] 3OS validation — Linux (build/typecheck/tests) + macOS (real-binary before/after) done; Windows is an OS-agnostic path (no platform-specific code), not separately run
- [x] Agent-working smoke — macOS patched-server before/after (original persists, patched idle-reaps ~3.3 s) + omp 16.1.11 leak-shape reproduction
- [x] Targets `next`
