### PR TITLE
fix(omp): seed APPEND_SYSTEM.md routing instructions

### DIFF
--- a/src/adapters/omp/plugin.ts
+++ b/src/adapters/omp/plugin.ts
@@ -141,18 +141,18 @@ function ensureMcpServerRegistered(): void {
 }
 
 /**
- * Seed OMP's native system-prompt file with context-mode routing rules.
+ * Append context-mode routing rules to OMP's native system prompt.
  *
- * OMP discovers `~/.omp/agent/SYSTEM.md` on startup, but `omp plugin install`
- * only installs the npm package. Copy the packaged instructions lazily and
- * never overwrite a user's existing system prompt.
+ * OMP discovers `~/.omp/agent/APPEND_SYSTEM.md` on startup and keeps its
+ * built-in tool guidance intact. Copy the packaged instructions lazily and
+ * never overwrite a user's existing append prompt.
  */
 function ensureSystemInstructionsSeeded(): void {
   try {
     const source = resolveOmpSystemInstructions();
     if (!source) return;
 
-    const target = join(_ompAdapter.getConfigDir(), "SYSTEM.md");
+    const target = join(_ompAdapter.getConfigDir(), "APPEND_SYSTEM.md");
     if (existsSync(target)) return;
 
     mkdirSync(dirname(target), { recursive: true });
@@ -296,7 +296,7 @@ export default function ompPlugin(pi: MinimalHookAPI): void {
   ensureMcpServerRegistered();
 
   // Seed OMP's native routing file so the model learns to use those tools
-  // without requiring the manual SYSTEM.md copy workaround (issue #873).
+  // without replacing OMP's built-in tool guidance (issue #873).
   ensureSystemInstructionsSeeded();
 
   const db = getOrCreateDB(projectDir);

--- a/src/adapters/omp/plugin.ts
+++ b/src/adapters/omp/plugin.ts
@@ -25,8 +25,8 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { resolveSessionDbPath, SessionDB } from "../../session/db.js";
@@ -87,12 +87,23 @@ const MCP_SERVER_NAME = "context-mode";
 // plugin.js ships at <pkg>/build/adapters/omp/plugin.js; the MCP server
 // bundle sits at the package root (<pkg>/server.bundle.mjs) — three up.
 const SERVER_BUNDLE_RELATIVE = "../../../server.bundle.mjs";
+const OMP_SYSTEM_MD_RELATIVE = "../../../configs/omp/SYSTEM.md";
 
 function resolveServerBundle(): string | null {
   try {
     const here = dirname(fileURLToPath(import.meta.url));
     const bundle = resolve(here, SERVER_BUNDLE_RELATIVE);
     return existsSync(bundle) ? bundle : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveOmpSystemInstructions(): string | null {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const source = resolve(here, OMP_SYSTEM_MD_RELATIVE);
+    return existsSync(source) ? source : null;
   } catch {
     return null;
   }
@@ -126,6 +137,28 @@ function ensureMcpServerRegistered(): void {
     _ompAdapter.writeSettings(settings as Record<string, unknown>);
   } catch {
     // best effort — a registration failure must never break plugin load
+  }
+}
+
+/**
+ * Seed OMP's native system-prompt file with context-mode routing rules.
+ *
+ * OMP discovers `~/.omp/agent/SYSTEM.md` on startup, but `omp plugin install`
+ * only installs the npm package. Copy the packaged instructions lazily and
+ * never overwrite a user's existing system prompt.
+ */
+function ensureSystemInstructionsSeeded(): void {
+  try {
+    const source = resolveOmpSystemInstructions();
+    if (!source) return;
+
+    const target = join(_ompAdapter.getConfigDir(), "SYSTEM.md");
+    if (existsSync(target)) return;
+
+    mkdirSync(dirname(target), { recursive: true });
+    copyFileSync(source, target);
+  } catch {
+    // best effort — a prompt-seeding failure must never break plugin load
   }
 }
 
@@ -261,6 +294,10 @@ export default function ompPlugin(pi: MinimalHookAPI): void {
   // Self-register the MCP server so `ctx_*` tools are reachable under the
   // plugin install path, not just the manual MCP-only path (issue #677).
   ensureMcpServerRegistered();
+
+  // Seed OMP's native routing file so the model learns to use those tools
+  // without requiring the manual SYSTEM.md copy workaround (issue #873).
+  ensureSystemInstructionsSeeded();
 
   const db = getOrCreateDB(projectDir);
 

--- a/tests/adapters/omp-plugin.test.ts
+++ b/tests/adapters/omp-plugin.test.ts
@@ -20,7 +20,7 @@ import "../setup-home";
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { SessionDB } from "../../src/session/db.js";
@@ -87,6 +87,7 @@ describe("OMP plugin", () => {
     }
     delete process.env.OMP_PROJECT_DIR;
     delete process.env.PI_PROJECT_DIR;
+    delete process.env.PI_CODING_AGENT_DIR;
   });
 
   // ═══════════════════════════════════════════════════════════
@@ -266,6 +267,31 @@ describe("OMP plugin", () => {
       const sid = mod._getOmpPluginSessionIdForTests();
       // 16-hex SHA-256 prefix per deriveSessionId contract
       expect(sid).toMatch(/^[a-f0-9]{16}$/);
+    });
+
+    it("seeds SYSTEM.md routing instructions into the OMP agent dir when missing", async () => {
+      const agentDir = join(tempDir, "agent");
+      process.env.PI_CODING_AGENT_DIR = agentDir;
+
+      await registerOmpPlugin(api);
+
+      const systemPath = join(agentDir, "SYSTEM.md");
+      expect(existsSync(systemPath)).toBe(true);
+      const content = readFileSync(systemPath, "utf-8");
+      expect(content).toContain("ctx_execute");
+      expect(content).toContain("ctx_batch_execute");
+    });
+
+    it("does not overwrite an existing OMP SYSTEM.md", async () => {
+      const agentDir = join(tempDir, "agent-existing");
+      const systemPath = join(agentDir, "SYSTEM.md");
+      mkdirSync(agentDir, { recursive: true });
+      writeFileSync(systemPath, "# custom OMP prompt\n", "utf-8");
+      process.env.PI_CODING_AGENT_DIR = agentDir;
+
+      await registerOmpPlugin(api);
+
+      expect(readFileSync(systemPath, "utf-8")).toBe("# custom OMP prompt\n");
     });
   });
 

--- a/tests/adapters/omp-plugin.test.ts
+++ b/tests/adapters/omp-plugin.test.ts
@@ -269,29 +269,30 @@ describe("OMP plugin", () => {
       expect(sid).toMatch(/^[a-f0-9]{16}$/);
     });
 
-    it("seeds SYSTEM.md routing instructions into the OMP agent dir when missing", async () => {
+    it("seeds APPEND_SYSTEM.md routing instructions into the OMP agent dir when missing", async () => {
       const agentDir = join(tempDir, "agent");
       process.env.PI_CODING_AGENT_DIR = agentDir;
 
       await registerOmpPlugin(api);
 
-      const systemPath = join(agentDir, "SYSTEM.md");
-      expect(existsSync(systemPath)).toBe(true);
-      const content = readFileSync(systemPath, "utf-8");
+      const appendSystemPath = join(agentDir, "APPEND_SYSTEM.md");
+      expect(existsSync(appendSystemPath)).toBe(true);
+      expect(existsSync(join(agentDir, "SYSTEM.md"))).toBe(false);
+      const content = readFileSync(appendSystemPath, "utf-8");
       expect(content).toContain("ctx_execute");
       expect(content).toContain("ctx_batch_execute");
     });
 
-    it("does not overwrite an existing OMP SYSTEM.md", async () => {
+    it("does not overwrite an existing OMP APPEND_SYSTEM.md", async () => {
       const agentDir = join(tempDir, "agent-existing");
-      const systemPath = join(agentDir, "SYSTEM.md");
+      const appendSystemPath = join(agentDir, "APPEND_SYSTEM.md");
       mkdirSync(agentDir, { recursive: true });
-      writeFileSync(systemPath, "# custom OMP prompt\n", "utf-8");
+      writeFileSync(appendSystemPath, "# custom OMP prompt\n", "utf-8");
       process.env.PI_CODING_AGENT_DIR = agentDir;
 
       await registerOmpPlugin(api);
 
-      expect(readFileSync(systemPath, "utf-8")).toBe("# custom OMP prompt\n");
+      expect(readFileSync(appendSystemPath, "utf-8")).toBe("# custom OMP prompt\n");
     });
   });
 


### PR DESCRIPTION
## Summary
- seed the packaged OMP routing instructions into `~/.omp/agent/APPEND_SYSTEM.md` when the plugin loads
- preserve OMP's built-in system prompt and native tool definitions
- preserve an existing user `APPEND_SYSTEM.md` instead of overwriting it
- add regression coverage for missing and existing append prompts

## Why `APPEND_SYSTEM.md`
OMP treats `SYSTEM.md` as a replacement for its default system prompt. Using `APPEND_SYSTEM.md` appends context-mode's routing rules while retaining OMP's built-in tool guidance.

Closes https://github.com/mksglu/context-mode/issues/873

## Validation
- `npx vitest run tests/adapters/omp-plugin.test.ts` — 24/24 passed
- `npm run typecheck`
- `npm run build`
- `git diff --check`