### PR TITLE
fix(windows): run the better-sqlite3 boot-install via node, not npm.cmd+shell (#861 follow-up)

### DIFF
--- a/hooks/ensure-deps.mjs
+++ b/hooks/ensure-deps.mjs
@@ -20,7 +20,7 @@
  */
 
 import { existsSync, copyFileSync, renameSync, unlinkSync } from "node:fs";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
@@ -70,15 +70,33 @@ export async function ensureDeps() {
   for (const pkg of NATIVE_DEPS) {
     const pkgDir = resolve(root, "node_modules", pkg);
     if (!existsSync(pkgDir)) {
-      // Package not installed at all
+      // Package not installed at all.
+      // #861 follow-up: mirror start.mjs (#861/e918eac). The previous
+      // `execSync("npm.cmd install …", { shell: true })` DROPS the `cwd` option
+      // on Windows — npm then resolves node_modules from the MCP server's
+      // inherited cwd (C:\Windows under Claude Code) → `mkdir
+      // C:\Windows\node_modules` → EPERM on every boot (the reporter listed
+      // better-sqlite3 among the EPERMs; e918eac fixed the turndown deps in
+      // start.mjs but not this native-dep install). Run npm's own CLI through
+      // node directly (`shell: false` honors `cwd`), falling back to the
+      // `npm.cmd` shim only when npm-cli.js isn't beside node so no host
+      // regresses; `windowsHide` suppresses the cmd.exe flash.
+      const npmCliJs = resolve(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
+      const installArgs = ["install", pkg, "--no-package-lock", "--no-save", "--silent"];
       try {
-        execSync(`${process.platform === "win32" ? "npm.cmd" : "npm"} install ${pkg} --no-package-lock --no-save --silent`, {
-          cwd: root,
-          stdio: "pipe",
-          timeout: 120000,
-          shell: true,
-        });
-      } catch { /* best effort — hook degrades gracefully without DB */ }
+        if (existsSync(npmCliJs)) {
+          execFileSync(process.execPath, [npmCliJs, ...installArgs], {
+            cwd: root, stdio: "pipe", timeout: 120000, windowsHide: true,
+          });
+        } else {
+          execFileSync(process.platform === "win32" ? "npm.cmd" : "npm", installArgs, {
+            cwd: root, stdio: "pipe", timeout: 120000, shell: process.platform === "win32", windowsHide: true,
+          });
+        }
+      } catch (err) {
+        // #861: surface the failure (was silently swallowed); still degrade gracefully.
+        process.stderr.write(`[context-mode] ensure-deps install of ${pkg} failed: ${err?.message ?? err}\n`);
+      }
     } else if (!existsSync(resolve(pkgDir, ...NATIVE_BINARIES[pkg]))) {
       // Package installed but native binary missing (e.g., npm ignore-scripts=true,
       // or Windows where `npm rebuild` falls through to node-gyp without MSVC — #408).

--- a/tests/hooks/ensure-deps.test.ts
+++ b/tests/hooks/ensure-deps.test.ts
@@ -578,3 +578,39 @@ describe("ensure-deps: better-sqlite3 binding self-heal (#408)", () => {
     expect(branch).not.toContain("binding present");
   });
 });
+
+// ── #861 follow-up: cwd-safe better-sqlite3 install (Windows npm.cmd cwd-drop) ──
+// e918eac (#861) fixed start.mjs's turndown installs by running npm's own CLI via
+// node (shell:false honors cwd) instead of `npm.cmd` + shell:true (which DROPS
+// cwd on Windows → `mkdir C:\Windows\node_modules` → EPERM). The same npm.cmd
+// cwd-drop hit this native-dep install path (reporter listed better-sqlite3 among
+// the EPERMs); this guard pins the absorbed fix in the install branch.
+describe("ensure-deps: cwd-safe native install (#861 follow-up)", () => {
+  const SRC = readFileSync(
+    resolvePath(fileURLToPath(import.meta.url), "..", "..", "..", "hooks", "ensure-deps.mjs"),
+    "utf-8",
+  );
+  // Scope to the "package not installed at all" install branch (before the
+  // missing-binary else-if) so the assertions can't be satisfied by the
+  // unrelated rebuild paths.
+  const installBranch = SRC.slice(
+    SRC.indexOf("Package not installed at all"),
+    SRC.indexOf("} else if (!existsSync(resolve(pkgDir"),
+  )
+    // Strip comments so assertions check the CODE, not the explanatory text
+    // (which intentionally names the old `execSync("npm.cmd … install")` pattern).
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+
+  test("runs npm's own CLI via node (shell:false honors cwd), not npm.cmd+shell:true", () => {
+    expect(installBranch.length).toBeGreaterThan(0);
+    expect(installBranch).toContain("npm-cli.js");
+    expect(installBranch).toMatch(/execFileSync\(\s*process\.execPath/);
+    // the primary path must NOT be the cwd-dropping npm.cmd + shell:true execSync
+    expect(installBranch).not.toMatch(/execSync\([^)]*npm\.cmd[^)]*install/);
+  });
+
+  test("surfaces install failures instead of swallowing them silently", () => {
+    expect(installBranch).toMatch(/ensure-deps install of \$\{pkg\} failed/);
+  });
+});


### PR DESCRIPTION
## What / Why / How

Follow-up to #861 (`e918eac`). That fix stopped the Windows boot-install EPERM for the optional fetch deps in `start.mjs` by running npm's own CLI through node (`shell:false` honors `cwd`) instead of `npm.cmd` + `shell:true` (which DROPS `cwd` on Windows → npm resolves `node_modules` from the inherited cwd `C:\Windows` → `mkdir C:\Windows\node_modules` → EPERM). The **identical `npm.cmd` cwd-drop** still affected the **native-dep install** in `hooks/ensure-deps.mjs` — the reporter explicitly listed `better-sqlite3` among the EPERMs, and that path was left unfixed.

With this PR applied, the `better-sqlite3` boot-install uses the same cwd-honoring path, so it can no longer EPERM at `C:\Windows\node_modules`.

This PR absorbs `e918eac`'s approach for the native-dep install:

- **`hooks/ensure-deps.mjs`** — resolve `npm-cli.js` beside `process.execPath` and run it via `execFileSync(process.execPath, [npmCliJs, "install", …], { shell:false })` (honors `cwd`) + `windowsHide:true`; fall back to the `npm.cmd` shim only when `npm-cli.js` isn't beside node (so no host regresses); **surface failures to stderr** (was silently swallowed behind `stdio:"pipe"` + an empty `catch`).
- **`tests/hooks/ensure-deps.test.ts`** — pin the install branch to the node-CLI / `shell:false` path + the failure surfacing (source guard, matching this file's existing #408/#634 patterns; the bug is Windows-only and doesn't reproduce on Linux CI).
- preserved: the `ensureNativeCompat` ABI-rebuild paths are untouched (they use `npm.cmd` too, but don't `mkdir node_modules` → no EPERM; left for a separate change).

## Affected platforms

Agent / CLI scope:

- [x] All platforms — `hooks/ensure-deps.mjs` runs on every adapter that boots the MCP server via `start.mjs`. No MCP/adapter behavior change; only the native-dep bootstrap install.

OS scope:

- [x] Windows — the affected OS (`npm.cmd` drops `cwd`). Reachable on Windows + Node when `better-sqlite3` is missing (codex/marketplace clones, broken installs) — the same condition that triggers the `start.mjs` turndown installs `e918eac` already fixed.
- [ ] Linux / macOS — unaffected: `ensureDeps()` returns early on Bun, and POSIX already runs npm with `shell:false` (cwd honored). The node-CLI path is equivalent there.

Scope notes:

- Only the "package not installed at all" install branch is changed. The probe and ABI-rebuild logic are untouched.

## Root Cause

- `e918eac` (#861) fixed `start.mjs` but not `hooks/ensure-deps.mjs`, which still ran `execSync("npm.cmd install better-sqlite3 …", { shell: true })`. On Windows, `shell:true`/`npm.cmd` does not honor the `cwd` option (verified), so the install targets the inherited cwd → `C:\Windows\node_modules` → EPERM.
- `ensureDeps()` only early-returns on Bun (no modern-Node gate), so on Windows + Node it does run this install when `better-sqlite3` is absent.

## Validation

| Check | Result |
| --- | --- |
| `npm run build` + `npm run typecheck` | passed (0 errors) |
| `vitest run tests/hooks/ensure-deps.test.ts` | 26 passed (existing #206/#148/#408/#331 + 2 new #861-follow-up guards) |
| **Windows** (`ssh my-window`, Node v24.13) | `node <npm-cli.js> install is-number` launched from `cwd=C:\Windows` → installed into `<target>\node_modules` (`installedInTarget:true`, `eperm:false`); `npm-cli.js` found beside node |

Behavioral evidence:

- BEFORE: `execSync("npm.cmd install better-sqlite3", { shell:true })` — same cwd-drop class as the (now-fixed) turndown installs → EPERM at `C:\Windows\node_modules` when `better-sqlite3` is missing.
- AFTER: `node <npm-cli.js> install … (shell:false)` installs into the plugin dir regardless of cwd — verified on real Windows from `cwd=C:\Windows`.

## Cross-agent / cross-OS risk

Minimal. One install call site in `hooks/ensure-deps.mjs`; no new dependency; no MCP/adapter/hook-routing change. The node-CLI path is the same mechanism `e918eac` already shipped and validated for `start.mjs`. POSIX behavior is unchanged (already `shell:false`).

## Checklist

- [x] Tests added (source guard for the node-CLI/`shell:false` install + failure surfacing), integrated into the existing `tests/hooks/ensure-deps.test.ts`
- [x] `npm run build` + `npm run typecheck` pass
- [x] Generated bundles regenerate via CI (not committed)
- [x] No new runtime dependency
- [x] One PR, single logical fix (absorbs `e918eac` for the native-dep install)
- [ ] 3OS validation — Windows verified (mechanism); Linux/macOS unaffected (Bun early-return / POSIX shell:false)
- [x] Targets `next`
