### PR TITLE
Hide Pi context injection from user entry

### DIFF
--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -696,10 +696,13 @@ export default function piExtension(pi: any): void {
       }
 
       // Store extra context (routing anchor, active_memory, resume, behavioralDirective)
-      // for injection via the 'context' hook as a message, NOT as a systemPrompt
-      // modification. Mutating systemPrompt breaks prefix prompt caching on
-      // DeepSeek/Anthropic/OpenAI because the system message sits at messages[0]
-      // and any change invalidates the entire cache chain.
+      // for injection via the 'context' hook as a hidden custom message, NOT as a
+      // systemPrompt modification. Mutating systemPrompt breaks prefix prompt
+      // caching on DeepSeek/Anthropic/OpenAI because the system message sits at
+      // messages[0] and any change invalidates the entire cache chain. A plain
+      // user-role message is also wrong here: Pi treats user messages as
+      // interactive conversation entries, which can leak this internal context
+      // into the CLI entry/editor surface.
       const baseLen = existingPrompt ? 1 : 0;
       if (parts.length > baseLen) {
         const extraParts = parts.slice(baseLen);
@@ -714,17 +717,20 @@ export default function piExtension(pi: any): void {
   });
 
   // ── 4a2. context — Inject active_memory + resume + behavioralDirective as message ──
-  // Uses the 'context' hook (like hindsight does) to append context at the END of
-  // messages rather than mutating systemPrompt at the beginning. This preserves
-  // prefix prompt cache for DeepSeek, Anthropic, and OpenAI.
+  // Uses the 'context' hook to append hidden context at the END of messages rather
+  // than mutating systemPrompt at the beginning. This preserves prefix prompt
+  // cache for DeepSeek, Anthropic, and OpenAI without rendering internal
+  // context-mode text in Pi's CLI entry/editor surface.
   pi.on("context", (event: any) => {
     try {
       if (!_pendingContext) return;
       const ctx = _pendingContext;
       _pendingContext = "";
       event.messages.push({
-        role: "user",
+        role: "custom",
+        customType: "context-mode-context",
         content: ctx,
+        display: false,
       });
       return { messages: event.messages };
     } catch {

--- a/tests/adapters/pi-help-skip-bootstrap.test.ts
+++ b/tests/adapters/pi-help-skip-bootstrap.test.ts
@@ -52,9 +52,11 @@ function createMockPi() {
     registerTool: vi.fn(),
     sendMessage: vi.fn(),
     _trigger: async (event: string, ...args: any[]) => {
+      const results = [];
       for (const handler of handlers[event] ?? []) {
-        await handler(...args);
+        results.push(await handler(...args));
       }
+      return results;
     },
   };
 }
@@ -126,6 +128,30 @@ describe("piExtension — lazy MCP bootstrap avoids brittle argv detection (#534
     await pi._trigger("before_agent_start", { prompt: "second", systemPrompt: "" });
 
     expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it("injects context-mode guidance as a hidden custom message, not a user entry", async () => {
+    const { pi, spy } = await registerWithBootstrapSpy(["-p", "task"]);
+    const ctx = {
+      sessionManager: {
+        getSessionFile: () => join(scratch, "session.jsonl"),
+      },
+    };
+
+    await pi._trigger("session_start", {}, ctx);
+    await pi._trigger("before_agent_start", { prompt: "task", systemPrompt: "" });
+    const event = { messages: [{ role: "user", content: "task" }] };
+    const [result] = await pi._trigger("context", event);
+    const injected = result.messages.at(-1);
+
+    expect(injected).toMatchObject({
+      role: "custom",
+      customType: "context-mode-context",
+      display: false,
+    });
+    expect(injected.content).toContain("context-mode active");
+    expect(injected.role).not.toBe("user");
     spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Fix Pi adapter context injection so context-mode's internal routing/memory context is appended as a hidden custom message instead of a normal user-role message.

## Why

In Pi, user-role messages can be treated/rendered as interactive conversation entries. Injecting the context-mode guidance as `role: "user"` can leak internal text such as `context-mode active...` into the CLI entry/editor surface.

Pi's extension/session model already supports hidden custom messages via `role: "custom"`, `customType`, and `display: false`; this preserves LLM context injection without presenting the text as user input.

## Changes

- Change Pi context hook injection to:
  - `role: "custom"`
  - `customType: "context-mode-context"`
  - `display: false`
- Update comments to document why user-role injection is avoided.
- Add a regression test proving Pi context-mode guidance is injected as hidden custom context, not a user entry.

## Verification

- `pnpm vitest run tests/adapters/pi-help-skip-bootstrap.test.ts` — 19 tests passed

Note: a broader ad-hoc targeted `tsc` command currently surfaces existing repo/typeconfig issues unrelated to this patch (`codex` adapter narrowing and better-sqlite3 import flags), so I used the existing focused Vitest coverage for this Pi adapter path.
