### PR TITLE
fix(store): enforce MAX_CHUNK_BYTES in #chunkMarkdown on oversized single paragraphs (#878)

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1062,8 +1062,15 @@ export class ContentStore {
       const now = new Date().toISOString();
       for (const chunk of chunks) {
         const ct = chunk.hasCode ? "code" : "prose";
-        this.#stmtInsertChunk.run(chunk.title, chunk.content, sourceId, ct, null, sessionIdCol, eventIdCol, now);
-        this.#stmtInsertChunkTrigram.run(chunk.title, chunk.content, sourceId, ct, null, sessionIdCol, eventIdCol, now);
+        // Defensive invariant (#878): if any format-specific chunker silently
+        // bypasses the cap in the future, hard-clip here so the FTS5 store
+        // never persists an unbounded chunk. The 4-byte slack matches the
+        // documented multibyte code-point overshoot of #byteCappedPrefix.
+        const safeContent = Buffer.byteLength(chunk.content) > MAX_CHUNK_BYTES + 4
+          ? this.#byteCappedPrefix(chunk.content, MAX_CHUNK_BYTES)
+          : chunk.content;
+        this.#stmtInsertChunk.run(chunk.title, safeContent, sourceId, ct, null, sessionIdCol, eventIdCol, now);
+        this.#stmtInsertChunkTrigram.run(chunk.title, safeContent, sourceId, ct, null, sessionIdCol, eventIdCol, now);
       }
 
       return sourceId;
@@ -1669,27 +1676,53 @@ export class ContentStore {
       let accumulator: string[] = [];
       let partIndex = 1;
 
+      const emitPart = (content: string, hasCode: boolean) => {
+        const partTitle = paragraphs.length > 1 ? `${title} (${partIndex})` : title;
+        partIndex++;
+        chunks.push({ title: partTitle, content, hasCode });
+      };
+
       const flushAccumulator = () => {
         if (accumulator.length === 0) return;
         const part = accumulator.join("\n\n").trim();
-        if (part.length === 0) return;
-        const partTitle = paragraphs.length > 1 ? `${title} (${partIndex})` : title;
-        partIndex++;
-        chunks.push({
-          title: partTitle,
-          content: part,
-          hasCode: part.includes("```"),
-        });
         accumulator = [];
+        if (part.length === 0) return;
+        emitPart(part, part.includes("```"));
+      };
+
+      // A single paragraph wider than the cap cannot be saved by paragraph
+      // boundaries (issue #878 — `ctx_batch_execute` heading-wrapped output
+      // collapses to one giant paragraph). Sub-split it by UTF-8 bytes via the
+      // shared plain-text helper so the cap holds regardless of input shape.
+      const flushOversizedSingleParagraph = (para: string) => {
+        const subChunks = this.#splitOversizedPlainChunk(
+          para.split("\n"),
+          paragraphs.length > 1 ? `${title} (${partIndex})` : title,
+          maxChunkBytes,
+        );
+        for (const sub of subChunks) {
+          chunks.push({ title: sub.title, content: sub.content, hasCode: sub.content.includes("```") });
+        }
+        // Advance partIndex past the sub-chunk batch so any subsequent paragraph
+        // parts keep monotonic numbering.
+        partIndex += Math.max(subChunks.length, 1);
       };
 
       for (const para of paragraphs) {
-        accumulator.push(para);
-        const candidate = accumulator.join("\n\n");
-        if (Buffer.byteLength(candidate) > maxChunkBytes && accumulator.length > 1) {
-          accumulator.pop();
+        const candidate = accumulator.length === 0
+          ? para
+          : accumulator.join("\n\n") + "\n\n" + para;
+        if (Buffer.byteLength(candidate) > maxChunkBytes) {
+          // Adding this paragraph would breach the cap. Flush what we've got…
           flushAccumulator();
-          accumulator = [para];
+          // …then decide how to handle the offending paragraph on its own.
+          if (Buffer.byteLength(para) > maxChunkBytes) {
+            flushOversizedSingleParagraph(para);
+          } else {
+            accumulator = [para];
+          }
+        } else {
+          accumulator.push(para);
         }
       }
       flushAccumulator();

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "340.8k+",
+  "message": "340.7k+",
   "color": "brightgreen",
   "npm": "310.9k+",
-  "marketplace": "29.8k+"
+  "marketplace": "29.7k+"
 }

--- a/tests/store-bytecap-markdown.test.ts
+++ b/tests/store-bytecap-markdown.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Regression coverage for #878: #chunkMarkdown must enforce MAX_CHUNK_BYTES
+ * even when a single paragraph / line / fenced code block exceeds the cap.
+ *
+ * The pre-fix paragraph-boundary splitter guarded the flush with
+ *     accumulator.length > 1
+ * so a single oversized paragraph passed flushAccumulator() unchanged and
+ * landed in `chunks` (and `chunks_trigram`) at full size. This is reachable
+ * through `ctx_batch_execute`, which wraps command stdout under a Markdown
+ * heading and routes the payload to `store.index(...)` — the Markdown chunker.
+ *
+ * RED/GREEN: reverting #chunkMarkdown to flush only when accumulator.length > 1
+ * makes every test below fail with a stored chunk above the cap. With the fix,
+ * every persisted markdown chunk is <= MAX_CHUNK_BYTES (modulo the documented
+ * 1-4 byte multibyte-codepoint overshoot).
+ */
+import { describe, test } from "vitest";
+import { strict as assert } from "node:assert";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ContentStore } from "../src/store.js";
+import { loadDatabase } from "../src/db-base.js";
+
+// Mirrors the private MAX_CHUNK_BYTES in src/store.ts.
+const MAX_CHUNK_BYTES = 4096;
+// Multibyte code-point overshoot tolerance documented on #byteCappedPrefix.
+const OVERSHOOT_TOLERANCE = 4;
+
+function tmpDbPath(tag: string): string {
+  return join(
+    tmpdir(),
+    `context-mode-bytecap-md-${tag}-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+  );
+}
+
+function storedChunkSizes(dbPath: string): number[] {
+  const Database = loadDatabase();
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const rows = db
+      .prepare("SELECT content FROM chunks")
+      .all() as Array<{ content: string }>;
+    return rows.map((r) => Buffer.byteLength(r.content));
+  } finally {
+    db.close();
+  }
+}
+
+describe("#chunkMarkdown byte cap (#878)", () => {
+  test("one oversized paragraph under a heading is split below the cap", () => {
+    const dbPath = tmpDbPath("paragraph");
+    const store = new ContentStore(dbPath);
+    // Mirrors ctx_batch_execute: `# <label>\n\n<command stdout>`.
+    const para = "a".repeat(MAX_CHUNK_BYTES * 3);
+    const md = `# Synthetic oversized line\n\n${para}`;
+    store.index({ content: md, source: "synthetic-oversized" });
+    store.close();
+
+    const sizes = storedChunkSizes(dbPath);
+    assert.ok(
+      sizes.length >= 2,
+      `expected the oversized paragraph to be split, got ${sizes.length} chunk(s)`,
+    );
+    for (const bytes of sizes) {
+      assert.ok(
+        bytes <= MAX_CHUNK_BYTES + OVERSHOOT_TOLERANCE,
+        `chunk of ${bytes}B exceeds cap ${MAX_CHUNK_BYTES}`,
+      );
+    }
+  });
+
+  test("one oversized single line (no paragraph breaks) stays capped", () => {
+    const dbPath = tmpDbPath("line");
+    const store = new ContentStore(dbPath);
+    // No double-newline: the paragraph splitter sees one paragraph that is
+    // itself one giant line. Both the paragraph guard and the line splitter
+    // must hold.
+    const md = `# Big single line\n${"a".repeat(MAX_CHUNK_BYTES * 2)}`;
+    store.index({ content: md, source: "single-line" });
+    store.close();
+
+    const sizes = storedChunkSizes(dbPath);
+    assert.ok(sizes.length >= 2, `expected the long line to be split, got ${sizes.length} chunk(s)`);
+    for (const bytes of sizes) {
+      assert.ok(
+        bytes <= MAX_CHUNK_BYTES + OVERSHOOT_TOLERANCE,
+        `chunk of ${bytes}B exceeds cap ${MAX_CHUNK_BYTES}`,
+      );
+    }
+  });
+
+  test("one oversized fenced code block is split below the cap", () => {
+    const dbPath = tmpDbPath("code");
+    const store = new ContentStore(dbPath);
+    // Fenced code blocks are collected as a unit by #chunkMarkdown — so an
+    // oversized fence used to land in a single chunk too.
+    const body = "console.log('x');\n".repeat(400); // ~7KB
+    const md = `# Big code\n\n\`\`\`ts\n${body}\`\`\`\n`;
+    store.index({ content: md, source: "big-code" });
+    store.close();
+
+    const sizes = storedChunkSizes(dbPath);
+    assert.ok(sizes.length >= 1, "expected at least one chunk");
+    for (const bytes of sizes) {
+      assert.ok(
+        bytes <= MAX_CHUNK_BYTES + OVERSHOOT_TOLERANCE,
+        `chunk of ${bytes}B exceeds cap ${MAX_CHUNK_BYTES}`,
+      );
+    }
+  });
+
+  test("oversized multibyte (CJK) paragraph is byte-split, not character-split", () => {
+    const dbPath = tmpDbPath("cjk");
+    const store = new ContentStore(dbPath);
+    // 4096 CJK code points = 12288 UTF-8 bytes in one paragraph.
+    const md = `# CJK\n\n${"你".repeat(MAX_CHUNK_BYTES)}`;
+    store.index({ content: md, source: "cjk-paragraph" });
+    store.close();
+
+    const sizes = storedChunkSizes(dbPath);
+    assert.ok(sizes.length >= 2, `expected CJK paragraph to be split, got ${sizes.length} chunk(s)`);
+    for (const bytes of sizes) {
+      assert.ok(
+        bytes <= MAX_CHUNK_BYTES + OVERSHOOT_TOLERANCE,
+        `chunk of ${bytes}B exceeds cap ${MAX_CHUNK_BYTES}`,
+      );
+    }
+  });
+
+  test("ctx_batch_execute heading-wrapped oversized output stays capped (#878 repro)", () => {
+    const dbPath = tmpDbPath("batch");
+    const store = new ContentStore(dbPath);
+    // Replicates the exact ctx_batch_execute synthetic repro from the issue:
+    // ~1.2MB of 'a' plus a search needle, wrapped under "# <label>".
+    const payload = "a".repeat(1_200_000) + " needleXYZ";
+    const md = `# Synthetic oversized line\n\n${payload}`;
+    store.index({ content: md, source: "batch-repro" });
+    store.close();
+
+    const sizes = storedChunkSizes(dbPath);
+    assert.ok(sizes.length >= 2, `expected oversized batch output to be split, got ${sizes.length}`);
+    for (const bytes of sizes) {
+      assert.ok(
+        bytes <= MAX_CHUNK_BYTES + OVERSHOOT_TOLERANCE,
+        `chunk of ${bytes}B exceeds cap ${MAX_CHUNK_BYTES}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## CLAIM_VERDICT: CONFIRMED on Windows 11

Reproduced the #878 bypass on Windows 11 / Node bundled. Before the fix, a `# heading\n\n<1.2MB paragraph>` payload routed through `store.index(...)` persists a single 1,200,010-byte chunk against `MAX_CHUNK_BYTES = 4096` (and the same row in `chunks_trigram`). The plain-text hardening from #781 did not cover this Markdown path because `ctx_batch_execute` wraps command stdout under a Markdown heading.

## Repro command + verbatim output

`npx vitest run tests/store-bytecap-markdown.test.ts` on master shows:

```
AssertionError: chunk of 1200010B exceeds cap 4096
 ❯ tests/store-bytecap-markdown.test.ts:143:14
 Test Files  1 failed (1)
      Tests  5 failed (5)
```

After the fix:

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## Archaeology

`git log --all -S "accumulator.length > 1" -- src/store.ts` → introduced in commit `af03f710` (Mert Koseoglu, 2026-03-04), which itself refined the paragraph-boundary splitter added in `609a3a5` ("feat: JSON chunking, maxChunkBytes, and content-type routing"). Original purpose: split oversized markdown chunks at paragraph boundaries to prevent BM25 length normalization from penalizing long sections. The `accumulator.length > 1` guard was defensive against an infinite-flush loop, but it created the bypass for the one shape that matters in practice: a single paragraph wider than the cap. This fix preserves the original BM25-length goal by routing oversized single paragraphs to the existing byte-accurate splitter, rather than letting them through.

`git blame -L 1685,1700 src/store.ts` confirms the offending line `if (Buffer.byteLength(candidate) > maxChunkBytes && accumulator.length > 1)` is authored by `af03f710`.

## Root cause

`src/store.ts:1689` (pre-fix): paragraph-splitter flushes only when `accumulator.length > 1`. A single paragraph wider than `MAX_CHUNK_BYTES` therefore stays in the accumulator and is emitted intact by `flushAccumulator()`. Reachable via `ctx_batch_execute`, whose `# <label>\n\n<output>` wrapping routes through the Markdown chunker.

## Fix strategy

Two layers:

1. **Markdown chunker (`#chunkMarkdown`)** — drop the `accumulator.length > 1` guard. When the next paragraph would breach the cap, flush the accumulator and either start a new one with that paragraph or, when the paragraph alone exceeds the cap, delegate to the shared `#splitOversizedPlainChunk` helper. CJK / emoji handled by `#byteCappedPrefix` exactly as in #781.
2. **`#insertChunks` invariant** — hard-clip any chunk above `MAX_CHUNK_BYTES + 4` (matches the documented multibyte overshoot) at the SQL bind step, so future format-specific chunkers cannot silently bypass the cap. Cheap: one `Buffer.byteLength` per chunk per insert.

## RED test evidence

`tests/store-bytecap-markdown.test.ts` lines 50, 83, 105, 123, 143 — 5 assertions, all failing on master with stored chunks of 12288 B / 7209 B / 12288 B / 1200010 B / etc. against the 4096 cap.

## GREEN test evidence

```
Test Files  4 passed (4)
Tests  285 passed | 1 skipped (286)
```

(`tests/store-bytecap-markdown.test.ts` + `tests/store-bytecap.test.ts` + `tests/store.test.ts` + `tests/core/search.test.ts`)

`npm run typecheck` clean.

## Files changed

- `src/store.ts:1063-1074` — defensive `#byteCappedPrefix` clip at insertion choke point.
- `src/store.ts:1679-1726` — rewrite of paragraph-boundary splitter inside `#chunkMarkdown`; new `flushOversizedSingleParagraph` delegates to `#splitOversizedPlainChunk` for one-paragraph oversize cases.
- `tests/store-bytecap-markdown.test.ts` (new) — 5 regression tests mirroring `store-bytecap.test.ts`: oversized paragraph under heading, oversized single line, oversized fenced code block, CJK paragraph, exact `ctx_batch_execute` 1.2 MB repro from the issue.

## Cross-OS impact

No platform-specific code paths touched. `Buffer.byteLength`, `String.prototype.split`, and the helper `#byteCappedPrefix` behave identically on linux/mac/windows. Full vitest run shows only pre-existing unrelated failures (`tests/executor.test.ts` Python/Rust runtime detection on this box; `tests/adapters/zod3tov4-production.test.ts` + `tests/adapters/omp-plugin.test.ts` build-artifact checks that fail on a fresh worktree without `npm run build`). Confirmed by stash + re-run on `origin/main` head — identical failures, identical assertion lines.

## Notes

- The defensive `#insertChunks` invariant uses `#byteCappedPrefix` so it never cuts a multibyte sequence in half — keeps the "1-4 byte overshoot" contract intact.
- Part-numbering monotonicity preserved: when a single oversized paragraph delegates to the sub-splitter, `partIndex` advances past the emitted sub-chunks so any subsequent paragraph parts continue from the correct number.
