### PR TITLE
Fix/mcp singleton concurrency

### DIFF
--- a/src/adapters/omp/plugin.ts
+++ b/src/adapters/omp/plugin.ts
@@ -70,8 +70,7 @@ const BLOCKED_BASH_PATTERNS: RegExp[] = [
 // Same shape as Pi: one DB per process, session ID rebound on each
 // session_start so multi-session reuse within a long-lived plugin
 // process keeps event attribution correct.
-let _db: SessionDB | null = null;
-let _dbPath = "";
+const _dbSingletons = new Map<string, SessionDB>();
 let _sessionId = "";
 
 const _ompAdapter = new OMPAdapter();
@@ -147,19 +146,13 @@ function getDBPath(projectDir: string): string {
 }
 
 function getOrCreateDB(projectDir: string): SessionDB {
-  // Reopen the singleton if the resolved DB path changes. See the
-  // matching Pi extension comment — defensive re-keying on projectDir
-  // hash keeps tests deterministic and stops a stale singleton from
-  // pointing at an earlier projectDir's `<hash>.db`. (#645)
   const dbPath = getDBPath(projectDir);
-  if (!_db || _dbPath !== dbPath) {
-    if (_db) {
-      try { _db.close(); } catch { /* best effort */ }
-    }
-    _db = new SessionDB({ dbPath });
-    _dbPath = dbPath;
+  let db = _dbSingletons.get(dbPath);
+  if (!db) {
+    db = new SessionDB({ dbPath });
+    _dbSingletons.set(dbPath, db);
   }
-  return _db;
+  return db;
 }
 
 /**
@@ -186,11 +179,10 @@ function deriveSessionId(ctx: Record<string, unknown> | undefined): string {
 // The plugin's default export is the OMP factory; this helper is only
 // imported by tests to clear singletons between cases.
 export function _resetOmpPluginStateForTests(): void {
-  if (_db) {
-    try { _db.close(); } catch { /* best effort */ }
+  for (const db of _dbSingletons.values()) {
+    try { db.close(); } catch { /* best effort */ }
   }
-  _db = null;
-  _dbPath = "";
+  _dbSingletons.clear();
   _sessionId = "";
 }
 

--- a/src/adapters/openclaw/plugin.ts
+++ b/src/adapters/openclaw/plugin.ts
@@ -270,30 +270,20 @@ function getDBPath(projectDir: string): string {
   return resolveSessionDbPath({ projectDir, sessionsDir: getSessionDir() });
 }
 
-// ── Module-level DB singleton ─────────────────────────────
+// ── Module-level DB singletons ─────────────────────────────
 // Shared across all register() calls (one per agent session).
-// Lazy-initialized on first register() using the first projectDir seen.
 // Uses OpenClawSessionDB for session_key mapping and rename support.
-let _dbSingleton: OpenClawSessionDB | null = null;
-let _dbSingletonPath = "";
+const _dbSingletons = new Map<string, OpenClawSessionDB>();
+
 function getOrCreateDB(projectDir: string): OpenClawSessionDB {
-  // Reopen the singleton if the resolved DB path changes. Production
-  // code normally loads the plugin once per process with a single
-  // workspace, but defensive re-keying on resolved path keeps the
-  // contract honest if a host ever calls register() twice with
-  // different projectDirs, and removes a subtle test-isolation
-  // foot-gun where a stale singleton pointed at a prior test's
-  // `<hash>.db`. Mirrors the Pi/OMP fix (#645).
   const dbPath = getDBPath(projectDir);
-  if (!_dbSingleton || _dbSingletonPath !== dbPath) {
-    if (_dbSingleton) {
-      try { _dbSingleton.close(); } catch { /* best effort */ }
-    }
-    _dbSingleton = new OpenClawSessionDB({ dbPath });
-    _dbSingletonPath = dbPath;
-    _dbSingleton.cleanupOldSessions(7);
+  let db = _dbSingletons.get(dbPath);
+  if (!db) {
+    db = new OpenClawSessionDB({ dbPath });
+    db.cleanupOldSessions(7);
+    _dbSingletons.set(dbPath, db);
   }
-  return _dbSingleton;
+  return db;
 }
 
 // ── Module-level state for command handlers ───────────────

--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -889,10 +889,12 @@ export default function piExtension(pi: any): void {
     description: "Show context-mode session statistics",
     handler: async (argsOrCtx: unknown, maybeCtx: unknown) => {
       const ctx = resolveCommandContext(argsOrCtx, maybeCtx);
+      const dbPath = getDBPath(projectDir);
+      const db = _dbSingletons.get(dbPath);
       const text =
-        !_db || !_sessionId
+        !db || !_sessionId
           ? "context-mode: no active session"
-          : buildStatsText(_db, _sessionId);
+          : buildStatsText(db, _sessionId);
 
       return handleCommandText(text, ctx);
     },
@@ -914,13 +916,14 @@ export default function piExtension(pi: any): void {
         `- Project dir: \`${projectDir}\``,
       ];
 
-      if (_db && _sessionId) {
+      const db = _dbSingletons.get(dbPath);
+      if (db && _sessionId) {
         try {
-          const stats = _db.getSessionStats(_sessionId);
-          const eventCount = _db.getEventCount(_sessionId);
+          const stats = db.getSessionStats(_sessionId);
+          const eventCount = db.getEventCount(_sessionId);
           lines.push(`- Events: ${eventCount}`);
           lines.push(`- Compactions: ${stats?.compact_count ?? 0}`);
-          const resume = _db.getResume(_sessionId);
+          const resume = db.getResume(_sessionId);
           lines.push(
             `- Resume snapshot: ${resume ? (resume.consumed ? "consumed" : "available") : "none"}`,
           );

--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -131,8 +131,7 @@ export function isSafeCurlWget(segment: string): boolean {
 
 // ── Module-level DB singleton ────────────────────────────
 
-let _db: SessionDB | null = null;
-let _dbPath = "";
+const _dbSingletons = new Map<string, SessionDB>();
 let _sessionId = "";
 
 // MCP bridge handle. The bridge spawns server.bundle.mjs once and
@@ -210,21 +209,13 @@ function getDBPath(projectDir: string): string {
 }
 
 function getOrCreateDB(projectDir: string): SessionDB {
-  // Reopen the singleton if the resolved DB path changes. Production code
-  // normally loads the extension once per process with a single workspace,
-  // but defensive re-keying on path keeps the contract honest if a host
-  // ever calls piExtension(pi) twice with different projectDirs, and
-  // removes a subtle test-isolation foot-gun where stale singletons
-  // pointed at a prior test's `<hash>.db`. (#645)
   const dbPath = getDBPath(projectDir);
-  if (!_db || _dbPath !== dbPath) {
-    if (_db) {
-      try { _db.close(); } catch { /* best effort */ }
-    }
-    _db = new SessionDB({ dbPath });
-    _dbPath = dbPath;
+  let db = _dbSingletons.get(dbPath);
+  if (!db) {
+    db = new SessionDB({ dbPath });
+    _dbSingletons.set(dbPath, db);
   }
-  return _db;
+  return db;
 }
 
 /** Derive a stable session ID from Pi's session file path (SHA256, 16 hex chars). */
@@ -857,11 +848,10 @@ export default function piExtension(pi: any): void {
 
   pi.on("session_shutdown", async () => {
     try {
-      if (_db) {
-        _db.cleanupOldSessions(7);
+      for (const db of _dbSingletons.values()) {
+        try { db.cleanupOldSessions(7); } catch { /* ignore */ }
       }
-      _db = null;
-      _dbPath = "";
+      _dbSingletons.clear();
       _sessionId = "";
     } catch {
       // best effort — never throw during shutdown

--- a/src/server.ts
+++ b/src/server.ts
@@ -433,8 +433,9 @@ writeFileSync(
 // snippets under /tmp when the host process exits.
 process.on("exit", () => { try { unlinkSync(CM_FS_PRELOAD); } catch { /* best effort */ } });
 
-// Lazy singleton — no DB overhead unless index/search is used
-let _store: ContentStore | null = null;
+// Map of dbPath -> ContentStore.
+// Lazy singletons — no DB overhead unless index/search is used
+const _stores = new Map<string, ContentStore>();
 
 /**
  * Build the FK-attribution object passed to every ContentStore.index*() call
@@ -696,24 +697,26 @@ function getStorePath(): string {
 }
 
 function getStore(): ContentStore {
+  const dbPath = getStorePath();
+  let _store = _stores.get(dbPath);
   if (!_store) {
     // Content DB cleanup on fresh start is handled by SessionStart hook.
     // Server just opens whatever DB exists (or creates new if hook deleted it).
-    const dbPath = getStorePath();
     _store = new ContentStore(dbPath);
+    _stores.set(dbPath, _store);
 
+    const boundProjectDir = getProjectDir();
     // Wire deny-policy hook: store re-checks the Read deny list before
     // re-reading any file_path during auto-refresh. Catches policy edits
     // made after a file was originally indexed. See #442 round-3.
     _store.setDenyChecker((filePath: string) => {
       try {
-        const projectDir = getProjectDir();
-        const denyGlobs = readToolDenyPatterns("Read", projectDir);
+        const denyGlobs = readToolDenyPatterns("Read", boundProjectDir);
         const r = evaluateFilePath(
           filePath,
           denyGlobs,
           process.platform === "win32",
-          projectDir,
+          boundProjectDir,
         );
         return r.denied;
       } catch {
@@ -724,7 +727,7 @@ function getStore(): ContentStore {
 
     // One-time startup cleanup: remove stale content DBs (>14 days)
     try {
-      const contentDir = dirname(getStorePath());
+      const contentDir = dirname(dbPath);
       cleanupStaleContentDBs(contentDir, 14);
       _store.cleanupStaleSources(14);
       // Also clean legacy shared dir from before platform isolation
@@ -4527,9 +4530,17 @@ EXAMPLE: ctx_purge(confirm: true, scope: "project")`,
     try {
       storePathForPurge = getStorePath();
     } catch { /* best effort — store path may be unresolvable on fresh install */ }
-    if (_store) {
-      try { _store.cleanup(); } catch { /* best effort */ }
-      _store = null;
+    if (storePathForPurge) {
+      const store = _stores.get(storePathForPurge);
+      if (store) {
+        try { store.cleanup(); } catch { /* best effort */ }
+        _stores.delete(storePathForPurge);
+      }
+    } else {
+      for (const store of _stores.values()) {
+        try { store.cleanup(); } catch { /* best effort */ }
+      }
+      _stores.clear();
     }
 
     // FTS5 store: pass contentDir so purgeSession sweeps BOTH canonical
@@ -4844,7 +4855,9 @@ async function main() {
   // Clean up own DB + backgrounded processes + preload script on shutdown
   const shutdown = () => {
     executor.cleanupBackgrounded();
-    if (_store) _store.close(); // persist DB for --continue sessions
+    for (const store of _stores.values()) {
+      try { store.close(); } catch { /* best effort */ }
+    } // persist DB for --continue sessions
     try { unlinkSync(CM_FS_PRELOAD); } catch { /* best effort */ }
     // Remove MCP readiness sentinel (#230)
     try { unlinkSync(mcpSentinel); } catch { /* best effort */ }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "340.8k+",
+  "message": "340.7k+",
   "color": "brightgreen",
   "npm": "310.9k+",
-  "marketplace": "29.8k+"
+  "marketplace": "29.7k+"
 }


### PR DESCRIPTION
## What / Why / How

<!-- Brief: what changed, why, and implementation approach. Link issue: Fixes #000 -->

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

<!-- What tests were added or modified? -->

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
