### PR TITLE
fix(adapters/omp): self-register MCP server on plugin load (#677)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,8 @@ Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/
 
    Both should show `context-mode` as `enabled`.
 
+   > The plugin self-registers its MCP server in `~/.omp/agent/mcp.json` on first load (spawned as `node <plugin>/server.bundle.mjs`, since the plugin-install package directory is not on `PATH`), so the 11 `ctx_*` tools become reachable after the restart in step 2 — no manual `mcp.json` edit needed ([#677](https://github.com/mksglu/context-mode/issues/677)). An existing `context-mode` entry is never overwritten; remove it if you want the plugin to re-register the bundled path.
+
 **Install — manual plugin path (if `omp plugin install` is unavailable):**
 
 OMP loads anything listed under `~/.omp/plugins/package.json` `dependencies` whose own `package.json` carries an `omp` (or `pi`) field. New plugins default to enabled — the lock file at `~/.omp/plugins/omp-plugins.lock.json` is only consulted when a plugin needs to be explicitly **disabled** (loader skips `runtimeState && !runtimeState.enabled` per [`extensibility/plugins/loader.ts:89-94`](https://github.com/can1357/oh-my-pi/blob/main/packages/coding-agent/src/extensibility/plugins/loader.ts)). So the manual install is two commands:

--- a/src/adapters/omp/plugin.ts
+++ b/src/adapters/omp/plugin.ts
@@ -25,8 +25,9 @@
  */
 
 import { createHash } from "node:crypto";
-import { mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { resolveSessionDbPath, SessionDB } from "../../session/db.js";
 import { extractEvents } from "../../session/extract.js";
@@ -73,6 +74,59 @@ let _dbPath = "";
 let _sessionId = "";
 
 const _ompAdapter = new OMPAdapter();
+
+// ── MCP self-registration (issue #677) ───────────────────
+// The `omp plugin install context-mode` path wires THIS extension factory
+// (so routing hooks fire), but never creates the MCP config — so the 11
+// `ctx_*` tools stay unreachable even though curl/wget are blocked. Register
+// the server ourselves on plugin load, ONLY when absent (never clobber a
+// user's existing entry). Takes effect on the next OMP restart, same as the
+// manual mcp.json workaround the issue documents.
+const MCP_SERVER_NAME = "context-mode";
+// plugin.js ships at <pkg>/build/adapters/omp/plugin.js; the MCP server
+// bundle sits at the package root (<pkg>/server.bundle.mjs) — three up.
+const SERVER_BUNDLE_RELATIVE = "../../../server.bundle.mjs";
+
+function resolveServerBundle(): string | null {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const bundle = resolve(here, SERVER_BUNDLE_RELATIVE);
+    return existsSync(bundle) ? bundle : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ensure `~/.omp/agent/mcp.json` registers the context-mode MCP server.
+ *
+ * Uses `node <abs>/server.bundle.mjs` rather than the `context-mode` bin:
+ * under the plugin install the package lives in `~/.omp/plugins/node_modules`
+ * and its bin is NOT on PATH, so the bare command would fail to spawn (the
+ * exact symptom reported on issue #677). Best effort — never throws, never
+ * breaks plugin load.
+ */
+function ensureMcpServerRegistered(): void {
+  try {
+    const bundle = resolveServerBundle();
+    if (!bundle) return; // bundle missing → nothing safe to register
+
+    const settings = _ompAdapter.readSettings() ?? {};
+    const mcpServers =
+      (settings.mcpServers as Record<string, unknown> | undefined) ?? {};
+    if (MCP_SERVER_NAME in mcpServers) return; // already present — don't clobber
+
+    mcpServers[MCP_SERVER_NAME] = {
+      type: "stdio",
+      command: "node",
+      args: [bundle],
+    };
+    settings.mcpServers = mcpServers;
+    _ompAdapter.writeSettings(settings as Record<string, unknown>);
+  } catch {
+    // best effort — a registration failure must never break plugin load
+  }
+}
 
 function getSessionDir(): string {
   const dir = _ompAdapter.getSessionDir();
@@ -189,6 +243,11 @@ export default function ompPlugin(pi: MinimalHookAPI): void {
   // earlier `OMP_PROJECT_DIR` read was an EM mistake — no upstream code
   // ever sets it. Drop it; fall through PI_PROJECT_DIR → cwd().
   const projectDir = process.env.PI_PROJECT_DIR || process.cwd();
+
+  // Self-register the MCP server so `ctx_*` tools are reachable under the
+  // plugin install path, not just the manual MCP-only path (issue #677).
+  ensureMcpServerRegistered();
+
   const db = getOrCreateDB(projectDir);
 
   // ── 1. session_start — initialize session row ─────────

--- a/tests/adapters/omp-plugin.test.ts
+++ b/tests/adapters/omp-plugin.test.ts
@@ -447,4 +447,64 @@ describe("OMP plugin", () => {
       }
     });
   });
+
+  // ═══════════════════════════════════════════════════════════
+  // Slice 5: MCP self-registration (issue #677)
+  // ═══════════════════════════════════════════════════════════
+  // The `omp plugin install` path wires the extension factory (routing
+  // hooks fire) but never creates mcp.json, so the `ctx_*` tools stay
+  // unreachable. The plugin must self-register the MCP server on load.
+
+  describe("Slice 5: MCP self-registration (issue #677)", () => {
+    it("registers the context-mode MCP server in mcp.json when absent", async () => {
+      const { OMPAdapter } = await import("../../src/adapters/omp/index.js");
+      const { rmSync } = await import("node:fs");
+      const adapter = new OMPAdapter();
+      // Clean slate — drop any mcp.json a prior test in this suite wrote.
+      try {
+        rmSync(adapter.getSettingsPath(), { force: true });
+      } catch {
+        /* best effort */
+      }
+
+      await registerOmpPlugin(api);
+
+      const settings = adapter.readSettings();
+      const server = (settings?.mcpServers as Record<string, unknown> | undefined)?.[
+        "context-mode"
+      ] as { command?: string; args?: unknown[] } | undefined;
+
+      expect(
+        server,
+        "context-mode must be registered in mcp.json after plugin load",
+      ).toBeDefined();
+      // Plugin install puts the package in ~/.omp/plugins/node_modules where
+      // the `context-mode` bin is NOT on PATH — must spawn via node + bundle.
+      expect(server?.command).toBe("node");
+      expect(Array.isArray(server?.args)).toBe(true);
+      expect(String(server?.args?.[0])).toMatch(/server\.bundle\.mjs$/);
+    });
+
+    it("does NOT clobber an existing context-mode mcp.json entry", async () => {
+      const { OMPAdapter } = await import("../../src/adapters/omp/index.js");
+      const adapter = new OMPAdapter();
+      // User-supplied entry (e.g. the commenter's own working config) that
+      // must survive plugin load untouched.
+      adapter.writeSettings({
+        mcpServers: {
+          "context-mode": { command: "context-mode", args: ["--user-custom"] },
+        },
+      });
+
+      await registerOmpPlugin(api);
+
+      const settings = adapter.readSettings();
+      const server = (settings?.mcpServers as Record<string, unknown>)["context-mode"] as {
+        command?: string;
+        args?: unknown[];
+      };
+      expect(server.command).toBe("context-mode");
+      expect(server.args).toEqual(["--user-custom"]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #677.

After `omp plugin install context-mode`, the extension factory is wired (so the `tool_call`/`tool_result`/`session_start`/`session_before_compact` hooks fire and `curl`/`wget` are hard-blocked), but the plugin never creates an `mcp.json` entry. Result: the 11 `ctx_*` MCP tools stay unreachable — the agent blocks raw HTTP yet has no sandbox to redirect to. A user on the issue confirmed this is still happening: hooks fire, but the MCP server is never registered, and adding the config to OMP's `mcp.json` by hand makes it work.

This makes the plugin self-register its MCP server on load.

## What changed

- `src/adapters/omp/plugin.ts` — on plugin load, ensure `~/.omp/agent/mcp.json` registers the `context-mode` server, **only when absent** (an existing entry is never clobbered). The server is spawned as `node <plugin>/server.bundle.mjs`, resolved relative to the loaded plugin file — **not** the `context-mode` bin, because under the plugin install the package lives in `~/.omp/plugins/node_modules` and its bin is not on `PATH` (the exact failure the reporter hit). Best-effort: a registration error never breaks plugin load. Takes effect on the next OMP restart, same as the manual workaround.
- `tests/adapters/omp-plugin.test.ts` — new "Slice 5" covering both the registers-when-absent and never-clobber paths.
- `README.md` — OMP "plugin path (recommended)" now documents the self-registration so users don't think they must hand-edit `mcp.json`.

Also drops a now-unused `node:path` `join` import that was already dead in the touched file.

## Test verification (RED → GREEN)

New tests run against the source with the fix reverted (`git stash` of `plugin.ts` only):

**RED** — fix reverted:
```
× registers the context-mode MCP server in mcp.json when absent
AssertionError: context-mode must be registered in mcp.json after plugin load: expected undefined to be defined
 Tests  1 failed | 1 passed | 20 skipped
```
(the never-clobber test passes on red — without the fix the user entry is simply never touched.)

**GREEN** — fix applied:
```
 Test Files  1 passed (1)
      Tests  2 passed | 20 skipped (22)
```

Full suite: **4531 passed, 43 skipped, 0 failed** (`npx vitest run`); `tsc --noEmit` clean; `npm run build` (bundle + drift assertions) OK. Pre-built bundles intentionally not committed.