### PR TITLE
docs: sync adapter install/usage/debugging with the code (v1.0.167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ This gives you all 11 MCP tools without automatic routing. The model can still u
    npm install -g context-mode
    ```
 
-2. Add the following to `~/.gemini/settings.json`. This single file registers the MCP server and all four hooks:
+2. Add the following to `~/.gemini/settings.json`. This single file registers the MCP server and four hooks (`BeforeTool`, `AfterTool`, `PreCompress`, `SessionStart`). The adapter additionally wires `BeforeAgent` (a UserPromptSubmit-equivalent that fires on prompt submit) when you run `context-mode upgrade`:
 
    ```json
    {
@@ -190,7 +190,7 @@ You should see `context-mode: ... - Connected`.
 cp node_modules/context-mode/configs/gemini-cli/GEMINI.md ./GEMINI.md
 ```
 
-> **Why the BeforeTool matcher?** It targets only tools that produce large output (`run_shell_command`, `read_file`, `read_many_files`, `grep_search`, `search_file_content`, `web_fetch`, `activate_skill`) plus context-mode's own tools (`mcp__plugin_context-mode`). This avoids unnecessary hook overhead on lightweight tools while intercepting every tool that could flood your context window.
+> **Why the BeforeTool matcher?** It targets only tools that produce large output (`run_shell_command`, `read_file`, `read_many_files`, `grep_search`, `search_file_content`, `web_fetch`, `activate_skill`), context-mode's own tools (`mcp__plugin_context-mode`, `mcp__context-mode`), and an external-MCP catch-all (`mcp__(?!.*context-mode)`) so any other MCP server's large payloads are intercepted too. This avoids unnecessary hook overhead on lightweight tools while intercepting every tool that could flood your context window.
 
 Full config reference: [`configs/gemini-cli/settings.json`](configs/gemini-cli/settings.json)
 
@@ -241,7 +241,7 @@ Full config reference: [`configs/gemini-cli/settings.json`](configs/gemini-cli/s
 
 4. Restart VS Code.
 
-**Verify:** Open Copilot Chat and type `ctx stats`. Context-mode tools should appear and respond.
+**Verify:** Open Copilot Chat and type `ctx stats` — context-mode tools should appear and respond, and `ctx stats` reports the context-window tokens saved this session. Run `context-mode doctor` (or `ctx doctor` in Copilot Chat) to confirm the hooks in `.github/hooks/context-mode.json` and the MCP server in `.vscode/mcp.json` are registered; a missing entry reports a `fail` with the fix `context-mode upgrade`.
 
 **Routing:** Automatic via SessionStart hook. Optionally copy routing instructions for full model awareness:
 
@@ -266,9 +266,9 @@ Full hook config including PreCompact: [`configs/vscode-copilot/hooks.json`](con
    npm install -g context-mode
    ```
 
-2. Add MCP server via Settings UI: **Settings > Tools > AI Assistant > Model Context Protocol (MCP) > Add Server**:
+2. Add MCP server via Settings UI: **Settings > Tools > GitHub Copilot > MCP > Configure**:
    - **Name:** `context-mode`
-   - **Command:** `context-mode`
+   - **Command:** `context-mode` (matches the shipped `configs/jetbrains-copilot/mcp.json`; use `npx -y context-mode` only if you skipped the global install)
 
 3. Create `.github/hooks/context-mode.json`:
 
@@ -290,7 +290,7 @@ Full hook config including PreCompact: [`configs/vscode-copilot/hooks.json`](con
 
 4. Restart the JetBrains IDE.
 
-**Verify:** Open Copilot Chat and type `ctx stats`. Context-mode tools should appear and respond.
+**Verify:** Open Copilot Chat and type `ctx stats` — context-mode tools should appear and respond, and `ctx stats` reports the context-window tokens saved this session. Run `context-mode doctor` (or `ctx doctor` in Copilot Chat) to confirm the hooks in `.github/hooks/context-mode.json`; note the MCP-registration check intentionally reports `WARN` on JetBrains because MCP servers are registered in the IDE Settings UI (not CLI-inspectable) — confirm the context-mode server shows under **Settings > Tools > GitHub Copilot > MCP**.
 
 **Routing:** Automatic via SessionStart hook. Optionally copy routing instructions for full model awareness:
 
@@ -427,7 +427,7 @@ Restart Cursor. The plugin appears in **Settings → Plugins** as "Context Mode 
        "preToolUse": [
          {
            "command": "context-mode hook cursor pretooluse",
-           "matcher": "Shell|Read|Grep|WebFetch|Task|MCP:ctx_execute|MCP:ctx_execute_file|MCP:ctx_batch_execute"
+           "matcher": "Shell|Read|Grep|WebFetch|mcp_web_fetch|mcp_fetch_tool|Task|MCP:ctx_execute|MCP:ctx_execute_file|MCP:ctx_batch_execute|MCP:(?!ctx_)"
          }
        ],
        "postToolUse": [
@@ -444,9 +444,9 @@ Restart Cursor. The plugin appears in **Settings → Plugins** as "Context Mode 
    }
    ```
 
-   The `preToolUse` matcher is optional — without it, the hook fires on all tools. The `stop` hook fires when the agent turn ends and can send a followup message to continue the loop. `afterAgentResponse` is also available (fire-and-forget, receives full response text).
+   The `preToolUse` matcher is optional — without it, the hook fires on all tools. The `stop` hook fires when the agent turn ends and can send a followup message to continue the loop. Two more events are available: `sessionStart` (Cursor v1 ships native `sessionStart`; context-mode wires `context-mode hook cursor sessionstart` and registers it on `context-mode upgrade`) and `afterAgentResponse` (fire-and-forget, receives full response text).
 
-4. Copy the routing rules file. Cursor lacks a SessionStart hook, so the model needs a rules file for routing awareness:
+4. Copy the routing rules file for full model awareness at session start (belt-and-braces alongside the `sessionStart` hook):
 
    ```bash
    mkdir -p .cursor/rules
@@ -455,13 +455,13 @@ Restart Cursor. The plugin appears in **Settings → Plugins** as "Context Mode 
 
 5. Restart Cursor or open a new agent session.
 
-**Verify:** Open Cursor Settings > MCP and confirm "context-mode" shows as connected. In agent chat, type `ctx stats`.
+**Verify:** Open Cursor Settings > MCP and confirm "context-mode" shows as connected. In agent chat, type `ctx stats` to confirm the context-window savings for the session (savings ratio + per-tool token breakdown). Run `context-mode doctor` to validate the native hooks in `.cursor/hooks.json` — it flags plugin/native duplicate firing (each event fires twice; remove one config) and warns about enterprise/Claude-compat hook configs.
 
-**Routing:** Hooks enforce routing programmatically via `preToolUse`/`postToolUse`/`stop`. The `.cursor/rules/context-mode.mdc` file provides routing instructions at session start since Cursor's `sessionStart` hook is currently rejected by their validator ([forum report](https://forum.cursor.com/t/unknown-hook-type-sessionstart/149566)). Project `.cursor/hooks.json` overrides `~/.cursor/hooks.json`.
+**Routing:** Hooks enforce routing programmatically via `preToolUse`/`postToolUse`/`sessionStart`/`stop`. Cursor v1 ships native `sessionStart`, so context-mode registers it as the SessionStart equivalent (state restore after compaction). The `.cursor/rules/context-mode.mdc` rules file additionally provides routing instructions for model awareness. Project `.cursor/hooks.json` overrides `~/.cursor/hooks.json`.
 
 **Known limitation:** Cursor accepts `additional_context` in hook responses but does not surface it to the model ([forum #155689](https://forum.cursor.com/t/native-posttooluse-hooks-accept-and-log-additional-context-successfully-but-the-injected-context-is-not-surfaced-to-the-model/155689)). Routing relies on the `.mdc` rules file instead of hook context injection.
 
-Full configs: [`configs/cursor/hooks.json`](configs/cursor/hooks.json) | [`configs/cursor/mcp.json`](configs/cursor/mcp.json) | [`configs/cursor/context-mode.mdc`](configs/cursor/context-mode.mdc)
+Full configs: [`configs/cursor/hooks.json`](configs/cursor/hooks.json) (manual-install reference) | [`configs/cursor/mcp.json`](configs/cursor/mcp.json) | [`configs/cursor/context-mode.mdc`](configs/cursor/context-mode.mdc). The Marketplace/local-folder **plugin** loads [`hooks/cursor/hooks.json`](hooks/cursor/hooks.json) instead (via `.cursor-plugin/plugin.json`), which registers all five events (`preToolUse`, `postToolUse`, `sessionStart`, `afterAgentResponse`, `stop`) using `npx -y context-mode …` so no global install is required; the manual `configs/cursor/hooks.json` above uses bare `context-mode …` (needs `npm install -g context-mode`).
 
 </details>
 
@@ -483,9 +483,10 @@ Full configs: [`configs/cursor/hooks.json`](configs/cursor/hooks.json) | [`confi
 
    The `plugin` entry registers all 11 `ctx_*` tools natively and enables hooks — OpenCode calls context-mode's TypeScript plugin in-process, so there is no redundant stdio MCP child per session.
 
-2. *(Optional)* Copy the routing rules file. The model needs an `AGENTS.md` file for routing awareness:
+2. *(Optional)* Copy the routing rules file. The model needs an `AGENTS.md` file for routing awareness. OpenCode resolves the `"context-mode"` plugin from npm into its own per-package cache (not a project-local `node_modules/`), so install the package first if you want a local copy to copy from — or download `AGENTS.md` from the repo:
 
    ```bash
+   npm install context-mode    # creates ./node_modules/context-mode for the cp below
    cp node_modules/context-mode/configs/opencode/AGENTS.md AGENTS.md
    ```
 
@@ -493,7 +494,7 @@ Full configs: [`configs/cursor/hooks.json`](configs/cursor/hooks.json) | [`confi
 
 3. Restart OpenCode.
 
-**Verify:** In the OpenCode session, type `ctx stats`. Context-mode tools should appear and respond.
+**Verify:** In the OpenCode session, type `ctx stats` — context-mode tools should appear and respond, and `ctx stats` shows the context-window savings ratio / per-tool token breakdown for the session. Run `context-mode doctor` to confirm `context-mode` is in the `plugin` array of `opencode.json`; if it is missing, zero `ctx_*` tools register — fix with `context-mode upgrade`.
 
 **Upgrade note:** If an existing config has BOTH `plugin: ["context-mode"]` AND `mcp.context-mode`, OpenCode will register zero `ctx_*` tools — the plugin path correctly suppresses MCP duplicates, but the legacy MCP entry confuses the loader. Run `context-mode upgrade` to remove the legacy `mcp.context-mode` entry; your other MCP servers are preserved. v1.0.140+ emits a stderr diagnostic with the same guidance when this happens.
 
@@ -512,7 +513,7 @@ Full configs: [`configs/opencode/opencode.json`](configs/opencode/opencode.json)
 
 **Install:**
 
-1. Add to `kilo.json` in your project root (or `~/.config/kilo/kilo.json` for global):
+1. Add to `kilo.json` in your project root (or `~/.config/kilo/kilo.json` for global). `kilo.jsonc` and the `.kilo/` and `.kilocode/` project subdirectories are also valid config locations that context-mode discovers and writes:
 
    ```json
    {
@@ -523,15 +524,16 @@ Full configs: [`configs/opencode/opencode.json`](configs/opencode/opencode.json)
 
    The `plugin` entry registers all 11 `ctx_*` tools natively and enables hooks — KiloCode calls context-mode's TypeScript plugin in-process, so there is no redundant stdio MCP child per session.
 
-2. *(Optional)* Copy the routing rules file. KiloCode shares the OpenCode plugin architecture, so the model needs an `AGENTS.md` file for routing awareness:
+2. *(Optional)* Copy the routing rules file. KiloCode shares the OpenCode plugin architecture, so the model needs an `AGENTS.md` file for routing awareness. KiloCode resolves the `"context-mode"` plugin from npm into its own per-package cache (not a project-local `node_modules/`), so install the package first to get a local copy — and use the KiloCode-specific routing file:
 
    ```bash
-   cp node_modules/context-mode/configs/opencode/AGENTS.md AGENTS.md
+   npm install context-mode    # creates ./node_modules/context-mode for the cp below
+   cp node_modules/context-mode/configs/kilo/AGENTS.md AGENTS.md
    ```
 
 3. Restart KiloCode.
 
-**Verify:** In the KiloCode session, type `ctx stats`. Context-mode tools should appear and respond.
+**Verify:** In the KiloCode session, type `ctx stats` — context-mode tools should appear and respond, and `ctx stats` shows the context-window savings ratio for the session. Run `context-mode doctor` to confirm `context-mode` is in the `plugin` array of `kilo.json` (or `kilo.jsonc`); if it is missing, zero `ctx_*` tools register — fix with `context-mode upgrade`.
 
 **Upgrade note:** If an existing config has BOTH `plugin: ["context-mode"]` AND `mcp.context-mode`, KiloCode will register zero `ctx_*` tools — the plugin path correctly suppresses MCP duplicates, but the legacy MCP entry confuses the loader. Run `context-mode upgrade` to remove the legacy `mcp.context-mode` entry; your other MCP servers are preserved. v1.0.140+ emits a stderr diagnostic with the same guidance when this happens.
 
@@ -546,7 +548,7 @@ Full configs: [`configs/opencode/opencode.json`](configs/opencode/opencode.json)
 
 **Prerequisites:** OpenClaw gateway running ([>2026.1.29](https://github.com/openclaw/openclaw/pull/9761)), Node.js 22+.
 
-context-mode runs as a native [OpenClaw](https://github.com/openclaw) gateway plugin, targeting **Pi Agent** sessions (Read/Write/Edit/Bash tools). Unlike other platforms, there's no separate MCP server — the plugin registers directly into the gateway runtime via OpenClaw's [plugin API](https://docs.openclaw.ai/tools/plugin).
+context-mode runs as a native [OpenClaw](https://github.com/openclaw) gateway plugin, targeting **Pi Agent** sessions (Read/Write/Edit/Bash tools). The plugin registers routing/lifecycle hooks in-process via OpenClaw's [plugin API](https://docs.openclaw.ai/tools/plugin), AND the installer registers a separate MCP sidecar (`mcp.servers.context-mode` → `node server.bundle.mjs`) so the agent-callable `ctx_*` tools appear in Pi Agent's tool list. Both are needed — without the sidecar the `ctx_*` tools are missing.
 
 **Install:**
 
@@ -570,7 +572,7 @@ context-mode runs as a native [OpenClaw](https://github.com/openclaw) gateway pl
 
 2. Open a Pi Agent session.
 
-**Verify:** The plugin registers 8 hooks via [`api.on()`](https://docs.openclaw.ai/tools/plugin) (lifecycle) and [`api.registerHook()`](https://docs.openclaw.ai/tools/plugin) (commands). Type `ctx stats` to confirm tools are loaded.
+**Verify:** The plugin registers lifecycle/tool hooks via [`api.on()`](https://docs.openclaw.ai/tools/plugin) (`before_tool_call`, `after_tool_call`, `session_start`, `before_compaction`, `after_compaction`, `before_model_resolve`, `before_prompt_build`, `session_end`, `subagent_spawning`), command hooks via [`api.registerHook()`](https://docs.openclaw.ai/tools/plugin) (`command:new/reset/stop`), and a context engine via `api.registerContextEngine()`. Type `ctx stats` to confirm tools are loaded and to read the context-saved ratio (it should climb toward ~98% after a few routed tool calls). Run `context-mode doctor` to confirm the plugin is registered in `plugins.entries`, is enabled, and owns compaction (`plugins.slots.contextEngine = context-mode`); a failed check prints the fix `context-mode upgrade`.
 
 **Routing:** Automatic. All tool interception, session tracking, and compaction recovery hooks activate automatically — no manual hook configuration or routing file needed.
 
@@ -670,7 +672,7 @@ The Codex plugin manifest provides MCP via `.codex-plugin/mcp.json`, skills via
 
    `PreToolUse` enforces deny/block routing today and is prepared for input rewrites once Codex supports them. `PostToolUse` captures session events. `PreCompact` builds the resume snapshot before compaction. `SessionStart` restores state after compaction. `UserPromptSubmit` captures user decisions and corrections. `Stop` records turn-end state.
 
-   > **Note:** Codex PreToolUse routing currently supports deny rules only (blocks dangerous commands). It still needs upstream `updatedInput` support before context-mode can rewrite tool input; track [openai/codex#18491](https://github.com/openai/codex/issues/18491). Context injection (`additionalContext`) is not supported in Codex PreToolUse — it works via PostToolUse and SessionStart instead. This is handled automatically.
+   > **Note:** Codex PreToolUse deny routing (blocks dangerous commands) works on all builds. On codex-cli >= 0.141.0 ([#845](https://github.com/mksglu/context-mode/issues/845)) context-mode additionally performs command rewrites (`updatedInput`) and PreToolUse context injection (`additionalContext`), detected at runtime via `codex --version`; older builds fail closed (a redirect becomes a deny). The earlier upstream blocker [openai/codex#18491](https://github.com/openai/codex/issues/18491) is therefore resolved for modern builds. This is handled automatically.
    >
    > `PreCompact` support is runtime-gated: it is present in Codex CLI 0.130.0, while the public Codex hooks docs may lag the shipped hook-event list. Older Codex builds that do not emit `PreCompact` will not create pre-compaction snapshots.
 
@@ -685,7 +687,7 @@ The Codex plugin manifest provides MCP via `.codex-plugin/mcp.json`, skills via
 
 5. Restart Codex CLI.
 
-**Verify:** Start a session and type `ctx stats` to verify MCP. To verify hook routing, confirm Codex lists/trusts the context-mode plugin hooks, then run a command that matches the routing rules.
+**Verify:** Start a session and type `ctx stats` — it confirms the MCP server is reachable and shows how much context window context-mode has saved this session (savings ratio + per-tool breakdown). Run `ctx doctor` (or `context-mode doctor`) to confirm the `codex` binary is on PATH, `[features].hooks = true`, MCP registration, and that each hook event is configured. To verify hook routing, confirm Codex lists/trusts the context-mode plugin hooks, then run a command that matches the routing rules.
 
 **Routing:** MCP tools work after plugin install. Plugin hook routing is active only when `hooks` and `plugin_hooks` are enabled and Codex trusts the plugin hook commands. Manual hook routing is active when `$CODEX_HOME/hooks.json` or `~/.codex/hooks.json` is configured. The `AGENTS.md` file provides routing instructions for model awareness.
 
@@ -748,13 +750,18 @@ The Codex plugin manifest provides MCP via `.codex-plugin/mcp.json`, skills via
    event = "Stop"
    command = "context-mode hook kimi stop"
    timeout = 30
+
+   [[hooks]]
+   event = "SessionEnd"
+   command = "context-mode hook kimi sessionend"
+   timeout = 30
    ```
 
-4. Restart Kimi Code CLI and verify MCP with `ctx stats`.
+4. Restart Kimi Code CLI. Type `ctx stats` to verify MCP and to see how much context window context-mode saved this session (savings ratio + per-tool token breakdown). Run `ctx doctor` (or `context-mode doctor`) to confirm the `kimi` binary is on PATH, the `[[hooks]]` entries are present in `config.toml`, and `context-mode` is registered in `~/.kimi-code/mcp.json`.
 
-   > **Note:** Kimi Code uses the same JSON stdin/stdout wire protocol as Codex, but accepts `additionalContext`, `updatedInput`, and `permissionDecision: "ask"` in PreToolUse responses (Codex rejects these). The kimi hook normalizes `ContentPart[]` prompt arrays to strings for downstream extractors.
+   > **Note:** Kimi Code uses the same JSON stdin/stdout wire protocol as Codex. PreToolUse is **deny-only** on Kimi: `updatedInput`, `additionalContext`, and `permissionDecision: "ask"` are silently dropped by Kimi's host runner (same as Codex), so context-mode uses PreToolUse only to block dangerous commands. The kimi hook normalizes `ContentPart[]` prompt arrays to strings for downstream extractors.
 
-5. (Optional) Copy the routing instructions file for your project:
+5. (Optional) Copy the routing instructions file for your project. Kimi reuses the Codex `AGENTS.md` by design — there is no separate `configs/kimi/AGENTS.md`:
 
    ```bash
    cp "$(npm root -g)/context-mode/configs/codex/AGENTS.md" ./AGENTS.md
@@ -818,9 +825,11 @@ Full documentation: [`docs/adapters/kimi-code.md`](docs/adapters/kimi-code.md)
 
 5. Restart Qwen Code.
 
-**Verify:** Start a session and type `ctx stats`. Context-mode tools should appear and respond.
+> **Per-turn token capture (Stop hook):** context-mode also wires a 6th hook — `Stop` — to capture per-turn token cost (token usage is unreachable through hook stdin, so the Stop script tails the Qwen chat log). The dispatcher form `context-mode hook qwen-code stop` is **not** wired in the CLI yet, so do **not** hand-add it to `settings.json` (it would silently no-op). Instead run `context-mode upgrade`, which writes all 6 hooks — including `Stop` as a direct node-script command (`hooks/qwen-code/stop.mjs`) that fires correctly. The 5 events above cover routing + session continuity even without it.
 
-**Note:** Qwen Code uses the same hook wire protocol as Claude Code (JSON stdin/stdout, same event names). Auto-detected via MCP clientInfo (`qwen-cli-mcp-client-*`) or `QWEN_PROJECT_DIR` env var.
+**Verify:** Start a session and type `ctx stats` — context-mode tools should appear and respond, and `ctx stats` reports the context-window tokens saved this session (per-tool breakdown). Run `context-mode doctor` to confirm the hooks and MCP server are registered in `~/.qwen/settings.json` (it reports each hook pass/fail and `context-mode found in mcpServers`).
+
+**Note:** Qwen Code uses the same hook wire protocol as Claude Code (JSON stdin/stdout, same event names). Auto-detected via MCP clientInfo (`qwen-cli-mcp-client-*`), `QWEN_PROJECT_DIR` env var, or the `~/.qwen/` config dir; force with `CONTEXT_MODE_PLATFORM=qwen-code`.
 
 </details>
 
@@ -859,7 +868,7 @@ Full documentation: [`docs/adapters/kimi-code.md`](docs/adapters/kimi-code.md)
 
 4. Restart Antigravity.
 
-**Verify:** In an Antigravity session, type `ctx stats`. Context-mode tools should appear and respond.
+**Verify:** In an Antigravity session, type `ctx stats` — context-mode tools should appear and respond, and `ctx stats` reports the context tokens saved this session. Because Antigravity is MCP-only (no hooks), savings depend on the model honoring `GEMINI.md` routing, so confirm `GEMINI.md` is at the project root and re-check `ctx stats` after a few data-heavy operations. Run `context-mode doctor` to confirm context-mode is registered in `~/.gemini/antigravity/mcp_config.json` (it reports MCP registration pass/fail and warns that Antigravity has no hook support).
 
 **Routing:** Manual. The `GEMINI.md` file is the only enforcement method (~60% compliance). There is no programmatic interception. Auto-detected via MCP protocol handshake (`clientInfo.name`) — no manual platform configuration needed.
 
@@ -883,10 +892,10 @@ agy plugin install https://github.com/mksglu/context-mode/tree/main/configs/anti
 
 Restart `agy`.
 
-**MCP-only (no plugin, no hooks):** if you only want the `ctx_*` tools, skip the plugin and add context-mode to agy's global MCP profile `~/.gemini/config/mcp_config.json` (distinct from the Antigravity IDE's `~/.gemini/antigravity/` path), then restart `agy`:
+**MCP-only (no plugin, no hooks):** if you only want the `ctx_*` tools, skip the plugin and add context-mode to agy's global MCP profile `~/.gemini/config/mcp_config.json` (distinct from the Antigravity IDE's `~/.gemini/antigravity/` path), then restart `agy`. The `env` pin matches the shipped config and guarantees agy is detected even when Claude Code is co-installed:
 
 ```json
-{ "mcpServers": { "context-mode": { "command": "context-mode" } } }
+{ "mcpServers": { "context-mode": { "command": "context-mode", "env": { "CONTEXT_MODE_PLATFORM": "antigravity-cli" } } } }
 ```
 
 **Verify:** type `ctx stats` in an agy session, or run any prompt from [Try It](#try-it) and check the savings. `context-mode doctor` confirms MCP + hook registration. Remove with `agy plugin uninstall context-mode`.
@@ -920,24 +929,15 @@ Restart `agy`.
    }
    ```
 
-3. Create `.kiro/hooks/context-mode.json`:
+3. Configure the hooks. Kiro reads hooks from the **agent config** at `~/.kiro/agents/default.json` under a top-level `hooks` key — *not* from a `.kiro/hooks/` file. The reliable way to write them in the correct place is:
 
-   ```json
-   {
-     "name": "context-mode",
-     "description": "Context-mode hooks for context window protection",
-     "hooks": {
-       "preToolUse": [
-         { "matcher": "execute_bash|fs_read|@context-mode/ctx_execute|@context-mode/ctx_execute_file|@context-mode/ctx_batch_execute|@(?!context-mode/)", "command": "context-mode hook kiro pretooluse" }
-       ],
-       "postToolUse": [
-         { "matcher": "*", "command": "context-mode hook kiro posttooluse" }
-       ]
-     }
-   }
+   ```bash
+   context-mode upgrade
    ```
 
-4. Copy routing instructions. Kiro's `agentSpawn` (SessionStart) is not yet implemented, so the model needs a routing file at session start:
+   This wires the `preToolUse`, `postToolUse`, `agentSpawn`, and `userPromptSubmit` hooks into `~/.kiro/agents/default.json`. (The matcher context-mode uses is `execute_bash|fs_read|@context-mode/ctx_execute|@context-mode/ctx_execute_file|@context-mode/ctx_batch_execute|@(?!context-mode/)`.)
+
+4. *(Optional)* Copy routing instructions for full model awareness at session start. `agentSpawn` (the Kiro SessionStart equivalent) already injects the routing block, so this is a belt-and-braces step:
 
    ```bash
    cp node_modules/context-mode/configs/kiro/KIRO.md ./KIRO.md
@@ -945,9 +945,9 @@ Restart `agy`.
 
 5. Restart Kiro.
 
-**Verify:** Open the Kiro panel > MCP Servers tab and confirm "context-mode" shows a green status indicator. In chat, type `ctx stats`.
+**Verify:** Open the Kiro panel > MCP Servers tab and confirm "context-mode" shows a green status indicator. In chat, type `ctx stats` to see the context-window tokens saved this session. Run `context-mode doctor` to confirm MCP registration (`~/.kiro/settings/mcp.json`) and the hooks in `~/.kiro/agents/default.json`; a missing hook prints the fix `context-mode upgrade`. Note that `context-mode doctor` validates only the **global** `~/.kiro/settings/mcp.json` even if you registered MCP at the project level.
 
-**Routing:** Hooks enforce routing programmatically via `preToolUse`/`postToolUse`. The `KIRO.md` file provides routing instructions since `agentSpawn` (SessionStart equivalent) is not yet wired. Tool names appear as `@context-mode/ctx_batch_execute`, `@context-mode/ctx_search`, etc. Auto-detected via MCP protocol handshake.
+**Routing:** Hooks enforce routing programmatically via `preToolUse`/`postToolUse`, and `agentSpawn` injects session context as the SessionStart equivalent (state restore after compaction). The `KIRO.md` file optionally adds routing instructions for model awareness. Tool names appear as `@context-mode/ctx_batch_execute`, `@context-mode/ctx_search`, etc. Auto-detected via MCP protocol handshake.
 
 Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/agent.json`](configs/kiro/agent.json) | [`configs/kiro/KIRO.md`](configs/kiro/KIRO.md)
 
@@ -990,9 +990,9 @@ Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/
 
 4. Restart Zed (or save `settings.json` — Zed auto-restarts context servers on config change).
 
-**Verify:** Open the Agent Panel (`Cmd+Shift+A`), go to settings, and check the indicator dot next to "context-mode" — green means active. Type `ctx stats` in the agent chat.
+**Verify:** Open the Agent Panel (`Cmd+Shift+A`), go to settings, and check the indicator dot next to "context-mode" — green means active. Because Zed has no hooks, routing is enforced only by `AGENTS.md` (~60% compliance), so type `ctx stats` in the agent chat to see the actual context-saved ratio for the session and confirm routing is happening. Run `context-mode doctor` to confirm context-mode is registered under `context_servers` in `~/.config/zed/settings.json` — a fail prints the exact fix; expect one `warn` that Zed is MCP-only (no hooks), which is normal. Note: `context-mode doctor` checks `~/.config/zed/settings.json` even on Windows; if you edited `%APPDATA%\Zed\settings.json` the MCP server still works but the doctor cannot verify it.
 
-**Routing:** Manual. The `AGENTS.md` file is the only enforcement method (~60% compliance). There is no programmatic interception. Tool names appear as `mcp:context-mode:ctx_batch_execute`, `mcp:context-mode:ctx_search`, etc. Auto-detected via MCP protocol handshake.
+**Routing:** Manual. The `AGENTS.md` file is the only enforcement method (~60% compliance). There is no programmatic interception. Tool names appear as `mcp:context-mode:ctx_batch_execute`, `mcp:context-mode:ctx_search`, etc. Detection: auto via MCP `clientInfo` handshake or presence of `~/.config/zed/`; force with `CONTEXT_MODE_PLATFORM=zed`.
 
 </details>
 
@@ -1009,35 +1009,19 @@ Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/
    npm install -g context-mode
    ```
 
-2. Install the package into Pi:
+2. Install the Pi extension:
 
    ```bash
-   pi install npm:context-mode
+   context-mode upgrade
    ```
 
-   Alternative — add it manually to `~/.pi/agent/settings.json` (or `.pi/settings.json` for project-level):
+   The Pi integration ships as an **extension** at `~/.pi/extensions/context-mode/`; `context-mode upgrade` copies/syncs it there. There is no `pi install npm:` / `packages[]` mechanism, and no `~/.pi/agent/settings.json` — Pi's config root is `~/.pi/`.
 
-   ```json
-   {
-     "packages": ["npm:context-mode"]
-   }
-   ```
-
-3. Add to `~/.pi/agent/mcp.json` (or `.pi/mcp.json` for project-level):
-
-   ```json
-   {
-     "mcpServers": {
-       "context-mode": {
-         "command": "context-mode"
-       }
-     }
-   }
-   ```
+3. The extension auto-bridges the MCP tools into Pi (via `pi.registerTool()` on `before_agent_start`), because Pi has no native MCP support. **No `mcp.json` edit is needed or honored** — do not create `~/.pi/agent/mcp.json`.
 
 4. Restart Pi.
 
-**Verify:** In a Pi session, type `ctx stats`. Context-mode tools should appear and respond.
+**Verify:** In a Pi session, type `ctx stats` — context-mode tools should appear and respond, and `ctx stats` shows the tokens saved / savings ratio for this Pi session (backed by the per-session DB). Run `context-mode doctor` to validate the extension at `~/.pi/extensions/context-mode/` and the MCP bridge; if the bridge fails the `ctx_*` tools won't appear and stderr shows `[context-mode] WARNING: failed to bridge MCP tools to Pi` — fix with `context-mode upgrade`.
 
 **Routing:** Automatic. The extension registers all key lifecycle events (`tool_call`, `tool_result`, `session_start`, `session_before_compact`), providing full session continuity and routing enforcement.
 
@@ -1110,7 +1094,7 @@ Then restart OMP. No lock file edit, no version pin — version is read from the
 
 4. Restart OMP.
 
-**Verify (any path):** In an OMP session, type `ctx stats`. Context-mode tools should appear and respond.
+**Verify (any path):** In an OMP session, type `ctx stats` — context-mode tools should appear and respond, and after some work `ctx stats` shows the tokens-saved / savings ratio (OMP additionally records real per-turn token + provider cost via the `turn_end` hook, so the ~98% figure is user-verifiable). Run `context-mode doctor` as a complementary check — it verifies the `context-mode` entry in `~/.omp/agent/mcp.json`; if that entry is absent the `ctx_*` tools won't appear until OMP is restarted (the plugin self-registers on load).
 
 **Routing:** Plugin path — programmatic enforcement via four `pi.on(...)` handlers (`tool_call` returns `{ block: true, reason }` for `curl`/`wget`/inline-fetch per upstream [`hooks/types.ts:566`](https://github.com/can1357/oh-my-pi/blob/main/packages/coding-agent/src/extensibility/hooks/types.ts), `tool_result` captures session events, `session_start` initializes the per-session DB row, `session_before_compact` persists a resume snapshot). ~98% compliance, parity with Claude Code hooks. MCP-only path — rule-based via `SYSTEM.md`, ~60% compliance. Auto-detected via `PI_CODING_AGENT_DIR` env var or presence of `~/.omp/`. Storage roots at `~/.omp/context-mode/` so OMP and Pi installs never share session DBs, content indices, or stats files.
 
@@ -1244,13 +1228,13 @@ Session continuity requires 5 hooks working together:
 |---|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **PreToolUse** | Enforces sandbox routing before tool execution | Yes | -- | -- | -- | Yes | Yes | -- | -- | -- | Yes | -- | Bounded | Yes | -- | ✓ (via tool_call event) | ✓ (via tool_call event) |
 | **PostToolUse** | Captures events after each tool call | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | -- | Yes (capture-only) | Yes | -- | ✓ (via tool_result event) | ✓ (via tool_result event) |
-| **UserPromptSubmit** | Captures user decisions and corrections | Yes | -- | -- | -- | Yes | -- | Plugin (via chat.message) | Plugin (via chat.message) | -- | Yes | -- | -- | -- | -- | -- | -- |
+| **UserPromptSubmit** | Captures user decisions and corrections | Yes | Yes (via BeforeAgent) | -- | -- | Yes | -- | Plugin (via chat.message) | Plugin (via chat.message) | -- | Yes | -- | -- | -- | -- | -- | -- |
 | **Stop** | Captures assistant turn-end state | Yes | -- | -- | -- | Yes | Yes | -- | -- | -- | Yes | -- | Best-effort | -- | -- | -- | -- |
 | **PreCompact** | Builds snapshot before compaction | Yes | Yes | Yes | Yes | Yes | -- | Plugin | Plugin | Plugin | Yes | -- | -- | -- | -- | ✓ (via session_before_compact) | ✓ (via session_before_compact) |
-| **SessionStart** | Restores state after compaction or resume | Yes | Yes | Yes | Yes | Yes | -- | ✓ (via experimental.chat.system.transform) | ✓ (via experimental.chat.system.transform) | Plugin | Yes | -- | -- | -- | -- | ✓ (via session_start event) | ✓ (via session_start event) |
-| | **Session completeness** | **Full** | **High** | **High** | **High** | **High** | **Partial** | **Full** | **Full** | **High** | **Partial** | **--** | **Partial** | **Partial** | **--** | **High** | **High** |
+| **SessionStart** | Restores state after compaction or resume | Yes | Yes | Yes | Yes | Yes | Yes (native sessionStart) | ✓ (via experimental.chat.system.transform) | ✓ (via experimental.chat.system.transform) | Plugin | Yes | -- | -- | Yes (via agentSpawn) | -- | ✓ (via session_start event) | ✓ (via session_start event) |
+| | **Session completeness** | **Full** | **High** | **High** | **High** | **High** | **High** | **Full** | **Full** | **High** | **Partial** | **--** | **Partial** | **High** | **--** | **High** | **High** |
 
-> **Note:** Full session continuity (capture + snapshot + restore) works on **Claude Code**, **Gemini CLI**, **VS Code Copilot**, **JetBrains Copilot**, **OpenCode**, and **KiloCode**. **GitHub Copilot CLI** uses its own camelCase hook config keys (`preToolUse`, `postToolUse`, `preCompact`, `sessionStart`, `userPromptSubmitted`, `agentStop`) and top-level hook responses; it captures prompt, tool, compaction, session-start, and stop events when the plugin hooks are installed. **OpenCode** and **KiloCode** use `experimental.chat.system.transform` as a SessionStart surrogate to inject the routing block and restore prior sessions, plus `chat.message` for user-prompt capture; full SessionStart hook support is not yet available ([#14808](https://github.com/sst/opencode/issues/14808), [#5409](https://github.com/sst/opencode/issues/5409)), but prior-session continuity and user-decision capture work fully. **Cursor** captures tool events via `preToolUse`/`postToolUse`, but `sessionStart` is currently rejected by Cursor's validator ([forum report](https://forum.cursor.com/t/unknown-hook-type-sessionstart/149566)), so session restore after compaction is not available yet. **OpenClaw** uses native gateway plugin hooks (`api.on()`) for full session continuity. **Pi Coding Agent** provides high session continuity via extension hooks (`tool_call`, `tool_result`, `session_start`, `session_before_compact`). **Codex CLI** provides partial hook-based session tracking through PreToolUse, PostToolUse, PreCompact, SessionStart, UserPromptSubmit, and Stop; MCP tools work. **Antigravity IDE** and **Zed** have no hook support in the current release, so session tracking is not available there. **Antigravity CLI (`agy`)** is separate from the IDE and supports bounded `PreToolUse`, capture-only `PostToolUse`, and best-effort `Stop` through its plugin hooks. **Kiro** captures tool events via native `preToolUse`/`postToolUse` hooks, but its SessionStart equivalent (`agentSpawn`) is not yet wired, so session restore after compaction is unavailable. **OMP** (Oh My Pi) ships full plugin-based hook support — `omp plugin install context-mode` registers `tool_call`, `tool_result`, `session_start`, and `session_before_compact` handlers and storage roots cleanly under `~/.omp/context-mode/` so OMP and Pi installs never share state.
+> **Note:** Full session continuity (capture + snapshot + restore) works on **Claude Code**, **Gemini CLI**, **VS Code Copilot**, **JetBrains Copilot**, **OpenCode**, and **KiloCode**. **GitHub Copilot CLI** uses its own camelCase hook config keys (`preToolUse`, `postToolUse`, `preCompact`, `sessionStart`, `userPromptSubmitted`, `agentStop`) and top-level hook responses; it captures prompt, tool, compaction, session-start, and stop events when the plugin hooks are installed. **OpenCode** and **KiloCode** use `experimental.chat.system.transform` as a SessionStart surrogate to inject the routing block and restore prior sessions, plus `chat.message` for user-prompt capture; full SessionStart hook support is not yet available ([#14808](https://github.com/sst/opencode/issues/14808), [#5409](https://github.com/sst/opencode/issues/5409)), but prior-session continuity and user-decision capture work fully. **Cursor** captures tool events via `preToolUse`/`postToolUse`, and Cursor v1's native `sessionStart` hook is registered (state restore after compaction); `afterAgentResponse` is also wired. **OpenClaw** uses native gateway plugin hooks (`api.on()`) for full session continuity. **Pi Coding Agent** provides high session continuity via extension hooks (`tool_call`, `tool_result`, `session_start`, `session_before_compact`). **Codex CLI** provides partial hook-based session tracking through PreToolUse, PostToolUse, PreCompact, SessionStart, UserPromptSubmit, and Stop; MCP tools work. **Antigravity IDE** and **Zed** have no hook support in the current release, so session tracking is not available there. **Antigravity CLI (`agy`)** is separate from the IDE and supports bounded `PreToolUse`, capture-only `PostToolUse`, and best-effort `Stop` through its plugin hooks. **Kiro** captures tool events via native `preToolUse`/`postToolUse` hooks, and its SessionStart equivalent (`agentSpawn`) is wired (injects session context via JSON stdout for state restore after compaction), plus `userPromptSubmit`. **OMP** (Oh My Pi) ships full plugin-based hook support — `omp plugin install context-mode` registers `tool_call`, `tool_result`, `session_start`, and `session_before_compact` handlers and storage roots cleanly under `~/.omp/context-mode/` so OMP and Pi installs never share state.
 
 <details>
 <summary><strong>What gets captured</strong></summary>
@@ -1335,7 +1319,7 @@ Detailed event data is also indexed into FTS5 for on-demand retrieval via `ctx_s
 
 **Claude Code** — Full session support. All 5 hook types fire, capturing tool events, user decisions, building compaction snapshots, and restoring state after compaction, `--continue`, `--resume`, or `/resume`.
 
-**Gemini CLI** — High coverage. PostToolUse (AfterTool), PreCompact (PreCompress), and SessionStart all fire. Missing UserPromptSubmit, so user decisions and corrections aren't captured — but file edits, git ops, errors, and tasks are fully tracked.
+**Gemini CLI** — High coverage. PostToolUse (AfterTool), PreCompact (PreCompress), and SessionStart all fire, and user prompts/decisions ARE captured via the `BeforeAgent` hook (Gemini's UserPromptSubmit equivalent, fires on prompt submit) when wired by `context-mode upgrade`. File edits, git ops, errors, and tasks are fully tracked.
 
 **VS Code Copilot** — High coverage. Same as Gemini CLI — PostToolUse, PreCompact, and SessionStart all fire. User decisions aren't captured but all tool-level events are.
 
@@ -1343,7 +1327,7 @@ Detailed event data is also indexed into FTS5 for on-demand retrieval via `ctx_s
 
 **GitHub Copilot CLI** — High coverage. Native plugin hooks use camelCase config keys (`preToolUse`, `postToolUse`, `preCompact`, `sessionStart`, `userPromptSubmitted`, `agentStop`) and top-level hook response fields. The plugin captures user prompts, tool events, compaction snapshots, session start restore, and stop events.
 
-**Cursor** — Partial coverage. Native `preToolUse` and `postToolUse` hooks capture tool events. `sessionStart` is documented by Cursor but currently rejected by their validator, so session restore is not available. Routing instructions are delivered via MCP server startup instead.
+**Cursor** — High coverage. Native `preToolUse` and `postToolUse` hooks capture tool events, and Cursor v1's native `sessionStart` hook is registered as the SessionStart equivalent, so session restore after compaction works; `afterAgentResponse` is also wired. The `.cursor/rules/context-mode.mdc` rules file additionally provides routing instructions for model awareness.
 
 **OpenCode** — Full session support. The TypeScript plugin captures PostToolUse events via `tool.execute.after`, user prompts and decisions via `chat.message`, builds compaction snapshots via `experimental.session.compacting`, and restores prior sessions via `experimental.chat.system.transform` (SessionStart surrogate). Routing block is injected on first `chat.system.transform` per session. AGENTS.md/CLAUDE.md/CONTEXT.md rules are captured automatically on first hook fire.
 
@@ -1351,7 +1335,7 @@ Detailed event data is also indexed into FTS5 for on-demand retrieval via `ctx_s
 
 **OpenClaw / Pi Agent** — High coverage. All tool lifecycle hooks (`after_tool_call`, `before_compaction`, `session_start`) fire via the native gateway plugin. User decisions aren't captured but file edits, git ops, errors, and tasks are fully tracked. Falls back to DB snapshot reconstruction if compaction hooks fail on older gateway versions. See [`docs/adapters/openclaw.md`](docs/adapters/openclaw.md).
 
-**Codex CLI** — MCP active, hooks require `[features].hooks = true`. Hook scripts (PreToolUse, PostToolUse, PreCompact, SessionStart, UserPromptSubmit, Stop) are implemented and tested; `PreCompact` remains runtime-gated on Codex builds that emit the event. PreToolUse deny routing works; input rewriting still depends on upstream `updatedInput` support ([openai/codex#18491](https://github.com/openai/codex/issues/18491)).
+**Codex CLI** — MCP active, hooks require `[features].hooks = true`. Hook scripts (PreToolUse, PostToolUse, PreCompact, SessionStart, UserPromptSubmit, Stop) are implemented and tested; `PreCompact` remains runtime-gated on Codex builds that emit the event. PreToolUse deny routing works on all builds; on codex-cli >= 0.141.0 ([#845](https://github.com/mksglu/context-mode/issues/845)) context-mode also performs command rewrites (`updatedInput`) and PreToolUse context injection (`additionalContext`), detected at runtime via `codex --version`; older builds fail closed (a redirect becomes a deny). The earlier upstream blocker [openai/codex#18491](https://github.com/openai/codex/issues/18491) is resolved for modern builds.
 
 **Antigravity** — No session support. No hooks, no event capture. Requires manually copying `GEMINI.md` to your project root. Auto-detected via MCP protocol handshake (`clientInfo.name`).
 
@@ -1359,7 +1343,7 @@ Detailed event data is also indexed into FTS5 for on-demand retrieval via `ctx_s
 
 **Zed** — No session support. No hooks, no event capture. Requires manually copying `AGENTS.md` to your project root. Auto-detected via MCP protocol handshake (`clientInfo.name`).
 
-**Kiro** — Partial coverage. Native `preToolUse` and `postToolUse` hooks capture tool events and enforce sandbox routing. `agentSpawn` (the Kiro equivalent of SessionStart) is not yet implemented, so session restore after compaction is not available. Requires manually copying `KIRO.md` to your project root. Auto-detected via MCP protocol handshake (`clientInfo.name`).
+**Kiro** — High coverage. Native `preToolUse` and `postToolUse` hooks capture tool events and enforce sandbox routing, `agentSpawn` (the Kiro equivalent of SessionStart) is wired and injects session context via JSON stdout so session restore after compaction works, and `userPromptSubmit` captures user decisions. `KIRO.md` is an optional belt-and-braces routing file. Auto-detected via MCP protocol handshake (`clientInfo.name`).
 
 **Pi Coding Agent** — High coverage. The extension registers all key lifecycle events: `tool_call` (PreToolUse), `tool_result` (PostToolUse), `session_start` (SessionStart), and `session_before_compact` (PreCompact). File edits, git ops, errors, and tasks are fully tracked. Session restore after compaction works via the extension's event hooks.
 Tool call output can be collapsed/expanded with the default Pi's default keybinding (Ctrl+O)
@@ -1375,9 +1359,9 @@ Tool call output can be collapsed/expanded with the default Pi's default keybind
 | MCP Server / Native Tools | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Native plugin | Native plugin | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | PreToolUse Hook | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | Yes | -- | Bounded | Yes | -- | Yes (extension) | Plugin |
 | PostToolUse Hook | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | Yes | -- | Yes (capture-only) | Yes | -- | Yes (extension) | Plugin |
-| SessionStart Hook | Yes | Yes | Yes | Yes | Yes | Yes | -- | ✓ (via experimental.chat.system.transform) | ✓ (via experimental.chat.system.transform) | Plugin | Yes | Yes | -- | -- | -- | -- | Yes (extension) | Plugin |
+| SessionStart Hook | Yes | Yes | Yes | Yes | Yes | Yes | Yes | ✓ (via experimental.chat.system.transform) | ✓ (via experimental.chat.system.transform) | Plugin | Yes | Yes | -- | -- | Yes (agentSpawn) | -- | Yes (extension) | Plugin |
 | PreCompact Hook | Yes | Yes | Yes | Yes | Yes | Yes | -- | Plugin | Plugin | Plugin | Yes | Yes | -- | -- | -- | -- | Yes (extension) | Plugin |
-| Can Modify Args | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | -- | Yes | -- | -- | -- | -- | Yes (extension) | -- |
+| Can Modify Args | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Runtime (codex-cli >= 0.141.0) | -- | -- | -- | -- | -- | Yes (extension) | -- |
 | Can Block Tools | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | Yes | -- | Bounded | Yes | -- | Yes (extension) | Plugin |
 | Utility Commands (ctx) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes (/ctx-stats, /ctx-doctor) | Yes |
 | Slash Commands | Yes | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
@@ -1389,11 +1373,11 @@ Tool call output can be collapsed/expanded with the default Pi's default keybind
 >
 > **OpenClaw** runs context-mode as a native gateway plugin targeting Pi Agent sessions. Hooks register via `api.on()` (tool/lifecycle) and `api.registerHook()` (commands). All tool interception and compaction hooks are supported. See [`docs/adapters/openclaw.md`](docs/adapters/openclaw.md).
 >
-> **Codex CLI** hooks require `[features].hooks = true`. MCP tools work, and hook scripts activate through `$CODEX_HOME/hooks.json` or `~/.codex/hooks.json`. PreToolUse supports `permissionDecision: "deny"` only; input modification still needs upstream `updatedInput` support ([openai/codex#18491](https://github.com/openai/codex/issues/18491)). `additionalContext` is not supported in PreToolUse (context injection works via PostToolUse and SessionStart instead; the codex formatter handles this automatically). PreCompact stores resume snapshots before compaction on Codex builds that emit the event, SessionStart restores them, and UserPromptSubmit/Stop capture prompt and turn-end continuity events. See the Codex install section for setup. **Antigravity** and **Zed** do not support hooks. They rely solely on manually-copied routing instruction files (`AGENTS.md` / `GEMINI.md`) for enforcement (~60% compliance). See each platform's install section for copy instructions. Antigravity and Zed are auto-detected via MCP protocol handshake — no manual platform configuration needed.
+> **Codex CLI** hooks require `[features].hooks = true`. MCP tools work, and hook scripts activate through `$CODEX_HOME/hooks.json` or `~/.codex/hooks.json`. PreToolUse `permissionDecision: "deny"` works on all builds; on codex-cli >= 0.141.0 ([#845](https://github.com/mksglu/context-mode/issues/845)) context-mode also performs command rewrites (`updatedInput`) and PreToolUse context injection (`additionalContext`), detected at runtime via `codex --version`; older builds fail closed (a redirect becomes a deny). The earlier upstream blocker [openai/codex#18491](https://github.com/openai/codex/issues/18491) is resolved for modern builds. PreCompact stores resume snapshots before compaction on Codex builds that emit the event, SessionStart restores them, and UserPromptSubmit/Stop capture prompt and turn-end continuity events. See the Codex install section for setup. **Antigravity** and **Zed** do not support hooks. They rely solely on manually-copied routing instruction files (`AGENTS.md` / `GEMINI.md`) for enforcement (~60% compliance). See each platform's install section for copy instructions. Antigravity and Zed are auto-detected via MCP protocol handshake — no manual platform configuration needed.
 >
 > **Antigravity CLI (`agy`)** supports bounded `PreToolUse` blocking for mapped Bash/Read/Grep/WebFetch surfaces, plus `PostToolUse` capture and best-effort `Stop` capture through its plugin `hooks.json`. The routing rule and routing skill remain the broader instruction layer; `PreInvocation`/`PostInvocation` are not wired until their payload/response semantics are verified.
 >
-> **Kiro** supports native `preToolUse` and `postToolUse` hooks for routing enforcement and tool event capture. `agentSpawn` (SessionStart equivalent) and `stop` are not yet wired. Requires manually copying `KIRO.md` to your project root. Kiro is auto-detected via MCP protocol handshake (`clientInfo.name`).
+> **Kiro** supports native `preToolUse` and `postToolUse` hooks for routing enforcement and tool event capture, plus `agentSpawn` (the SessionStart equivalent, injects session context via JSON stdout) and `userPromptSubmit`. `stop` is not wired. `KIRO.md` is an optional routing file (`agentSpawn` already injects the routing block). Kiro is auto-detected via MCP protocol handshake (`clientInfo.name`).
 >
 > **Pi Coding Agent** runs context-mode as an extension with full hook support. The extension registers `tool_call`, `tool_result`, `session_start`, and `session_before_compact` events, providing high session continuity coverage. The MCP server provides all 11 MCP tools.
 >
@@ -1598,6 +1582,7 @@ That blocks loopback + RFC1918 + ULA in addition to the always-blocked ranges. U
 | Variable | Default | Purpose |
 |---|---|---|
 | `CONTEXT_MODE_DIR` | Adapter default, for example `~/.codex/context-mode` or `~/.claude/context-mode` | Since v1.0.147. Absolute writable root for context-mode storage. Sessions and stats use `<root>/sessions`; indexed content uses `<root>/content`. Empty or whitespace-only values are treated as unset and shown by `ctx_doctor`; non-empty values must be absolute. `~` is not expanded. |
+| `CONTEXT_MODE_DATA_DIR` | Adapter default | Universal storage override ([#649](https://github.com/mksglu/context-mode/issues/649)) that relocates the adapter-level `sessionDir` and `memoryDir`. Distinct from `CONTEXT_MODE_DIR` (the storage root for sessions/stats/content): a Codex user who sets only `CONTEXT_MODE_DIR` will not relocate the adapter-level sessions/memories governed by `CONTEXT_MODE_DATA_DIR`. Set both if you are relocating all storage. |
 
 ### Routing-guidance environment variables
 

--- a/configs/copilot-cli/README.md
+++ b/configs/copilot-cli/README.md
@@ -18,8 +18,10 @@ This registers:
   rules that keep raw bytes out of the context window.
 - **Capture hooks** (`hooks.json`) — `preToolUse`, `postToolUse`,
   `sessionStart`, `userPromptSubmitted`, `agentStop`, `preCompact` (Copilot
-  CLI's camelCase event names — verified against the `@github/copilot` 1.0.60
-  binary; PascalCase keys are silently ignored and never fire), each dispatching
+  CLI's native camelCase event names — verified against the `@github/copilot`
+  1.0.60 binary; PascalCase event names are ALSO accepted and fire, so the
+  casing is not load-bearing — context-mode uses camelCase because it is the
+  CLI's native naming, not because PascalCase would fail), each dispatching
   `context-mode hook copilot-cli <event>`. Byte-equivalent to what
   `context-mode upgrade` writes to `~/.copilot/hooks/`, so the plugin registers
   them with no `upgrade` / agent call.
@@ -45,3 +47,30 @@ Then, to also install the capture hooks, run the upgrade **from inside Copilot**
 ```sh
 copilot -p "Use the context-mode ctx_upgrade tool to install context-mode's hooks." --allow-all
 ```
+
+## Verify / Troubleshoot
+
+Run the diagnostic:
+
+```sh
+context-mode doctor
+```
+
+Under the plugin, the doctor validates the bundle's `hooks.json` and the MCP
+registration. When something is missing it prints the exact fix:
+
+- **Plugin path** (`CONTEXT_MODE_COPILOT_PLUGIN=1`) — the suggested fix is
+  `copilot plugin install mksglu/context-mode:configs/copilot-cli`.
+- **Standalone path** — the MCP fix is
+  `copilot mcp add context-mode -- context-mode` and the hooks fix is
+  `context-mode upgrade`.
+
+Hooks fail open: if a stale global `context-mode` is on PATH, routing goes inert
+rather than blocking your tools — so a misconfiguration shows up as *no
+redirection*, not as errors.
+
+## Confirm savings
+
+In a Copilot CLI session, type `ctx stats` (or call the `ctx_stats` MCP tool) to
+see the context-window tokens saved this session — savings ratio plus a per-tool
+breakdown.

--- a/docs/adapters/kimi-code.md
+++ b/docs/adapters/kimi-code.md
@@ -26,7 +26,7 @@ Kimi Code CLI uses a JSON stdin/stdout hook paradigm similar to Claude Code and 
 | UserPromptSubmit | Yes (handles `ContentPart[]` array format) |
 | Stop | Yes (per-turn end) |
 | Modify args | No (`updatedInput` silently dropped by host runner) |
-| Modify output | Yes |
+| Modify output | No (PostToolUse `additionalContext` emitted but not acted upon by host; `canModifyOutput: false`) |
 | Inject session context | No via `additionalContext` (host has no channel) — use `UserPromptSubmit.message` instead |
 | Block tools | Yes (exit code 2 or `permissionDecision: "deny"`) |
 
@@ -142,3 +142,8 @@ echo '{"tool_name":"Bash","tool_input":{"command":"curl https://example.com"}}' 
 ```
 
 Expected output: a JSON response with routing guidance redirecting to `ctx_execute` / `ctx_fetch_and_index`.
+
+## Confirm savings
+
+Run `ctx stats` to see how much context window context-mode saved this session
+(savings ratio plus a per-tool token breakdown).

--- a/docs/jetbrains-copilot.md
+++ b/docs/jetbrains-copilot.md
@@ -4,7 +4,7 @@ Setup guide for using context-mode with JetBrains IDEs (IntelliJ IDEA, WebStorm,
 
 ## Prerequisites
 
-- **Node.js 18+** (`node --version`)
+- **Node.js >= 22.5** (or Bun) (`node --version`)
 - **JetBrains IDE** — any JetBrains IDE (IntelliJ IDEA, WebStorm, PyCharm, GoLand, Rider, CLion, etc.)
 - **GitHub Copilot plugin v1.5.57+** — install from Settings > Plugins > Marketplace, search "GitHub Copilot"
 
@@ -13,23 +13,29 @@ Setup guide for using context-mode with JetBrains IDEs (IntelliJ IDEA, WebStorm,
 JetBrains configures MCP servers via the Settings UI, not a file.
 
 1. Open your JetBrains IDE.
-2. Go to **Settings > Tools > AI Assistant > Model Context Protocol (MCP)**.
-3. Click **Add Server** and configure:
+2. Go to **Settings > Tools > GitHub Copilot > MCP**.
+3. Click **Add Server** (or **Configure**) and set:
    - **Name:** `context-mode`
-   - **Command:** `npx`
-   - **Args:** `-y context-mode`
+   - **Command:** `context-mode`
+   - **Args:** *(none)*
 4. Click **OK** to save.
 
-Alternatively, you can use a global install (`npm install -g context-mode`) and set the command to `context-mode` with no args.
+This matches the shipped [`configs/jetbrains-copilot/mcp.json`](../configs/jetbrains-copilot/mcp.json), which registers `{ "command": "context-mode" }` and requires a global install (`npm install -g context-mode`).
 
-Example MCP config (for reference): [`configs/jetbrains-copilot/mcp.json`](../configs/jetbrains-copilot/mcp.json)
+If you prefer not to install globally, set the **Command** to `npx` and **Args** to `-y context-mode` instead.
 
 ## Hook Installation
 
-Install hooks using the automated setup command:
+Install hooks using the upgrade command (the hook-config writer):
 
 ```bash
-npx context-mode@latest setup --adapter jetbrains-copilot
+context-mode upgrade
+```
+
+If you have multiple CLIs installed and want to force JetBrains detection:
+
+```bash
+CONTEXT_MODE_PLATFORM=jetbrains-copilot context-mode upgrade
 ```
 
 This creates `.github/hooks/context-mode.json` in your project with the following hook configuration:
@@ -82,14 +88,14 @@ You can also verify context savings by typing `ctx stats` in a Copilot chat sess
 ## Troubleshooting
 
 **MCP server not connecting**
-- Ensure Node.js 18+ is in your PATH.
+- Ensure Node.js >= 22.5 is in your PATH.
 - Restart the JetBrains IDE after adding the MCP server.
 - Check Settings > Tools > AI Assistant > MCP and confirm "context-mode" shows a green status indicator.
 
 **Hooks not firing**
 - Verify `.github/hooks/context-mode.json` exists in your project root.
 - JetBrains Copilot reads hooks from `.github/hooks/` — the same location as VS Code Copilot.
-- Re-run `npx context-mode@latest setup --adapter jetbrains-copilot` to regenerate the hook config.
+- Re-run `context-mode upgrade` (optionally `CONTEXT_MODE_PLATFORM=jetbrains-copilot context-mode upgrade`) to regenerate the hook config.
 
 **"context-mode: command not found"**
 - Install globally: `npm install -g context-mode`

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -10,7 +10,8 @@ context-mode supports 17 client platforms, plus the OpenClaw gateway integration
 |----------|-----------|
 | **JSON stdin/stdout** | Claude Code, Gemini CLI, VS Code Copilot, JetBrains Copilot, GitHub Copilot CLI, Cursor, Codex CLI, Qwen Code, Kimi Code, Antigravity CLI (`agy`), Kiro |
 | **TS Plugin** | OpenCode, KiloCode, OpenClaw |
-| **MCP-only** | Antigravity, Zed, Pi, OMP (Oh My Pi) |
+| **Extension (in-process hooks + MCP bridge)** | Pi, OMP (Oh My Pi) |
+| **MCP-only** | Antigravity, Zed |
 
 The MCP server layer is 100% portable and needs no adapter. Only the hook layer requires platform-specific adapters.
 
@@ -34,20 +35,20 @@ This puts the `context-mode` binary in PATH, which is required for:
 
 | Feature | Claude Code | Qwen Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | GitHub Copilot CLI | Cursor | OpenCode | KiloCode | OpenClaw | Codex CLI | Kimi Code | Antigravity | Antigravity CLI (`agy`) | Kiro | Zed | Pi | OMP |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| **Paradigm** | json-stdio | json-stdio | json-stdio | json-stdio | json-stdio | json-stdio | json-stdio | ts-plugin | ts-plugin | ts-plugin | json-stdio | json-stdio | mcp-only | json-stdio | json-stdio | mcp-only | mcp-only | mcp-only |
-| **PreToolUse equivalent** | `PreToolUse` | `PreToolUse` | `BeforeTool` | `PreToolUse` | `PreToolUse` | `preToolUse` | `preToolUse` | `tool.execute.before` | `tool.execute.before` | `tool_call:before` | `PreToolUse` | `PreToolUse` | -- | `PreToolUse` (bounded) | `preToolUse` | -- | -- | -- |
-| **PostToolUse equivalent** | `PostToolUse` | `PostToolUse` | `AfterTool` | `PostToolUse` | `PostToolUse` | `postToolUse` | `postToolUse` | `tool.execute.after` | `tool.execute.after` | `tool_call:after` | `PostToolUse` | `PostToolUse` | -- | `PostToolUse` (capture-only) | `postToolUse` | -- | -- | -- |
-| **PreCompact equivalent** | `PreCompact` | `PreCompact` | `PreCompress` | `PreCompact` | `PreCompact` | `preCompact` | -- | `experimental.session.compacting` | `experimental.session.compacting` | `registerContextEngine` | -- | `PreCompact` | -- | -- | -- | -- | -- | -- |
-| **SessionStart** | `SessionStart` | `SessionStart` | `SessionStart` | `SessionStart` | `SessionStart` | `sessionStart` | -- (buggy in Cursor) | -- | -- | `command:new` | `SessionStart` | `SessionStart` | -- | -- | -- | -- | -- | -- |
-| **Stop equivalent** | -- | -- | -- | `Stop` | `Stop` | `agentStop` | `stop` | -- | -- | -- | `Stop` | `Stop` | -- | `Stop` (best-effort, unverified on agy 1.0.6) | -- | -- | -- | -- |
-| **Can modify args** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes | -- | -- | -- | -- | -- | -- |
+| **Paradigm** | json-stdio | json-stdio | json-stdio | json-stdio | json-stdio | json-stdio | json-stdio | ts-plugin | ts-plugin | ts-plugin | json-stdio | json-stdio | mcp-only | json-stdio | json-stdio | mcp-only | extension | extension |
+| **PreToolUse equivalent** | `PreToolUse` | `PreToolUse` | `BeforeTool` | `PreToolUse` | `PreToolUse` | `preToolUse` | `preToolUse` | `tool.execute.before` | `tool.execute.before` | `before_tool_call` | `PreToolUse` | `PreToolUse` | -- | `PreToolUse` (bounded) | `preToolUse` | -- | `tool_call` (extension) | `tool_call` (plugin) |
+| **PostToolUse equivalent** | `PostToolUse` | `PostToolUse` | `AfterTool` | `PostToolUse` | `PostToolUse` | `postToolUse` | `postToolUse` | `tool.execute.after` | `tool.execute.after` | `after_tool_call` | `PostToolUse` | `PostToolUse` | -- | `PostToolUse` (capture-only) | `postToolUse` | -- | `tool_result` (extension) | `tool_result` (plugin) |
+| **PreCompact equivalent** | `PreCompact` | `PreCompact` | `PreCompress` | `PreCompact` | `PreCompact` | `preCompact` | -- | `experimental.session.compacting` | `experimental.session.compacting` | `registerContextEngine` | -- | `PreCompact` | -- | -- | -- | -- | `session_before_compact` (extension) | `session_before_compact` (plugin) |
+| **SessionStart** | `SessionStart` | `SessionStart` | `SessionStart` | `SessionStart` | `SessionStart` | `sessionStart` | `sessionStart` | -- | -- | `session_start` | `SessionStart` | `SessionStart` | -- | -- | `agentSpawn` | -- | `session_start` (extension) | `session_start` (plugin) |
+| **Stop equivalent** | `Stop` | `Stop` | -- | `Stop` | `Stop` | `agentStop` | `stop` | -- | -- | -- | `Stop` | `Stop` | -- | `Stop` (best-effort, registered but not observed through agy 1.0.10) | -- | -- | `turn_end` (extension) | `turn_end` (plugin) |
+| **Can modify args** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Runtime (codex-cli >= 0.141.0) | Yes | -- | -- | -- | -- | -- | -- |
 | **Can modify output** | Yes | Yes | Yes | Yes | Yes | No | No | Yes (caveat) | Yes (caveat) | No | No | Yes | -- | -- | -- | -- | -- | -- |
-| **Can inject session context** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | Yes | Yes | Yes | -- | -- | -- | -- | -- | -- |
-| **Can block tools** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes (throw) | Yes (throw) | Yes | Yes | Yes | -- | Bounded | Yes | -- | -- | -- |
-| **Config location** | `~/.claude/settings.json` | `~/.qwen/settings.json` | `~/.gemini/settings.json` | `.github/hooks/*.json` | `.github/hooks/*.json` | `~/.copilot/hooks/context-mode.json` + `~/.copilot/mcp-config.json` | `.cursor/hooks.json` or `~/.cursor/hooks.json` | `opencode.json` | `kilo.json` | `openclaw.json` | `~/.codex/hooks.json` + `~/.codex/config.toml` | `~/.kimi-code/config.toml` | `~/.gemini/antigravity/mcp_config.json` | `~/.gemini/config/mcp_config.json` + `~/.gemini/config/hooks.json` | `~/.kiro/settings/mcp.json` | `~/.config/zed/settings.json` | `~/.pi/settings.json` | `~/.omp/agent/mcp_config.json` |
+| **Can inject session context** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | Yes | Yes | Yes | -- | -- | Yes | -- | -- | -- |
+| **Can block tools** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes (throw) | Yes (throw) | Yes | Yes | Yes | -- | Bounded | Yes | -- | Yes (extension) | Yes (plugin) |
+| **Config location** | `~/.claude/settings.json` | `~/.qwen/settings.json` | `~/.gemini/settings.json` | `.github/hooks/*.json` | `.github/hooks/*.json` | `~/.copilot/hooks/context-mode.json` + `~/.copilot/mcp-config.json` | `.cursor/hooks.json` or `~/.cursor/hooks.json` | `opencode.json` | `kilo.json` / `kilo.jsonc` | `openclaw.json` | `~/.codex/hooks.json` + `~/.codex/config.toml` | `~/.kimi-code/config.toml` | `~/.gemini/antigravity/mcp_config.json` | `~/.gemini/config/mcp_config.json` + `~/.gemini/config/hooks.json` | `~/.kiro/settings/mcp.json` | `~/.config/zed/settings.json` | `~/.pi/extensions/context-mode/` (extension) | `~/.omp/agent/mcp.json` |
 | **Session ID field** | `session_id` | `session_id` | `session_id` | `sessionId` (camelCase) | `sessionId` (camelCase) | `session_id` (snake_case; `sessionId` defensive fallback) | `conversation_id` | `sessionID` (camelCase) | `sessionID` (camelCase) | `pid-${ppid}` fallback | N/A | `session_id` | N/A | `conversationId` (unverified) | `pid-${ppid}` fallback | N/A | N/A | N/A |
-| **Project dir env** | `CLAUDE_PROJECT_DIR` | `QWEN_PROJECT_DIR` | `GEMINI_PROJECT_DIR` | `CLAUDE_PROJECT_DIR` | `CLAUDE_PROJECT_DIR` | stdin `cwd` | stdin `workspace_roots` | `ctx.directory` (plugin init) | `ctx.directory` (plugin init) | `process.cwd()` | N/A | stdin `cwd` | N/A | stdin `workspace.current_dir` (refs-backed; `workspacePaths[0]` fallback) | stdin `cwd` | N/A | N/A | `OMP_PROCESSING_AGENT_DIR` |
-| **MCP/tool naming** | `mcp__server__tool` | `mcp__server__tool` | `mcp__server__tool` | `f1e_` prefix | `f1e_` prefix | `mcp__server__tool` | `MCP:<tool>` in hook payloads | native `ctx_*` plugin tools | native `ctx_*` plugin tools | native `ctx_*` plugin tools | `mcp__server__tool` | `mcp__context-mode__tool` | `mcp__server__tool` | `context-mode/<tool>` | `mcp__server__tool` | `mcp__server__tool` | `mcp__server__tool` | `mcp__server__tool` |
+| **Project dir env** | `CLAUDE_PROJECT_DIR` | `QWEN_PROJECT_DIR` | `GEMINI_PROJECT_DIR` | `CLAUDE_PROJECT_DIR` | `CLAUDE_PROJECT_DIR` | stdin `cwd` | stdin `workspace_roots` | `ctx.directory` (plugin init) | `ctx.directory` (plugin init) | `process.cwd()` | N/A | stdin `cwd` | N/A | stdin `workspace.current_dir` (refs-backed; `workspacePaths[0]` fallback) | stdin `cwd` | N/A | `PI_WORKSPACE_DIR` / `PI_PROJECT_DIR` (extension-set) | `PI_CODING_AGENT_DIR` |
+| **MCP/tool naming** | `mcp__server__tool` | `mcp__server__tool` | `mcp__server__tool` | host-side naming | host-side naming | `mcp__server__tool` | `MCP:<tool>` in hook payloads | native `ctx_*` plugin tools | native `ctx_*` plugin tools | native `ctx_*` plugin tools | `mcp__server__tool` | `mcp__context-mode__tool` | `mcp__server__tool` | `context-mode/<tool>` | `mcp__server__tool` | `mcp__server__tool` | native `ctx_*` (bridged) | `mcp__server__tool` |
 | **Hook command format** | `context-mode hook claude-code <event>` | `context-mode hook qwen-code <event>` | `context-mode hook gemini-cli <event>` | `context-mode hook vscode-copilot <event>` | `context-mode hook jetbrains-copilot <event>` | `context-mode hook copilot-cli <event>` | `context-mode hook cursor <event>` | TS plugin (no command) | TS plugin (no command) | TS plugin (no command) | `context-mode hook codex <event>` | `context-mode hook kimi <event>` | N/A | `context-mode hook antigravity-cli <event>` | `context-mode hook kiro <event>` | N/A | N/A | N/A |
 | **Hook registration** | settings.json hooks object | settings.json hooks object | settings.json hooks object | `.github/hooks/*.json` | `.github/hooks/*.json` | `~/.copilot/hooks/context-mode.json` (`version: 1`) | `hooks.json` native hook arrays | opencode.json plugin array | kilo.json plugin array | openclaw.json `plugins.entries` | `~/.codex/hooks.json` | `config.toml` hooks array | N/A | plugin root `hooks.json` (`PreToolUse`, `PostToolUse`, `Stop`; bundle mirrors `hooks/hooks.json` for agy validate/install) | Kiro CLI hooks (JSON stdin) | N/A | N/A | N/A |
 | **MCP server command** | `context-mode` (or plugin auto) | `context-mode` | `context-mode` | `context-mode` | `context-mode` | `context-mode` | `context-mode` | N/A (native plugin tools) | N/A (native plugin tools) | N/A (native plugin tools) | `context-mode` | `context-mode` | `context-mode` | `context-mode` | `context-mode` | `context-mode` | `context-mode` | `context-mode` |
@@ -99,7 +100,10 @@ context-mode hook claude-code posttooluse
 context-mode hook claude-code precompact
 context-mode hook claude-code sessionstart
 context-mode hook claude-code userpromptsubmit
+context-mode hook claude-code stop
 ```
+
+**Verify:** Run `/context-mode:ctx-doctor` (or `context-mode doctor`) to confirm hooks, the MCP server, and plugin registration are wired. Type `ctx stats` (or check the `context-mode statusline`) to confirm context-window savings for the session.
 
 **Known Issues:** None significant.
 
@@ -114,8 +118,10 @@ context-mode hook claude-code userpromptsubmit
 Gemini CLI uses the same JSON stdin/stdout paradigm as Claude Code but with different hook names and response format.
 
 **Hook Names:**
+- `BeforeAgent` -- equivalent to UserPromptSubmit (fires when the user submits a prompt; used for session-continuity capture)
 - `BeforeTool` -- equivalent to PreToolUse
 - `AfterTool` -- equivalent to PostToolUse
+- `AfterModel` -- per-turn token/cost capture hook. Shipped in `configs/gemini-cli/settings.json` and emitted by the adapter, but **not currently routed through the CLI dispatcher** (`HOOK_MAP['gemini-cli']` omits `aftermodel`), so `context-mode hook gemini-cli aftermodel` is a no-op until the dispatcher gains the key (tracked in [#882](https://github.com/mksglu/context-mode/issues/882)).
 - `PreCompress` -- equivalent to PreCompact (advisory only, async, cannot block)
 - `SessionStart` -- fires when a session starts
 
@@ -131,13 +137,20 @@ Gemini CLI uses the same JSON stdin/stdout paradigm as Claude Code but with diff
 
 **Hook Commands:**
 ```
+context-mode hook gemini-cli beforeagent
 context-mode hook gemini-cli beforetool
 context-mode hook gemini-cli aftertool
 context-mode hook gemini-cli precompress
 context-mode hook gemini-cli sessionstart
 ```
 
+(`aftermodel` is intentionally omitted — it is not dispatchable via the CLI today; see the `AfterModel` note above.)
+
+**Verify:** Run `context-mode doctor` (or `ctx doctor` in Gemini CLI) to confirm the BeforeTool/SessionStart hooks, FTS5, and plugin registration in `~/.gemini/settings.json`. A hook failure shows as a `fail` row with a `context-mode upgrade` fix. Type `ctx stats` in Gemini CLI to confirm context-window savings for the session.
+
 **Known Issues / Caveats:**
+- User prompts/decisions **are** captured via the `BeforeAgent` hook (the UserPromptSubmit equivalent on Gemini CLI).
+- `AfterModel` is defined and shipped but **not** currently routed through the CLI dispatcher (`HOOK_MAP` omits `aftermodel`), so per-turn token/cost capture via the dispatcher is inactive until `HOOK_MAP` is updated ([#882](https://github.com/mksglu/context-mode/issues/882)).
 - `PreCompress` is advisory only (async, cannot block)
 - No `decision: "ask"` support
 - Hooks don't fire for subagents yet
@@ -166,7 +179,7 @@ OpenCode uses a TypeScript plugin paradigm instead of JSON stdin/stdout. Hooks a
 
 **Session ID:** `input.sessionID` (camelCase, note the uppercase `ID`)
 
-**Project Directory:** Available via `ctx.directory` in plugin init, not via environment variable
+**Project Directory:** The live plugin uses `ctx.directory` from plugin init. The adapter's CLI/parse path additionally honors the `OPENCODE_PROJECT_DIR` environment variable, falling back to `process.cwd()`.
 
 **Desktop markers:** OpenCode desktop shells also export `OPENCODE_CLIENT=desktop` and `OPENCODE_TERMINAL=1`; context-mode treats those as OpenCode identity signals when the CLI markers are absent.
 
@@ -185,6 +198,50 @@ When OpenCode triggers `experimental.session.compacting` (auto on context overfl
 - `experimental.session.compacting` is marked experimental and may change
 - No `canInjectSessionContext` capability
 - Resume snapshots are scoped per-project (DB sharded by SHA-256 of `ctx.directory`); no cross-project bleed
+
+**Verify:** Run `context-mode doctor` (or the doctor MCP tool) to confirm `context-mode` is present in the `plugin` array of `opencode.json`/`.jsonc` and that hooks are wired; the doctor warns on a legacy `mcp.context-mode` block and prints `context-mode upgrade` as the fix. Failure signature: the plugin is not in the array, so zero `ctx_*` tools appear. To confirm savings, type `ctx stats` — it shows the session's context-window savings ratio and per-tool token breakdown, so you can verify routing is actually saving context (not just that tools respond).
+
+---
+
+### KiloCode
+
+**Status:** Fully supported
+
+**Hook Paradigm:** TS Plugin
+
+KiloCode is an OpenCode fork. context-mode routes the `kilo` platform through the **same `OpenCodeAdapter`** (`getAdapter("kilo")` returns `OpenCodeAdapter("kilo")`), so it inherits OpenCode's hook names, blocking, arg/output modification, and the 11 native `ctx_*` plugin tools registered via the `plugin` array. Hooks and tools are registered via the `plugin` array in `kilo.json`; no separate `mcp` block or stdio MCP child is required.
+
+**Hook Names:** Same as OpenCode —
+- `tool.execute.before` -- equivalent to PreToolUse
+- `tool.execute.after` -- equivalent to PostToolUse
+- `experimental.session.compacting` -- equivalent to PreCompact (experimental)
+- `experimental.chat.system.transform` -- SessionStart-equivalent (cross-session resume injection)
+
+**Blocking:** `throw Error` in `tool.execute.before` handler
+
+**Arg Modification:** `output.args` mutation
+
+**Output Modification:** `output.output` mutation (shares OpenCode's TUI bash-rendering caveat, issue #13575)
+
+**Session ID:** `input.sessionID` (camelCase, note the uppercase `ID`)
+
+**Configuration:**
+- `kilo.json` or `kilo.jsonc` (the adapter discovers and writes both). The shipped config sets `"$schema": "https://app.kilo.ai/config.json"` and registers `context-mode` in the `plugin` array.
+- Project config dirs: `.kilo/` and `.kilocode/` (each accepting `kilo.json`/`kilo.jsonc`), plus `~/.config/kilo/kilo.json(c)` — mirroring KiloCode runtime's accepted config dirs.
+- `ctx_*` tools are native plugin tools, not `mcp__server__tool` calls.
+- `context-mode upgrade` removes stale `mcp.context-mode` entries while preserving other MCP servers (same as OpenCode).
+
+**Detection:**
+- KiloCode runtime sets `KILO=1` + `KILO_PID=<pid>` — both are identification markers.
+- `~/.config/kilo/` directory presence.
+- `CONTEXT_MODE_PLATFORM=kilo` override.
+
+**Session dir:** `~/.config/kilo/context-mode/sessions/`
+
+**Verify:** Run `context-mode doctor` to confirm `context-mode` is in the `kilo.json`/`kilo.jsonc` `plugin` array and hooks are wired (doctor messages are parameterized to say "kilo.json or kilo.jsonc" for this platform); a failure prints `context-mode upgrade`. Failure signature: plugin not in the array ⇒ zero `ctx_*` tools. Type `ctx stats` to confirm the session's context-window savings ratio and per-tool token breakdown.
+
+**Known Issues / Caveats:**
+- Inherits OpenCode's caveats: `experimental.session.compacting` is experimental and may change; output modification has a TUI rendering bug for the bash tool (issue #13575); SessionStart relies on `experimental.chat.system.transform` as a surrogate.
 
 ---
 
@@ -205,9 +262,9 @@ Codex CLI's Rust backend (codex-rs) includes a hook system using the same JSON s
 - `Stop` -- fires when agent turn ends (can continue with followup)
 
 **Blocking:** `permissionDecision: "deny"` in hookSpecificOutput, or exit code 2
-**Arg Modification:** NOT supported (updatedInput returns error)
+**Arg Modification:** Runtime-gated. On codex-cli >= 0.141.0 ([#845](https://github.com/mksglu/context-mode/issues/845)) context-mode performs command rewrites by emitting `permissionDecision: "allow"` + `updatedInput`, detected at runtime via `codex --version`; older builds fail closed (the redirect becomes a deny). The adapter's static `canModifyArgs` is `false`.
 **Output Modification:** NOT supported (updatedMCPToolOutput returns error)
-**Context Injection:** `additionalContext` in hookSpecificOutput (PostToolUse, SessionStart only). PreToolUse does NOT support `additionalContext` — the codex formatter handles this automatically (deny works, context/modify/ask responses are dropped).
+**Context Injection:** `additionalContext` in hookSpecificOutput. On all builds it works via PostToolUse and SessionStart; on codex-cli >= 0.141.0 ([#845](https://github.com/mksglu/context-mode/issues/845)) PreToolUse `additionalContext` also reaches the model (runtime-detected). On older builds PreToolUse fails closed — deny works, but modify/context/ask responses are dropped by the codex formatter automatically.
 
 **Configuration:**
 - Hook config: `$CODEX_HOME/hooks.json` or `~/.codex/hooks.json` (JSON format, same structure as Claude Code)
@@ -227,12 +284,12 @@ context-mode hook codex stop
 ```
 
 **Known Issues / Caveats:**
-- PreToolUse `additionalContext` is unsupported — context injection works via PostToolUse and SessionStart instead. The codex formatter handles this automatically (deny works, context is dropped). Source: `codex-rs/hooks/src/engine/output_parser.rs:267`.
-- PreToolUse input rewriting still needs upstream `updatedInput` support. Track: [openai/codex#18491](https://github.com/openai/codex/issues/18491).
+- PreToolUse capability is **runtime-gated on the Codex build**: deny works on all builds; on codex-cli >= 0.141.0 ([#845](https://github.com/mksglu/context-mode/issues/845)) context-mode also performs command rewrites (`updatedInput`) and PreToolUse context injection (`additionalContext`), detected at runtime via `codex --version`. On older builds PreToolUse fails closed (the redirect becomes a deny; modify/context/ask are dropped by the codex formatter). Source: `codex-rs/hooks/src/engine/output_parser.rs:267`.
+- The upstream `updatedInput` gap ([openai/codex#18491](https://github.com/openai/codex/issues/18491)) is resolved for modern builds — input rewriting works on codex-cli >= 0.141.0 and is no longer a hard blocker.
 - PreCompact support is runtime-gated: context-mode configures it and treats a missing registration as a warning, because older Codex builds may not emit the event. The hook stores the resume snapshot out-of-band and SessionStart restores it.
 - Codex emits structured tool names such as `Bash` and `apply_patch`; context-mode only normalizes legacy shell aliases.
-- updatedInput and updatedMCPToolOutput are in the schema but NOT implemented
-- Default hook timeout: 600 seconds
+- `updatedMCPToolOutput` is in the schema but NOT implemented (output modification is unsupported).
+- Hook timeout: Codex host default (~600 seconds); context-mode sets no per-hook timeout in `configs/codex/hooks.json`.
 - Older context-mode releases used a `plugins/context-mode -> ..` symlink shim
   because Codex rejects the repository root (`"./"`) as an empty local plugin
   source path. On native Windows, Git can check that symlink out as a regular
@@ -254,6 +311,8 @@ context-mode hook codex stop
   the MCP tools can still work, but automatic session capture and persistent
   memory may not record events.
 
+**Verify:** Run `ctx doctor` (or `context-mode doctor`) to confirm the `codex` binary is on PATH, `[features].hooks=true`, MCP registration, and each hook event is configured. Run `ctx stats` to confirm the MCP server is reachable and to see how much context window context-mode has saved this session (savings ratio + per-tool token breakdown).
+
 ---
 
 ### Kimi Code
@@ -262,7 +321,7 @@ context-mode hook codex stop
 
 **Hook Paradigm:** JSON stdin/stdout
 
-Kimi Code CLI uses the same JSON stdin/stdout wire protocol as Claude Code and Codex, configured via `~/.kimi-code/config.toml` with `[[hooks]]` array tables. The key difference from Codex is that Kimi accepts `additionalContext`, `updatedInput`, and `permissionDecision: "ask"` in PreToolUse responses — the codex formatter drops these, but the kimi formatter emits them fully.
+Kimi Code CLI uses the same JSON stdin/stdout wire protocol as Claude Code and Codex, configured via `~/.kimi-code/config.toml` with `[[hooks]]` array tables. PreToolUse is **deny-only** on Kimi: `updatedInput`, `additionalContext`, and `permissionDecision: "ask"` are silently dropped by Kimi's host runner (the same effective behavior as Codex's older builds). context-mode's `kimi` formatter may emit these fields, but the host strips them, so routing enforcement relies on deny.
 
 **Hook Names:**
 - `PreToolUse` — fires before a tool is executed
@@ -271,14 +330,15 @@ Kimi Code CLI uses the same JSON stdin/stdout wire protocol as Claude Code and C
 - `SessionStart` — fires when a session starts or resumes
 - `UserPromptSubmit` — fires when user submits a prompt (payload is `ContentPart[]`)
 - `Stop` — fires when the agent turn ends
+- `SessionEnd` — fires when the session ends
 
 **Blocking:** `permissionDecision: "deny"` in `hookSpecificOutput`, or exit code 2
 
-**Arg Modification:** `updatedInput` inside `hookSpecificOutput` wrapper
+**Arg Modification:** Not supported — `updatedInput` is emitted but silently dropped by Kimi's host runner (`canModifyArgs: false`).
 
-**Output Modification:** `additionalContext` inside `hookSpecificOutput`
+**Output Modification:** Not supported — `additionalContext` is emitted but silently dropped by Kimi's host runner (`canModifyOutput: false`).
 
-**Context Injection:** `additionalContext` in `hookSpecificOutput` (works in all hook types)
+**Context Injection:** Not supported through the hook response — `additionalContext` is emitted in `hookSpecificOutput` but Kimi's host runner does not surface it to the model (`canInjectSessionContext: false`).
 
 **Configuration:**
 - Hooks: `~/.kimi-code/config.toml` (`[[hooks]]` array tables)
@@ -293,11 +353,15 @@ context-mode hook kimi precompact
 context-mode hook kimi sessionstart
 context-mode hook kimi userpromptsubmit
 context-mode hook kimi stop
+context-mode hook kimi sessionend
 ```
 
+**Verify:** Run `ctx doctor` (or `context-mode doctor`) to confirm the `kimi` binary is on PATH, the `[[hooks]]` entries are present in `~/.kimi-code/config.toml`, and context-mode is registered in `~/.kimi-code/mcp.json`. Run `ctx stats` to see how much context window context-mode saved this session (savings ratio + per-tool token breakdown).
+
 **Known Issues / Caveats:**
+- PreToolUse is deny-only: `updatedInput` / `additionalContext` / `permissionDecision: "ask"` are silently dropped by Kimi's host runner (same effective limit as Codex's older builds). Routing enforcement relies on deny.
 - `UserPromptSubmit` sends `prompt` as a `ContentPart[]` array; the kimi hook normalizes this to a string for downstream extractors.
-- SessionStart `additionalContext` injection is emitted but acceptance by the host is not documented in Kimi Code CLI docs (fails-open if unsupported).
+- SessionStart/PostToolUse `additionalContext` injection is emitted but Kimi's host runner does not surface it to the model (fails-open).
 
 ---
 
@@ -309,7 +373,7 @@ context-mode hook kimi stop
 
 Qwen Code (by Alibaba/Qwen team) uses the exact same hook wire protocol as Claude Code, verified from source (`hookRunner.ts`, `claude-converter.ts`). Hooks are configured inside `~/.qwen/settings.json` under the `hooks` key.
 
-**Hook Names:** `PreToolUse`, `PostToolUse`, `SessionStart`, `PreCompact`, `UserPromptSubmit` (Qwen supports 12 events total, context-mode uses these 5)
+**Hook Names:** `PreToolUse`, `PostToolUse`, `SessionStart`, `PreCompact`, `UserPromptSubmit`, `Stop` (Qwen supports 12 events total; context-mode uses these 6). The `Stop` hook tails `~/.qwen/tmp/<hash>/chats/<sessionId>.jsonl` to capture per-turn token cost (token usage is unreachable through hook stdin). **Note:** `context-mode upgrade` wires `Stop` as a direct node-script command, which fires; the CLI dispatcher form `context-mode hook qwen-code stop` does **not** work today because `HOOK_MAP['qwen-code']` omits `stop` (it fails open / no-op). Use `context-mode upgrade` so the Stop hook is wired correctly.
 
 **Blocking:** `permissionDecision: "deny"` or exit code 2
 **Arg Modification:** `updatedInput` in response
@@ -321,7 +385,7 @@ Qwen Code (by Alibaba/Qwen team) uses the exact same hook wire protocol as Claud
 - MCP: `mcpServers` in settings.json
 - Sessions: `~/.qwen/context-mode/sessions/`
 
-**Detection:** MCP clientInfo (`qwen-cli-mcp-client-*` pattern), `QWEN_PROJECT_DIR` env var, or `~/.qwen/` config dir.
+**Detection:** MCP clientInfo (`qwen-cli-mcp-client-*` pattern), `QWEN_PROJECT_DIR` env var, or `~/.qwen/` config dir. Force with `CONTEXT_MODE_PLATFORM=qwen-code`.
 
 **Hook Commands:**
 ```
@@ -331,6 +395,10 @@ context-mode hook qwen-code sessionstart
 context-mode hook qwen-code precompact
 context-mode hook qwen-code userpromptsubmit
 ```
+
+(The `Stop` hook is wired by `context-mode upgrade` as a direct node-script command, not via the dispatcher — `context-mode hook qwen-code stop` is not mapped in `HOOK_MAP` today.)
+
+**Verify:** Run `context-mode doctor` (or `ctx doctor`) to confirm all 6 hooks in `~/.qwen/settings.json` and that `context-mode` is in `mcpServers`; a missing hook reports a `fail`. Type `ctx stats` to confirm the context-window tokens saved this session (savings ratio + per-tool breakdown).
 
 ---
 
@@ -348,10 +416,12 @@ Google Antigravity is an AI-powered IDE by Google/DeepMind. It shares the `~/.ge
 
 **Detection:**
 - Auto-detected via MCP protocol handshake (`clientInfo.name: "antigravity-client"`)
+- Env-var marker: `ANTIGRAVITY_CLI_ALIAS` (the canonical Antigravity marker, used for identification in `detect.ts`)
 - Fallback: `CONTEXT_MODE_PLATFORM=antigravity` environment variable override
+- Version detection reads `~/.gemini/extensions/context-mode/package.json`; a manual `mcp_config.json`-only install (no extension) may report version `not installed` even when the MCP server works correctly.
 
 **Routing Instructions:**
-- `GEMINI.md` auto-written at project root on first MCP server startup
+- `GEMINI.md` must be **copied manually** to your project root (`cp node_modules/context-mode/configs/antigravity/GEMINI.md ./GEMINI.md`). Auto-write to project trees was disabled to avoid polluting git working trees ([#158](https://github.com/mksglu/context-mode/issues/158), [#164](https://github.com/mksglu/context-mode/issues/164)).
 - Antigravity reads `GEMINI.md` natively (same filename as Gemini CLI, different content — no hook references)
 
 **Capabilities:**
@@ -363,10 +433,11 @@ Google Antigravity is an AI-powered IDE by Google/DeepMind. It shares the `~/.ge
 - Can modify output: --
 - Can inject session context: --
 
+**Verify:** Run `context-mode doctor` to confirm context-mode is registered in `~/.gemini/antigravity/mcp_config.json` (the doctor reports MCP registration pass/fail and warns that Antigravity has no hook support). Failure signature: `ctx_*` tools absent ⇒ check the `mcp_config.json` path/command. Because Antigravity is MCP-only (no hooks, no status line), `ctx stats` is the primary way to confirm context-window savings — but savings depend on the agent honoring `GEMINI.md` routing (~60% compliance), so confirm `GEMINI.md` is present at the project root and re-check `ctx stats` after a few data-heavy operations.
+
 **Known Issues / Caveats:**
 - No hook support — only routing instruction files for enforcement (~60% compliance)
 - Shares `~/.gemini/` directory with Gemini CLI — session DB uses project hash to prevent collision
-- No verified Antigravity-specific environment variables exist
 
 **Sources:**
 - Config path: [Gemini CLI Issue #16058](https://github.com/google-gemini/gemini-cli/issues/16058)
@@ -411,6 +482,8 @@ The standalone Antigravity CLI (`agy`) is the command-line companion to Google A
 - Shares `~/.gemini/` with Gemini CLI and Antigravity — session DB uses the project hash to prevent collisions.
 - **Gemini function-calling tool exposure.** agy exposes MCP tools as Gemini function declarations, and Gemini's API rejects JSON Schema `const` / `additionalProperties` — a rejected schema makes agy **silently drop** that tool from the model's function list (the agent then hand-rolls the tool via shell scripts instead of calling it). context-mode emits Gemini-safe tool schemas (`const`→`enum`, `additionalProperties` stripped) so the `ctx_*` tools are exposed. agy also **caches** each server's tool schemas under `~/.gemini/antigravity-cli/mcp/<server>/` and does **not** refresh them on reconnect, so a cache captured by an older context-mode keeps the tools hidden — delete `~/.gemini/antigravity-cli/mcp/context-mode/` and restart agy to force a re-fetch.
 
+**Verify:** Run `context-mode doctor` — it checks MCP registration and the PreToolUse/PostToolUse (best-effort Stop) hooks across both the plugin profile (`~/.gemini/config/plugins/context-mode/`) and the global manual profile, and prints `agy plugin install ...` / `context-mode upgrade` as the repair fix when degraded. In an agy session, type `ctx stats` (or call the `ctx_stats` MCP tool) to confirm the context-window savings for the session.
+
 ---
 
 ### Kiro
@@ -419,28 +492,31 @@ The standalone Antigravity CLI (`agy`) is the command-line companion to Google A
 
 **Hook Paradigm:** JSON stdin/stdout
 
-Kiro is an AWS agentic IDE and CLI. It supports MCP servers via `~/.kiro/settings/mcp.json` using the standard `mcpServers` JSON format. The Kiro CLI also fires `preToolUse`/`postToolUse` hooks over JSON stdin (exit code 2 blocking), which context-mode's `kiro` adapter implements for routing enforcement and tool-event capture. `agentSpawn` (the Kiro SessionStart equivalent) and `stop` are not yet wired, so session restore after compaction is not available.
+Kiro is an AWS agentic IDE and CLI. It supports MCP servers via `~/.kiro/settings/mcp.json` using the standard `mcpServers` JSON format. The Kiro CLI also fires `preToolUse`/`postToolUse` hooks over JSON stdin (exit code 2 blocking), which context-mode's `kiro` adapter implements for routing enforcement and tool-event capture. `agentSpawn` (the Kiro SessionStart equivalent) **is** wired — it returns `additionalContext` via JSON stdout for session-start context injection — alongside `userPromptSubmit`. The `stop` event is not wired.
 
 **Detection:**
 - Auto-detected via MCP protocol handshake (`clientInfo.name: "Kiro CLI"`)
 
 **Configuration:**
-- Global: `~/.kiro/settings/mcp.json` (JSON format, standard `mcpServers` object)
-- Project: `.kiro/settings/mcp.json`
+- Hooks: `~/.kiro/agents/default.json` (top-level `hooks` key — this is where `context-mode upgrade` writes and where `context-mode doctor` validates the hook config; **not** `.kiro/hooks/`)
+- MCP (global): `~/.kiro/settings/mcp.json` (JSON format, standard `mcpServers` object) — `context-mode doctor` validates this global path
+- MCP (project): `.kiro/settings/mcp.json` — read by Kiro itself, but `context-mode doctor` validates only the global path, so prefer the global path (or both)
 
 **Routing Instructions:**
-- `KIRO.md` written at project root on first MCP server startup
+- `KIRO.md` must be **copied manually** to the project root (`cp node_modules/context-mode/configs/kiro/KIRO.md ./KIRO.md`) — auto-write to project trees was disabled in [#158](https://github.com/mksglu/context-mode/issues/158)/[#164](https://github.com/mksglu/context-mode/issues/164). With `agentSpawn` wired, this copy is an optional belt-and-suspenders for session-start routing rather than a required workaround.
 
 **Hook System:**
 - `preToolUse`/`postToolUse` hooks via JSON stdin (implemented)
 - Blocking: exit code 2 (similar to Gemini CLI pattern)
-- `agentSpawn` (SessionStart equivalent) and `stop` are not yet wired
+- `agentSpawn` (SessionStart equivalent) is wired — injects `additionalContext` on session start; `userPromptSubmit` is wired as well. `stop` is not wired.
+- **Dispatcher note:** the CLI dispatcher maps only `pretooluse`/`posttooluse` for `kiro`. `agentSpawn` and `userPromptSubmit` are written into `~/.kiro/agents/default.json` by `context-mode upgrade` and fire via Kiro's runtime, but are not exposed as standalone `context-mode hook kiro <event>` dispatcher tokens today — so run `context-mode upgrade` to get the full hook set.
 
 **Hook Commands:**
 ```
 context-mode hook kiro pretooluse
 context-mode hook kiro posttooluse
 ```
+(Use `context-mode upgrade` to additionally wire `agentSpawn` and `userPromptSubmit` into `~/.kiro/agents/default.json`.)
 
 **Built-in Tools:**
 - `fs_read` / `read`, `fs_write` / `write`, `execute_bash` / `shell`, `use_aws` / `aws`
@@ -449,20 +525,23 @@ context-mode hook kiro posttooluse
 - PreToolUse: Yes
 - PostToolUse: Yes
 - PreCompact: --
-- SessionStart: -- (`agentSpawn` not yet wired)
+- SessionStart: Yes (via `agentSpawn`)
 - Can modify args: --
 - Can modify output: --
-- Can inject session context: -- (via `agentSpawn`, not yet wired)
+- Can inject session context: Yes (via `agentSpawn` `additionalContext`)
 - Can block tools: Yes (exit code 2)
 
+**Verify:** Run `context-mode doctor` to confirm both MCP registration (`~/.kiro/settings/mcp.json`) and the `preToolUse`/`postToolUse` hooks in `~/.kiro/agents/default.json`; a missing hook prints `Run: context-mode upgrade` as the fix. (This is the exact tool that catches a hook config placed in the wrong location.) Type `ctx stats` to confirm context-window savings for the session.
+
 **Known Issues / Caveats:**
-- `agentSpawn` (SessionStart) and `stop` are not yet wired, so session restore after compaction is unavailable — copy `KIRO.md` to the project root for session-start routing
+- `stop` is not wired. `agentSpawn` (SessionStart equivalent) and `userPromptSubmit` are written by `context-mode upgrade` into `~/.kiro/agents/default.json` but are not exposed as standalone CLI dispatcher tokens.
+- Version detection is best-effort: `getInstalledVersion()` reads `~/.kiro/extensions/context-mode/package.json`, which a standard npm-global install does not create, so the doctor version line may report `not installed` even when Kiro is configured correctly.
 - Kiro IDE hooks use a UI-based "Run Command" shell action; stdin format unverified
 
 **Sources:**
 - clientInfo.name: [Kiro GitHub Issue #5205](https://github.com/kirodotdev/Kiro/issues/5205)
 - MCP config: [Kiro MCP Configuration docs](https://kiro.dev/docs/mcp/configuration/)
-- CLI hooks: [Kiro CLI Hooks docs](https://kiro.dev/docs/cli/hooks/)
+- CLI hooks: [Kiro CLI custom-agents configuration reference (hooks field)](https://kiro.dev/docs/cli/custom-agents/configuration-reference#hooks-field)
 
 ---
 
@@ -472,16 +551,13 @@ context-mode hook kiro posttooluse
 
 **Hook Paradigm:** JSON stdin/stdout
 
-VS Code Copilot uses the same JSON stdin/stdout paradigm as Claude Code with PascalCase hook names. It also provides unique hooks for subagent lifecycle.
+VS Code Copilot uses the same JSON stdin/stdout paradigm as Claude Code with PascalCase hook names.
 
 **Hook Names:**
 - `PreToolUse` -- fires before a tool is executed
 - `PostToolUse` -- fires after a tool completes
 - `PreCompact` -- fires before context compaction
 - `SessionStart` -- fires when a session starts
-- `Stop` -- fires when agent stops (unique to VS Code)
-- `SubagentStart` -- fires when a subagent starts (unique to VS Code)
-- `SubagentStop` -- fires when a subagent stops (unique to VS Code)
 
 **Blocking:** `permissionDecision: "deny"` (same as Claude Code)
 
@@ -497,7 +573,7 @@ VS Code Copilot uses the same JSON stdin/stdout paradigm as Claude Code with Pas
 
 **Output Modification:** `additionalContext` inside `hookSpecificOutput`, or `decision: "block"` + `reason`
 
-**MCP Tool Naming:** Uses `f1e_` prefix (not `mcp__server__tool`)
+**MCP Tool Naming:** MCP tools are surfaced under the host's own naming scheme (context-mode declares no tool-name prefix; tool naming is host-side).
 
 **Session ID:** `sessionId` (camelCase, not `session_id`)
 
@@ -507,8 +583,9 @@ VS Code Copilot uses the same JSON stdin/stdout paradigm as Claude Code with Pas
 - MCP config: `.vscode/mcp.json`
 
 **Environment Detection:**
-- `VSCODE_PID` environment variable
-- `TERM_PROGRAM=vscode`
+- `VSCODE_CWD` (workspace; also used as the project-dir source)
+- `VSCODE_PID` (identification)
+- `CONTEXT_MODE_PLATFORM=vscode-copilot` override
 
 **Hook Commands:**
 ```
@@ -518,8 +595,11 @@ context-mode hook vscode-copilot precompact
 context-mode hook vscode-copilot sessionstart
 ```
 
+**Verify:** Run `context-mode doctor` (or `ctx doctor` in Copilot Chat) to confirm hooks in `.github/hooks/context-mode.json` and the MCP server in `.vscode/mcp.json` are registered; a missing entry reports a `fail` with the fix `context-mode upgrade`. Type `ctx stats` in Copilot Chat (or call the `ctx_stats` tool) to confirm context-window savings; the status line also shows live savings.
+
 **Known Issues / Caveats:**
 - Preview status -- API may change without notice
+- Subagent-lifecycle hooks (Stop/SubagentStart/SubagentStop) are **not** wired for VS Code Copilot — only PreToolUse, PostToolUse, PreCompact, SessionStart ship.
 - Matchers are parsed but IGNORED (all hooks fire on all tools)
 - Tool input property names use camelCase (`filePath` not `file_path`)
 - Response must be wrapped in `hookSpecificOutput` with `hookEventName`
@@ -539,9 +619,6 @@ JetBrains Copilot (GitHub Copilot plugin for JetBrains IDEs) uses the same JSON 
 - `PostToolUse` -- fires after a tool completes
 - `PreCompact` -- fires before context compaction
 - `SessionStart` -- fires when a session starts
-- `Stop` -- fires when agent stops
-- `SubagentStart` -- fires when a subagent starts
-- `SubagentStop` -- fires when a subagent stops
 
 **Blocking:** `permissionDecision: "deny"` (same as VS Code Copilot)
 
@@ -557,13 +634,19 @@ JetBrains Copilot (GitHub Copilot plugin for JetBrains IDEs) uses the same JSON 
 
 **Output Modification:** `additionalContext` inside `hookSpecificOutput`, or `decision: "block"` + `reason`
 
-**MCP Tool Naming:** Uses `f1e_` prefix (same as VS Code Copilot)
+**MCP Tool Naming:** MCP tools are surfaced under the host's own naming scheme (same as VS Code Copilot; context-mode declares no tool-name prefix).
 
 **Session ID:** `sessionId` (camelCase)
 
 **Configuration:**
 - Hook config: `.github/hooks/*.json`
-- MCP config: Settings UI (Settings > Tools > AI Assistant > MCP)
+- MCP config: Settings UI (Settings > Tools > GitHub Copilot > MCP). Register the server as `context-mode` (no args) to match the shipped config; `npx -y context-mode` is the no-global-install alternative.
+
+**Environment Detection:**
+- `IDEA_INITIAL_DIRECTORY` (workspace; the primary JetBrains marker)
+- `~/.config/JetBrains/` directory presence
+- `CONTEXT_MODE_PLATFORM=jetbrains-copilot` override
+- Note: `IDEA_HOME` and `JETBRAINS_CLIENT_ID` are **no longer** used for detection — don't rely on them.
 
 **Hook Commands:**
 ```
@@ -573,10 +656,13 @@ context-mode hook jetbrains-copilot precompact
 context-mode hook jetbrains-copilot sessionstart
 ```
 
+**Verify:** Run `context-mode doctor` (or `ctx doctor` in Copilot Chat). The MCP-registration check intentionally reports **WARN** on JetBrains (MCP registration lives in the IDE Settings UI and is not CLI-inspectable), so confirm the context-mode server manually in Settings > Tools > GitHub Copilot > MCP. Type `ctx stats` in Copilot Chat (or call `ctx_stats`) to confirm context-window savings for the session.
+
 **Known Issues / Caveats:**
 - Preview status -- API may change without notice
+- Subagent-lifecycle hooks (Stop/SubagentStart/SubagentStop) are **not** wired for JetBrains Copilot — only PreToolUse, PostToolUse, PreCompact, SessionStart ship.
 - Shares the same hook wire protocol as VS Code Copilot
-- MCP servers are configured via Settings UI, not a file
+- MCP servers are configured via Settings UI, not a file (the doctor MCP check reports WARN by design)
 - Requires GitHub Copilot plugin v1.5.57+
 
 ---
@@ -589,7 +675,7 @@ context-mode hook jetbrains-copilot sessionstart
 
 The standalone GitHub Copilot CLI (`copilot`) is user-home rooted under `~/.copilot` (override with `COPILOT_HOME`). Its hook config uses camelCase event keys, and its command output contract is **top-level** (`permissionDecision`, `modifiedArgs`, `additionalContext`) rather than the VS Code `hookSpecificOutput` wrapper — context-mode's `copilot-cli` adapter formats responses accordingly.
 
-**Hook config keys:** (Copilot CLI 1.0.59 fires six events context-mode uses; verified against the `@github/copilot` binary)
+**Hook config keys:** (Copilot CLI 1.0.60 fires six events context-mode uses; verified against the `@github/copilot` binary)
 - `preToolUse` -- fires before a tool is executed
 - `postToolUse` -- fires after a tool completes
 - `preCompact` -- fires before context compaction
@@ -652,22 +738,25 @@ Cursor uses native lower-camel hook names and flat hook entries in `.cursor/hook
 - `postToolUse` -- fires after a tool completes
 - `stop` -- fires when agent turn ends (can send followup_message to continue loop)
 - `afterAgentResponse` -- fires after assistant response (fire-and-forget, receives full response text)
-- `sessionStart` -- documented but currently rejected by Cursor's validator ([forum report](https://forum.cursor.com/t/unknown-hook-type-sessionstart/149566))
+- `sessionStart` -- Cursor v1 ships native `sessionStart`; context-mode wires the matching hook script (`hooks/cursor/sessionstart.mjs`) through the dispatcher, and every install path (plugin, `context-mode upgrade`) registers it.
 
 **Blocking:** `{ "permission": "deny", "user_message": "..." }`
 
-**Arg Modification:** not natively supported (Cursor does not have `updated_input`)
+**Arg Modification:** supported — context-mode returns `{ "updated_input": ... }` from `preToolUse` (`canModifyArgs: true`).
 
-**Output Modification:** not supported in v1
+**Output Modification:** not supported (`canModifyOutput: false` — `postToolUse` only ever emits `additional_context`).
 
 **Session Context Injection:** `{ "additional_context": "..." }`
 
 **Session ID Extraction Priority:**
 1. `conversation_id` (stdin JSON)
-2. `CURSOR_TRACE_ID` environment variable
-3. Parent process ID fallback
+2. `session_id` (stdin JSON)
+3. `CURSOR_SESSION_ID` environment variable
+4. `CURSOR_TRACE_ID` environment variable
+5. Parent process ID fallback
 
 **Platform Detection Env Vars:**
+- `CURSOR_CWD` (workspace; also the project-dir source)
 - `CURSOR_TRACE_ID` (MCP server context)
 - `CURSOR_CLI` (integrated terminal context)
 - `~/.cursor/` directory fallback (medium confidence)
@@ -684,8 +773,14 @@ Cursor uses native lower-camel hook names and flat hook entries in `.cursor/hook
 ```
 context-mode hook cursor pretooluse
 context-mode hook cursor posttooluse
+context-mode hook cursor sessionstart
 context-mode hook cursor stop
+context-mode hook cursor afteragentresponse
 ```
+
+> **npx vs bare command:** the Marketplace plugin (`hooks/cursor/hooks.json`) uses `npx -y context-mode hook cursor <event>`, so it needs **no** global install. The manual `.cursor/hooks.json` config and the config written by `context-mode upgrade` use the bare `context-mode hook cursor <event>` form, which **requires** `npm install -g context-mode` for the command to resolve.
+
+**Verify:** Run `context-mode doctor`. It loads `.cursor/hooks.json` or `~/.cursor/hooks.json`, checks the required/optional hooks, flags **plugin/native duplicate firing** (each event firing twice when both the plugin and native hooks register context-mode — remove one), and warns about enterprise (`/Library/Application Support/Cursor/hooks.json`) and Claude-compat configs. Because Cursor cannot surface hook `additional_context` to the model (see below), `ctx stats` (or the `ctx_stats` MCP tool) is the primary way to confirm context savings — type it in agent chat to see the session's context-saved ratio.
 
 **Known Issues / Caveats:**
 - `preCompact` is intentionally not shipped in v1
@@ -705,16 +800,19 @@ context-mode hook cursor stop
 
 OpenClaw is an OpenAI-stack agent gateway. context-mode ships as a native gateway plugin that registers hooks through OpenClaw's plugin API rather than the JSON stdin/stdout wire protocol. The same plugin entry also registers context-mode as a context engine, owning compaction.
 
-**Hook Names:**
-- `tool_call:before` -- equivalent to PreToolUse
-- `tool_call:after` -- equivalent to PostToolUse
-- `command:new` -- equivalent to SessionStart (fires on each new gateway command)
+**Hook Names:** (the running plugin registers these via `api.on()`)
+- `before_tool_call` -- equivalent to PreToolUse
+- `after_tool_call` -- equivalent to PostToolUse
+- `session_start` -- equivalent to SessionStart
+- `before_compaction` / `after_compaction` + `registerContextEngine` (with `ownsCompaction`) -- equivalent to PreCompact
 - `before_prompt_build` -- lifecycle hook for routing instruction injection
-- `registerContextEngine` (with `ownsCompaction`) -- equivalent to PreCompact
+- `command:new` / `command:reset` / `command:stop` -- gateway command hooks registered via `api.registerHook()` (per-command session init/cleanup), distinct from the `api.on()` lifecycle hooks above
 
-**Blocking:** `return { block: true, blockReason: "..." }` from the `tool_call:before` handler
+> Note: use the `api.on()` names (`before_tool_call`, `after_tool_call`, `session_start`) for tool/session lifecycle. The older `tool_call:before` / `tool_call:after` strings are **not** what the running plugin uses — `api.registerHook('before_tool_call')` registers silently but never fires.
 
-**Arg Modification:** mutate `event.params` in the `tool_call:before` handler (or return `{ params: ... }`)
+**Blocking:** `return { block: true, blockReason: "..." }` from the `before_tool_call` handler
+
+**Arg Modification:** mutate `event.params` in the `before_tool_call` handler (or return `{ params: ... }`)
 
 **Output Modification:** not supported (the plugin paradigm exposes args/context, not the rendered tool output)
 
@@ -735,10 +833,12 @@ OpenClaw is an OpenAI-stack agent gateway. context-mode ships as a native gatewa
 - `plugins.slots.contextEngine = "context-mode"` enables ownership of compaction
 - No CLI hook command; OpenClaw imports the plugin module directly
 
+**Verify:** Run `context-mode doctor` to confirm the plugin is registered in `plugins.entries`, that it is enabled, and that `plugins.slots.contextEngine = context-mode` (owns compaction); a failed check prints the fix `context-mode upgrade`. Beyond loading, type `ctx stats` (maps to the `ctx_stats` MCP tool) to read the context-saved ratio — after a few routed tool calls it should climb toward ~98%, confirming routing is actually saving context.
+
 **Notes / Caveats:**
 - TS plugin paradigm — hooks run in-process, so there is no shell command to chmod and no platform-specific stdin/stdout quirks
 - `ask` decisions are converted to `block` (with the original reason) since the gateway has no interactive confirmation path
-- `context` decisions inside `tool_call:before` are dropped — context injection must be routed through `before_prompt_build` or the registered context engine
+- `context` decisions inside `before_tool_call` are dropped — context injection must be routed through `before_prompt_build` or the registered context engine
 - Session ID falls back to `pid-${process.ppid}` when the gateway does not surface one
 
 ---
@@ -774,51 +874,94 @@ The hook adapter exists only to satisfy the interface contract — every parser 
 - Auto-detected via the presence of `~/.config/zed/`
 - Override via `CONTEXT_MODE_PLATFORM=zed`
 
+**Verify:** Run `context-mode doctor` to confirm context-mode is registered under `context_servers` in `~/.config/zed/settings.json`; a fail prints the exact fix (add context-mode to `context_servers`). Expect one `warn` that Zed is MCP-only (no hooks) — that is normal. Because Zed has no hooks, routing is enforced only by `AGENTS.md` (~60% compliance), so run `ctx stats` to see the actual context-saved ratio for the session and confirm routing is happening.
+
 **Notes / Caveats:**
 - No hook adapter implies no automatic routing — the model must follow AGENTS.md voluntarily
 - No marketplace or plugin registry for Zed; `getInstalledVersion()` always reports `not installed`
 - `validateHooks` always returns a single `warn` row reminding the user that Zed exposes only MCP integration
 - `configureAllHooks`, `setHookPermissions`, and `updatePluginRegistry` are intentional no-ops
+- **Windows path divergence:** context-mode's doctor/detection only ever reads `~/.config/zed/settings.json`, even on Windows (there is no `%APPDATA%\Zed` branch in the adapter). If you edit `%APPDATA%\Zed\settings.json` the MCP server may still work for Zed-the-app, but `context-mode doctor` cannot verify it — the two paths are not interchangeable for context-mode tooling.
+
+---
+
+### Pi
+
+**Status:** Fully supported via extension
+
+**Hook Paradigm:** Extension (in-process hooks + MCP bridge)
+
+[Pi](https://pi.dev) (Pi coding agent) has **no** JSON-stdio hooks and **no** native MCP support. context-mode ships as a Pi **extension** at `~/.pi/extensions/context-mode/`: the extension wires in-process hooks via Pi's JS-callback runtime API (`pi.on("session_start", fn)`, `pi.on("tool_call", fn)`, …) and bootstraps an MCP **bridge** that registers each `ctx_*` tool with Pi via `pi.registerTool()` — without that bridge the tools would be invisible (Pi 0.73.x has no native MCP). The dedicated adapter is mandatory: before it existed, `getAdapter("pi")` fell through to the Claude Code adapter and Pi sessions contaminated `~/.claude/context-mode/sessions/` (issue [#473](https://github.com/mksglu/context-mode/issues/473) follow-up).
+
+**Install:** Install context-mode (`npm install -g context-mode`), then run `context-mode upgrade`, which syncs the extension into `~/.pi/extensions/context-mode/`. There is **no** `pi install npm:` / `packages[]` mechanism and **no** `mcp.json` to edit — the extension auto-bridges the MCP tools into Pi on `before_agent_start`; no manual MCP registration is needed or honored.
+
+**Hook Names (wired in-process by the extension):**
+- `session_start` -- SessionStart equivalent
+- `tool_call` -- PreToolUse equivalent (blocks inline HTTP / curl / wget by returning `{ block: true }`)
+- `tool_result` -- PostToolUse equivalent (event capture)
+- `session_before_compact` -- PreCompact equivalent (resume snapshot)
+- `turn_end` -- per-turn token/cost capture
+- Plus `before_agent_start` (MCP bridge), `context`, `before_provider_response`, `session_compact`, `session_shutdown`.
+
+> The **adapter-layer** `PlatformCapabilities` (`src/adapters/pi/index.ts`) are all-false by design (`mcp-only` adapter contract) because the integration lives in `extension.ts`, not the JSON-stdio path. The user-facing capabilities (PreToolUse/PostToolUse/PreCompact/SessionStart/Block Tools) are supported via the extension — see the Capability Matrix.
+
+**Configuration / Path Resolution:**
+- Config root: `~/.pi/`
+- Settings file: `~/.pi/settings.json` (lightweight; Pi prescribes no canonical settings file, but this keeps parity with Claude Code)
+- Extension: `~/.pi/extensions/context-mode/` (registration is by directory presence; the version-sync script writes its `package.json`)
+- Session dir: `~/.pi/context-mode/sessions/`
+- Routing instructions: `AGENTS.md`
+
+**Detection:**
+- Identification markers: `PI_CONFIG_DIR` (config dir override), `PI_SESSION_FILE` (active session path), `PI_COMPILED` (binary build marker), `PI_CODING_AGENT` (set in package-spawned MCP children, #760)
+- `~/.pi/` directory presence (medium confidence)
+- `CONTEXT_MODE_PLATFORM=pi` override
+- Note: `PI_WORKSPACE_DIR` / `PI_PROJECT_DIR` are consumer-set workspace vars that do **not** auto-detect Pi (they set the workspace, not platform identity).
+
+**Verify:** Run `context-mode doctor` — it detects Pi and validates the extension at `~/.pi/extensions/context-mode/` and the MCP bridge; the fix string is `context-mode upgrade`. Failure mode: if the MCP bridge fails to spawn the server, the `ctx_*` tools won't appear and stderr shows `[context-mode] WARNING: failed to bridge MCP tools to Pi`. To confirm savings, type `ctx stats` after a few tool calls to see tokens saved / savings ratio — it is backed by the per-session DB at `~/.pi/context-mode/sessions/`, so it reflects this Pi session's routing (the `turn_end` hook captures real per-turn tokens).
+
+**Known Issues / Caveats:**
+- Pi has no native MCP; the extension's MCP bridge is required for `ctx_*` tools to appear.
+- If the project also has `CLAUDE.md`, Pi reads both `AGENTS.md` and `CLAUDE.md` and duplicates routing instructions in context — remove one.
 
 ---
 
 ### OMP (Oh My Pi)
 
-**Status:** MCP-only (no hooks)
+**Status:** Fully supported via plugin (`omp plugin install context-mode`)
 
-**Hook Paradigm:** MCP-only
+**Hook Paradigm:** Extension — TS plugin (in-process hooks) + native MCP self-registration
 
-[Oh My Pi (OMP)](https://github.com/can1357/oh-my-pi) is a Pi-compatible harness that stores its agent state under `~/.omp/agent/` (overridable via `OMP_PROCESSING_AGENT_DIR`). Before the dedicated adapter, OMP detection fell through to `pi` and storage rooted under another harness's directory (typically `~/.claude/`), per [issue #473](https://github.com/mksglu/context-mode/issues/473). The OMP adapter exists primarily to keep `~/.omp/context-mode/` isolated, not to provide hook integration — OMP, like Antigravity/Kiro/Zed, runs context-mode purely as an MCP server.
+[Oh My Pi (OMP)](https://github.com/can1357/oh-my-pi) is a Pi-compatible harness that stores its agent state under `~/.omp/agent/` (overridable via the `PI_CODING_AGENT_DIR` env var). Before the dedicated adapter, OMP detection fell through to `pi` and storage rooted under another harness's directory (typically `~/.claude/`), per [issue #473](https://github.com/mksglu/context-mode/issues/473). The OMP adapter keeps `~/.omp/context-mode/` isolated; the OMP **plugin** (`src/adapters/omp/plugin.ts`) additionally wires real in-process hooks and self-registers the MCP server.
 
-**Hook Support:**
-- PreToolUse: --
-- PostToolUse: --
-- PreCompact: --
-- SessionStart: --
-- Stop: --
-- Can modify args: --
-- Can modify output: --
-- Can inject session context: --
+**Hook Support (via the OMP plugin):**
+- `session_start` -- SessionStart equivalent (initializes the session row)
+- `tool_call` -- PreToolUse equivalent; hard-blocks curl/wget/inline-HTTP by returning `{ block: true, reason }`
+- `tool_result` -- PostToolUse equivalent (captures structured tool events into the session DB)
+- `session_before_compact` -- PreCompact equivalent (persists a resume snapshot before compaction)
+- `turn_end` -- per-turn token/cost capture (input/output/cache tokens + provider USD cost into the session DB)
+- Can block tools: **Yes** (via `tool_call`)
+- Can modify args / output / inject session context: -- (not wired)
 
-The hook adapter exists only to satisfy the interface contract — every parser throws `Error("OMP does not support hooks")` and every formatter returns `undefined`.
+> The **adapter-layer** `PlatformCapabilities` (`src/adapters/omp/index.ts`) are all-false by design because hooks are wired by the plugin, not the JSON-stdio adapter contract. The adapter's parse methods throw `Error("OMP hooks not wired by this adapter (MCP-only delivery)")` — this refers to the JSON-stdio path; the plugin hooks are what actually fire on the plugin install path.
 
 **Path Resolution:**
-- Agent root: `$OMP_PROCESSING_AGENT_DIR` if set, else `~/.omp/agent/`
-- Settings file: `<agent root>/mcp_config.json`
-- MCP registration: `mcpServers` object inside `mcp_config.json`
+- Agent root: `$PI_CODING_AGENT_DIR` if set, else `~/.omp/agent/`
+- Settings file / MCP registration: `<agent root>/mcp.json` (the plugin self-registers context-mode under `mcpServers` in `~/.omp/agent/mcp.json`)
 - Session dir: `~/.omp/context-mode/sessions/` (intentionally rooted at `~/.omp/`, not the agent dir, so multiple OMP instances on one host share an index without colliding session DBs)
-- Routing instructions: `PI.md` (Pi-compatible filename — OMP shares the Pi instruction surface)
+- Routing instructions: `SYSTEM.md` (primary system-prompt file — project `.omp/SYSTEM.md` precedence, global `~/.omp/agent/SYSTEM.md` fallback); `AGENTS.md` is also auto-discovered. There is no `PI.md` loader upstream.
 
 **Detection (priority order, listed BEFORE `pi` so OMP is never misclassified):**
-- `OMP_PROCESSING_AGENT_DIR` env var (high confidence)
+- `PI_CODING_AGENT_DIR` env var (high confidence)
 - `~/.omp/` directory presence (medium confidence)
 - `CONTEXT_MODE_PLATFORM=omp` override
 
+**Verify:** Run `omp plugin list` / `omp plugin doctor` (both show context-mode enabled), and `context-mode doctor` as a complementary check — it verifies the context-mode entry in `~/.omp/agent/mcp.json`. Failure mode: if `mcp.json` lacks the context-mode server, the `ctx_*` tools will not appear until OMP is restarted (the plugin self-registers on load). To confirm savings, run `ctx stats` after some work to see tokens-saved / savings ratio; OMP additionally records real per-turn token + provider cost via the `turn_end` hook, so the ~98% figure is user-verifiable.
+
 **Notes / Caveats:**
-- No hook adapter implies no automatic routing — the model must follow `PI.md` voluntarily (~60% compliance)
-- No marketplace or plugin registry for OMP; `getInstalledVersion()` reports `not installed` unless an `extensions/context-mode/package.json` exists under the agent dir
-- `validateHooks` always returns a single `warn` row reminding the user that OMP exposes only MCP integration
-- `configureAllHooks`, `setHookPermissions`, and `updatePluginRegistry` are intentional no-ops
+- Routing compliance differs by install path: the **plugin** path enforces routing via in-process hooks (hard-block, ~98%); a bare **MCP-only** install (no plugin) depends on the model following `SYSTEM.md` voluntarily (~60%).
+- `validateHooks` returns a `warn` row noting that **native OMP** pre/post tool-call hooks are not wired by the adapter — but the context-mode **plugin** hooks (above) are active on the plugin install path.
+- No marketplace or plugin registry entry for OMP version detection; `getInstalledVersion()` reports `not installed` unless an `extensions/context-mode/package.json` exists under the agent dir.
 
 ---
 
@@ -826,21 +969,23 @@ The hook adapter exists only to satisfy the interface contract — every parser 
 
 | Capability | Claude Code | Qwen Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | GitHub Copilot CLI | Cursor | OpenCode | KiloCode | OpenClaw | Codex CLI | Kimi Code | Antigravity | Antigravity CLI (`agy`) | Kiro | Zed | Pi | OMP |
 |-----------|:-----------:|:---------:|:----------:|:---------------:|:-----------------:|:------------------:|:------:|:--------:|:--------:|:--------:|:---------:|:---------:|:-----------:|:-----------------------:|:----:|:---:|:--:|:---:|
-| PreToolUse | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes*** | Yes | -- | Bounded | Yes | -- | -- | -- |
-| PostToolUse | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | Yes (capture-only) | Yes | -- | -- | -- |
-| PreCompact | Yes | Yes | Yes | Yes | Yes | Yes | -- | Yes* | Yes* | Yes | Yes**** | Yes | -- | -- | -- | -- | -- | -- |
-| SessionStart | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | Yes | Yes | Yes | -- | -- | -- | -- | -- | -- |
-| Stop | -- | -- | -- | Yes | Yes | Yes | Yes | -- | -- | -- | Yes | Yes | -- | Best-effort capture | -- | -- | -- | -- |
-| Modify Args | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | Yes | -- | -- | -- | -- | -- | -- |
+| PreToolUse | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes*** | Yes | -- | Bounded | Yes | -- | Yes (ext) | Yes (plugin) |
+| PostToolUse | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | Yes (capture-only) | Yes | -- | Yes (ext) | Yes (plugin) |
+| PreCompact | Yes | Yes | Yes | Yes | Yes | Yes | -- | Yes* | Yes* | Yes | Yes**** | Yes | -- | -- | -- | -- | Yes (ext) | Yes (plugin) |
+| SessionStart | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | Yes | Yes | Yes | -- | -- | Yes (agentSpawn) | -- | Yes (ext) | Yes (plugin) |
+| Stop | Yes | -- | -- | Yes | Yes | Yes | Yes | -- | -- | -- | Yes | Yes | -- | Best-effort capture | -- | -- | Yes (ext) | Yes (plugin) |
+| Modify Args | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Runtime***** | Yes | -- | -- | -- | -- | -- | -- |
 | Modify Output | Yes | Yes | Yes | Yes | Yes | No | No | Yes** | Yes** | No | -- | Yes | -- | -- | -- | -- | -- | -- |
-| Inject Context | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | Yes | Yes | Yes | -- | -- | -- | -- | -- | -- |
-| Block Tools | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | Bounded | Yes | -- | -- | -- |
+| Inject Context | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | Yes | Yes | Yes | -- | -- | Yes | -- | -- | -- |
+| Block Tools | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | Bounded | Yes | -- | Yes (ext) | Yes (plugin) |
 | MCP/native tool support | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Native plugin | Native plugin | Native plugin | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 
 \* OpenCode `experimental.session.compacting` is experimental
 \*\* OpenCode has a TUI rendering bug for bash tool output (#13575)
-\*\*\* Codex CLI PreToolUse supports deny only (no `additionalContext`); context injection works via PostToolUse and SessionStart
+\*\*\* Codex CLI PreToolUse deny works on all builds; on codex-cli >= 0.141.0 (#845) context-mode also performs PreToolUse context injection (`additionalContext`), detected at runtime via `codex --version`; older builds fail closed (redirect becomes deny). Context injection also works via PostToolUse and SessionStart.
 \*\*\*\* Codex CLI PreCompact is runtime-gated on builds that emit the event
+\*\*\*\*\* Codex CLI command rewriting (`updatedInput`) is runtime-gated on codex-cli >= 0.141.0 (#845); the adapter's static `canModifyArgs` is `false`, so older builds cannot modify args
+- **(ext)** Pi wires hooks in-process via its extension runtime (`pi.on(...)`); **(plugin)** OMP wires hooks via its TS plugin `api`. In both, the adapter-layer `PlatformCapabilities` are all-false by design (mcp-only adapter contract) because the integration lives in the extension/plugin, not the JSON-stdio path.
 
 ---
 
@@ -907,19 +1052,23 @@ The dispatcher resolves the hook script relative to the installed package and dy
 
 | Platform | Events |
 |----------|--------|
-| `claude-code` | `pretooluse`, `posttooluse`, `precompact`, `sessionstart`, `userpromptsubmit` |
-| `gemini-cli` | `beforetool`, `aftertool`, `precompress`, `sessionstart` |
+| `claude-code` | `pretooluse`, `posttooluse`, `precompact`, `sessionstart`, `userpromptsubmit`, `stop` |
+| `gemini-cli` | `beforeagent`, `beforetool`, `aftertool`, `precompress`, `sessionstart` |
 | `vscode-copilot` | `pretooluse`, `posttooluse`, `precompact`, `sessionstart` |
 | `jetbrains-copilot` | `pretooluse`, `posttooluse`, `precompact`, `sessionstart` |
-| `cursor` | `pretooluse`, `posttooluse`, `stop` |
+| `cursor` | `pretooluse`, `posttooluse`, `sessionstart`, `stop`, `afteragentresponse` |
 | `codex` | `pretooluse`, `posttooluse`, `precompact`, `sessionstart`, `userpromptsubmit`, `stop` |
-| `kimi` | `pretooluse`, `posttooluse`, `precompact`, `sessionstart`, `userpromptsubmit`, `stop` |
+| `kimi` | `pretooluse`, `posttooluse`, `precompact`, `sessionstart`, `userpromptsubmit`, `stop`, `sessionend` |
 | `qwen-code` | `pretooluse`, `posttooluse`, `precompact`, `sessionstart`, `userpromptsubmit` |
 | `copilot-cli` | `pretooluse`, `posttooluse`, `precompact`, `sessionstart`, `userpromptsubmit`, `stop` |
 | `antigravity-cli` | `pretooluse`, `posttooluse`, `stop` |
 | `kiro` | `pretooluse`, `posttooluse` |
 
-OpenCode, KiloCode, and OpenClaw use a TS plugin paradigm (no command dispatcher). Pi and OMP register hooks through their own host APIs rather than the CLI dispatcher; Antigravity IDE and Zed are MCP-only (no hooks).
+> **Gemini CLI `aftermodel`:** the shipped `configs/gemini-cli/settings.json` and the adapter's `generateHookConfig` emit an `AfterModel` hook for per-turn token/cost capture, but the CLI dispatcher's `HOOK_MAP['gemini-cli']` does **not** include `aftermodel` — so `context-mode hook gemini-cli aftermodel` currently fails open (no-op). The dispatcher table above reflects the events that actually route. AfterModel routing is inactive until `HOOK_MAP` gains the key.
+
+> **Kiro:** the CLI dispatcher maps only `pretooluse`/`posttooluse` for `kiro`. The programmatic installer (`context-mode upgrade`) additionally writes `agentSpawn` (SessionStart-equivalent) and `userPromptSubmit` into `~/.kiro/agents/default.json`, so those events fire via Kiro's own runtime even though they are not exposed as standalone dispatcher tokens.
+
+OpenCode, KiloCode, and OpenClaw use a TS plugin paradigm (no command dispatcher). Pi and OMP wire hooks in-process through their extension/plugin runtimes (`pi.on(...)` / OMP plugin `api`) rather than the CLI dispatcher; Antigravity IDE and Zed are MCP-only (no hooks).
 
 ---
 


### PR DESCRIPTION
## What

Syncs the per-adapter **install, usage, and debugging** docs with the current code (v1.0.167). **Documentation-only** — no code or shipped configs are touched.

Driven by a full code-vs-docs audit across all adapters. The genuine code/config inconsistencies it surfaced are tracked in the consolidated docs issue **#885**; this PR fixes the **docs** that lag the code.

## Highlights

**README.md** (`## Install` blocks + `## Platform Compatibility`)
- **JetBrains / Qwen**: install via `context-mode upgrade` (the documented `npx context-mode@latest setup --adapter …` does not exist).
- **VS Code / JetBrains**: hook lists trimmed to the actually-wired set (PreToolUse/PostToolUse/PreCompact/SessionStart) — Stop/SubagentStart/SubagentStop were not wired.
- **Gemini**: `BeforeAgent` now captures user prompts (the "missing UserPromptSubmit" note was stale).
- **Cursor**: `sessionStart` is shipped and dispatched now; matcher + Verify corrected.
- **Pi**: replaced the bogus `pi install npm:` / `~/.pi/agent/mcp.json` steps with the real extension flow (`context-mode upgrade` → `~/.pi/extensions/context-mode/`, automatic MCP bridge).
- **OpenClaw**: removed the false "no separate MCP server" claim.
- **Codex**: PreToolUse blocking nuance (deny on all builds; arg-rewrite + `additionalContext` on codex-cli ≥ 0.141.0, #845).
- **Kimi**: deny-only correction + the missing `SessionEnd` hook block.
- Added **Verify** + token-savings guidance (`ctx stats` + `context-mode doctor`) across the install blocks.

**docs/platform-support.md**
- New **Extension (in-process hooks + MCP bridge)** paradigm; **Pi** and **OMP** moved out of MCP-only.
- Added the missing **`### KiloCode`** and **`### Pi`** sections.
- CLI Hook Dispatcher table: added `claude-code stop`, `gemini-cli beforeagent`, `kimi sessionend`, `cursor sessionstart`/`afteragentresponse`; noted `gemini aftermodel` is non-dispatchable (#885).
- Comparison table + capability matrix corrected (Cursor/Kiro `SessionStart`, Codex arg-modify runtime, Kimi modify-args, OMP `PI_CODING_AGENT_DIR` / `mcp.json` / `SYSTEM.md`, etc.).

**Scattered**: `configs/copilot-cli/README.md` (casing note), `docs/adapters/kimi-code.md`, `docs/jetbrains-copilot.md`.

## Scope

Docs only. The underlying code/config mismatches are out of scope here and tracked in #885.
