### PR TITLE
feat: one-time GitHub-star nudge (postinstall + doctor) + RepoStars README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1597,3 +1597,11 @@ cd context-mode && npm install && npm test
 ## License
 
 Licensed under [Elastic License 2.0](LICENSE) (source-available). You can use it, fork it, modify it, and distribute it. Two things you can't do: offer it as a hosted/managed service, or remove the licensing notices. We chose ELv2 over MIT because MIT permits repackaging the code as a competing closed-source SaaS — ELv2 prevents that while keeping the source available to everyone.
+
+---
+
+<div align="center">
+
+[![RepoStars](https://repostars.dev/api/embed?repo=mksglu%2Fcontext-mode&theme=light)](https://repostars.dev/?repos=mksglu%2Fcontext-mode&theme=light)
+
+</div>

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -382,3 +382,16 @@ if (isGlobalInstall() && !TMPDIR_UPGRADE_RE.test(pkgRoot)) {
     });
   } catch { /* best effort — never block install */ }
 }
+
+// ── 5. One-time GitHub-star nudge ────────────────────────────────────
+// After a real global install, print a single friendly star request. There is
+// no TTY during `npm install`, so this only PRINTS the message + URL — it never
+// stars an account without consent (the interactive Y/n/skip consent flow lives
+// in `context-mode doctor`). Gated to real global installs (not contributor/CI/
+// upgrade-staging) and shown at most once. Best-effort; never blocks install.
+if (isGlobalInstall() && !TMPDIR_UPGRADE_RE.test(pkgRoot)) {
+  try {
+    const { maybeStarNudge } = await import("../build/star-nudge.js");
+    await maybeStarNudge("postinstall");
+  } catch { /* best effort — never block install */ }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ import {
   hasBunRuntime,
   getAvailableLanguages,
 } from "./runtime.js";
+import { maybeStarNudge } from "./star-nudge.js";
 import { getHookScriptPaths } from "./util/hook-config.js";
 import { resolveClaudeConfigDir } from "./util/claude-config.js";
 import {
@@ -1210,6 +1211,10 @@ async function doctor(): Promise<number> {
       ? color.green("Diagnostics complete!")
       : color.yellow("Some checks need attention — see above for details"),
   );
+
+  // One-time, consent-gated GitHub-star nudge (interactive Y/n/skip on a TTY).
+  await maybeStarNudge("doctor");
+
   return 0;
 }
 

--- a/src/star-nudge.ts
+++ b/src/star-nudge.ts
@@ -1,0 +1,136 @@
+/**
+ * star-nudge — one-time, consent-gated GitHub-star prompt.
+ *
+ * Shown at most once per `surface` ("postinstall" | "doctor"), only when the
+ * GitHub CLI (`gh`) is available and the repo is not already starred. The repo
+ * is starred ONLY on an explicit "Y" at the interactive prompt; with no TTY
+ * (e.g. postinstall during `npm install`) it just prints the message and never
+ * touches the user's account. Opt out entirely with CONTEXT_MODE_NO_STAR_NUDGE=1.
+ * Everything here is best-effort — a nudge must never break install or `doctor`.
+ */
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { createInterface } from "node:readline";
+
+const REPO = "mksglu/context-mode";
+const STAR_URL = `https://github.com/${REPO}`;
+
+export type StarNudgeSurface = "postinstall" | "doctor";
+
+function markerDir(): string {
+  return join(homedir(), ".context-mode");
+}
+function markerPath(surface: StarNudgeSurface): string {
+  return join(markerDir(), `.star-nudge.${surface}`);
+}
+function alreadyShown(surface: StarNudgeSurface): boolean {
+  try {
+    return existsSync(markerPath(surface));
+  } catch {
+    return false;
+  }
+}
+function markShown(surface: StarNudgeSurface): void {
+  try {
+    mkdirSync(markerDir(), { recursive: true });
+    writeFileSync(markerPath(surface), "");
+  } catch {
+    /* best effort */
+  }
+}
+function suppressed(): boolean {
+  // Never nudge in CI/automation, and honour an explicit opt-out.
+  return Boolean(
+    process.env.CI ||
+      process.env.GITHUB_ACTIONS ||
+      process.env.CONTEXT_MODE_NO_STAR_NUDGE,
+  );
+}
+function ghReady(): boolean {
+  try {
+    return spawnSync("gh", ["--version"], { stdio: "ignore", timeout: 4000 }).status === 0;
+  } catch {
+    return false;
+  }
+}
+function alreadyStarred(): boolean {
+  try {
+    // `gh api user/starred/<repo>` → 204 (exit 0) when starred, 404 otherwise.
+    return (
+      spawnSync("gh", ["api", `user/starred/${REPO}`], { stdio: "ignore", timeout: 5000 }).status === 0
+    );
+  } catch {
+    return false;
+  }
+}
+function star(): boolean {
+  try {
+    return (
+      spawnSync("gh", ["api", "-X", "PUT", `user/starred/${REPO}`], { stdio: "ignore", timeout: 8000 }).status === 0
+    );
+  } catch {
+    return false;
+  }
+}
+function ask(question: string): Promise<string> {
+  return new Promise((resolve) => {
+    try {
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      rl.question(question, (answer) => {
+        rl.close();
+        resolve(answer);
+      });
+    } catch {
+      resolve("");
+    }
+  });
+}
+function printNudge(): void {
+  process.stdout.write(
+    "\n" +
+      "  ❤️  If context-mode has been helpful to you, would you mind starring the repo?\n" +
+      "     It really helps the project grow!\n" +
+      `     → ${STAR_URL}\n` +
+      "\n",
+  );
+}
+
+/**
+ * Show the one-time star nudge for `surface`. Returns silently in every
+ * not-applicable case (suppressed, already shown, no `gh`, already starred).
+ */
+export async function maybeStarNudge(surface: StarNudgeSurface): Promise<void> {
+  try {
+    if (suppressed() || alreadyShown(surface)) return;
+    if (!ghReady()) return; // can't check or star — leave the one-shot for later
+    if (alreadyStarred()) {
+      markShown(surface);
+      return;
+    }
+
+    printNudge();
+
+    // Interactive consent only when attached to a TTY. postinstall (npm install)
+    // is not a TTY, so it shows the message and stops — never stars silently.
+    if (process.stdin.isTTY && process.stdout.isTTY) {
+      const choice = (await ask("  Star now? (Y/n/skip): ")).trim().toLowerCase();
+      if (choice === "y" || choice === "yes") {
+        process.stdout.write(
+          star()
+            ? "  Thank you! ⭐\n\n"
+            : `  Couldn't star automatically — please star manually: ${STAR_URL}\n\n`,
+        );
+      } else if (choice === "s" || choice === "skip") {
+        process.stdout.write("  Skipped. You can star later anytime.\n\n");
+      } else {
+        process.stdout.write("  Maybe later. Thank you anyway!\n\n");
+      }
+    }
+
+    markShown(surface);
+  } catch {
+    /* a star nudge must never break install or doctor */
+  }
+}

--- a/tests/star-nudge.test.ts
+++ b/tests/star-nudge.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, assert, describe, test, vi } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { maybeStarNudge } from "../src/star-nudge.js";
+
+// These guards must hold WITHOUT touching the network, `gh`, or the filesystem:
+// each returns before ghReady()/markShown(), so the user's account and CI runs
+// are never affected.
+describe("star-nudge — opt-out / CI guards", () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+    vi.restoreAllMocks();
+  });
+
+  test("CONTEXT_MODE_NO_STAR_NUDGE makes it a silent no-op (opt-out)", async () => {
+    delete process.env.CI;
+    delete process.env.GITHUB_ACTIONS;
+    process.env.CONTEXT_MODE_NO_STAR_NUDGE = "1";
+    const write = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    await maybeStarNudge("doctor");
+    assert.equal(write.mock.calls.length, 0, "opt-out must print nothing and never call gh");
+  });
+
+  test("never nudges or stars under CI (automated installs)", async () => {
+    delete process.env.CONTEXT_MODE_NO_STAR_NUDGE;
+    process.env.CI = "true";
+    const write = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    await maybeStarNudge("postinstall");
+    assert.equal(write.mock.calls.length, 0, "CI must print nothing");
+  });
+
+  test("shows at most once per surface (marker short-circuits before any gh call)", async () => {
+    delete process.env.CI;
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.CONTEXT_MODE_NO_STAR_NUDGE;
+    const home = mkdtempSync(join(tmpdir(), "cm-star-"));
+    process.env.HOME = home; // os.homedir() honours $HOME on POSIX…
+    process.env.USERPROFILE = home; // …and %USERPROFILE% on Windows
+    mkdirSync(join(home, ".context-mode"), { recursive: true });
+    writeFileSync(join(home, ".context-mode", ".star-nudge.doctor"), "");
+    const write = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    await maybeStarNudge("doctor");
+    assert.equal(write.mock.calls.length, 0, "an already-shown surface must never nudge again (the 1회 guarantee)");
+  });
+});


### PR DESCRIPTION
## What / Why / How

Adds a friendly, **consent-gated** GitHub-star nudge — shown at most once after a real global install and once after `context-mode doctor` — plus the **RepoStars** badge at the bottom of the README. (Feature request, not a bug — no `Fixes #`.)

With this PR applied, after a real `npm i -g context-mode` and after a `context-mode doctor` run, the user sees a single star request; the account is starred **only** on an explicit "Y".

This PR (one commit per item):

- **star nudge** — `src/star-nudge.ts` `maybeStarNudge(surface)`, wired into `src/cli.ts` `doctor()` (interactive consent) and `scripts/postinstall.mjs` (print-only). Shown once per surface via marker `~/.context-mode/.star-nudge.<surface>`; only when `gh` is present and the repo is not already starred; stars only on an explicit "Y" at the `Star now? (Y/n/skip)` prompt; no TTY (postinstall) → message + URL only, never stars; opt out with `CONTEXT_MODE_NO_STAR_NUDGE`; never under CI; best-effort throughout.
- **README** — RepoStars badge at the bottom.
- **tests** — `tests/star-nudge.test.ts`: opt-out, CI-safety, and the once-per-surface marker guard.
- preserved maintainer invariants: opt-OUT env only (no opt-in flag); exact string compare for the prompt (no NL regex); no MCP/adapter/hook/session behavior changed.

## Affected platforms

Agent / CLI scope:

- [x] All platforms — this is the shared install (postinstall) + `context-mode doctor` CLI layer, common to every agent; no agent-specific or MCP/adapter code path is touched.

OS scope:

- [x] Linux — build + typecheck + unit tests + fake-`gh` smoke.
- [ ] macOS / Windows — not separately gated: `star-nudge.ts` is pure cross-platform Node (`os.homedir()`, `spawnSync`, `readline`, `fs`, `path.join`) with no platform-specific branches, and the postinstall hook is OS-agnostic. (A macOS spot-smoke also passed.)

Scope notes:

- Touches only the install/update + CLI `doctor` path. No change to the MCP server, hooks, adapters, or any agent integration — Claude Code / Codex / Cursor / Gemini / pi / OpenCode runtime behavior is unaffected.

## Root Cause

N/A — this is an additive **feature**, not a fix for prior behavior, so there is no regression source to trace. It introduces one new module and two call sites and preserves the maintainer invariants listed above (opt-out-only env, no NL regex, no shared-path behavior change).

## Validation

| Check | Result |
| --- | --- |
| `npm run build` + `npm run typecheck` | pass |
| `vitest run tests/star-nudge.test.ts` | 3 pass (opt-out, CI-safety, once-per-surface marker) |
| Smoke (fake `gh`, not starred, non-TTY) | nudge prints once → marker suppresses repeat ✓ |
| Smoke (already starred) | silent; marker written ✓ |
| Smoke (`gh` absent) | no-op; no marker (retries later) ✓ |
| Smoke (non-TTY) | prints message; never prompts / stars / hangs ✓ |
| `context-mode doctor` (fake `gh`) | exits 0, nudge appended after the outro ✓ |

Behavioral evidence:

- BEFORE: no star prompt anywhere.
- AFTER: a single, consent-gated prompt after a real global install and after `doctor`; never stars without an explicit "Y"; never runs in CI or under the opt-out env.

## Cross-agent / cross-OS risk

Minimal. The change lives entirely in `scripts/postinstall.mjs` and the `context-mode doctor` CLI path; it adds no dependency and does not touch the MCP server, hooks, adapters, or session paths. Pure cross-platform Node, so no OS-specific risk. The only outward action (`gh api -X PUT`) runs solely on explicit user consent at an interactive prompt.

## Checklist

- [x] Tests added with a real behavioral regression guard (opt-out, CI-safety, once-per-surface marker)
- [x] New test file justified — new `star-nudge` module; no existing focused test owns this behavior
- [x] `npm run build` + `npm run typecheck` pass
- [x] Generated bundles regenerate via CI (not committed)
- [x] No new runtime dependency
- [x] One PR, one commit per item (star nudge; README badge)
- [x] Env is opt-OUT only (`CONTEXT_MODE_NO_STAR_NUDGE`) — no opt-in flag
- [x] No regex for prompt parsing — exact string compare
- [ ] 3OS validation — Linux verified; macOS/Windows not separately gated (OS-portable Node, no platform branches)
- [x] Targets `next`
