### PR TITLE
docs(readme): correct Zed MCP config shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,15 +972,15 @@ Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/
    {
      "context_servers": {
        "context-mode": {
-         "command": {
-           "path": "context-mode"
-         }
+         "command": "context-mode",
+         "args": [],
+         "env": {}
        }
      }
    }
    ```
 
-   Note: Zed uses `"context_servers"` and `"command": { "path": "..." }` syntax, not `"mcpServers"` or `"command": "..."` like other platforms.
+   Note: Zed uses `"context_servers"` instead of `"mcpServers"`. `args` and `env` are optional for context-mode, but are shown here to match Zed's custom MCP server shape.
 
 3. Copy routing instructions (Zed has no hook support):
 


### PR DESCRIPTION
## What / Why / How

Fixes #869.

The reported behavior is that the README's Zed install section documents the wrong custom MCP server shape. The old README example used the internal `ContextServerCommand.path` representation:

```json
"command": { "path": "context-mode" }
```

Zed's user-facing settings schema expects a string `command` inside `context_servers`, with optional `args` and `env`.

With this PR applied, Zed users can copy the README snippet directly into `~/.config/zed/settings.json` without translating the internal source representation into the public settings format.

This PR:

- updates the README Zed MCP config example to use `"command": "context-mode"`
- shows optional `args` and `env` fields in the same shape Zed documents for custom MCP servers
- removes the stale note claiming Zed settings use `command.path`
- preserves the existing Zed MCP-only routing guidance and AGENTS.md copy step

## Affected platforms

Agent / CLI scope:

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw / Pi
- [ ] Kiro
- [ ] Antigravity
- [x] Zed
- [ ] All standalone MCP server launchers
- [ ] All platforms

OS scope:

- [x] Linux
- [x] macOS
- [x] Windows
- [ ] All operating systems

Scope notes:

- This is a README-only install documentation change for Zed's MCP-only path.
- No runtime adapter, hook, MCP server, generated bundle, or package config changes are included.
- OS scope is checked because the README snippet includes both Unix and Windows settings paths, and CI passed across Linux, macOS, and Windows.

## Root Cause

Git archaeology:

- `ef9b9f0` introduced Zed editor support as an MCP-only adapter and added the original Zed documentation path.
- `4bbbd46` later rewrote platform-specific README guidance and left the Zed section describing the internal `command.path` shape instead of Zed's public settings shape.

The failure happens because Zed's Rust source stores the command path internally as `ContextServerCommand.path`, but serde renames that field to the user-facing settings key `command`. The README documented the internal representation rather than the JSON settings shape users actually write.

Evidence:

- Zed docs show custom local MCP servers under `context_servers` with string `command`, `args`, and `env`: https://github.com/zed-industries/zed/blob/1e7f1a11f99237d4dbd448656f0f3df3bf7a1faa/docs/src/ai/mcp.md#L56-L63
- Zed source flattens `ContextServerCommand` into `ContextServerSettingsContent::Stdio`: https://github.com/zed-industries/zed/blob/1e7f1a11f99237d4dbd448656f0f3df3bf7a1faa/crates/settings_content/src/project.rs#L392-L407
- Zed source renames internal `path` to settings key `command`, with default `args` and optional `env`: https://github.com/zed-industries/zed/blob/1e7f1a11f99237d4dbd448656f0f3df3bf7a1faa/crates/settings_content/src/project.rs#L479-L486

The PR preserves these older invariants:

- Zed remains documented as MCP-only with no hook support.
- Zed still uses `context_servers`, not `mcpServers`.
- The AGENTS.md manual routing step remains unchanged.

## Validation

| Environment | Command / check | Result |
| --- | --- | --- |
| Linux local | parsed the updated README Zed JSON snippet with `JSON.parse` | passed |
| Linux local | `git diff --check` | passed |
| GitHub Actions / Linux | `test (ubuntu-latest)` | passed |
| GitHub Actions / macOS | `test (macos-latest)` | passed |
| GitHub Actions / Windows | `test (windows-latest)` | passed |
| GitHub Actions / Linux | `openclaw-e2e (ubuntu-latest)` | passed |
| GitHub Actions / macOS | `openclaw-e2e (macos-latest)` | passed |

Behavioral evidence:

- BEFORE: README told Zed users to configure `"command": { "path": "context-mode" }`, which does not match Zed's documented custom MCP server settings shape.
- AFTER: README tells Zed users to configure `"command": "context-mode"`, matching Zed docs and serde input schema.

Agent-working smoke:

- Not run against the Zed app UI. This PR is docs-only; the schema claim is verified against current Zed docs and source.

Additional adversarial invariants covered:

- Searched README/docs/configs for remaining Zed `command.path` guidance; none remains.
- The updated README JSON block parses as valid JSON.

## Cross-agent / cross-OS risk

This affects only Zed installation documentation. There is no runtime behavior change for Claude Code, Codex, Cursor, Gemini CLI, Qwen Code, JetBrains Copilot, OpenCode/KiloCode, Copilot CLI, Antigravity CLI, Pi/OpenClaw, Kiro, or standalone MCP server launchers.

Cross-OS risk is limited to copy-paste docs. The settings path text still includes Linux/macOS `~/.config/zed/settings.json` and Windows `%APPDATA%\Zed\settings.json`; no path handling code changed.

## Checklist

- [ ] Tests added/updated with a real behavioral regression guard
- [ ] Regression coverage integrated into an existing relevant test file, or new test file justified
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] Targeted tests pass
- [ ] Generated bundles updated when source changes require it
- [x] Docs updated if user-facing behavior changed
- [x] 3OS validation completed or each unverified OS has a concrete reason
- [ ] Agent-working smoke completed for agent-facing changes
- [ ] Targets `next` branch unless this is an explicit hotfix

Checklist notes:

- No tests, build, typecheck, or bundle updates were needed locally because this PR changes README prose only. Full GitHub Actions CI still passed across Linux, macOS, and Windows.
- Zed app smoke is unverified; the docs/source schema evidence is the direct validation for this docs correction.
- The PR currently targets `main` because the issue was reported against README on `main` and this is a docs-only correction.
