### PR TITLE
docs(readme): sync Zed config fix to next

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,15 +972,15 @@ Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/
    {
      "context_servers": {
        "context-mode": {
-         "command": {
-           "path": "context-mode"
-         }
+         "command": "context-mode",
+         "args": [],
+         "env": {}
        }
      }
    }
    ```
 
-   Note: Zed uses `"context_servers"` and `"command": { "path": "..." }` syntax, not `"mcpServers"` or `"command": "..."` like other platforms.
+   Note: Zed uses `"context_servers"` instead of `"mcpServers"`. `args` and `env` are optional for context-mode, but are shown here to match Zed's custom MCP server shape.
 
 3. Copy routing instructions (Zed has no hook support):
 


### PR DESCRIPTION
## Summary

- follow up on #870 by syncing the Zed README config correction onto `next`
- replace the stale internal `command.path` shape with Zed's user-facing `command`: `"context-mode"` settings shape
- keep the existing Zed MCP-only guidance and AGENTS.md copy step unchanged

## Validation

- `git diff --check HEAD~1..HEAD`
- parsed the Zed README JSON block from `HEAD:README.md` with Node and verified `command`, `args`, and `env`

Not run: full build/test suite because this is a README-only docs sync.