### PR TITLE
Fix typo in README verification instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,7 +889,7 @@ Restart `agy`.
 { "mcpServers": { "context-mode": { "command": "context-mode" } } }
 ```
 
-**Verify:** type `ctx stats` in an agy session, or run any prompt from [Try It](#try-it) and check the savings. `context-mode doctor` confirms MCP + hook registration. Remove with `agy plugin uninstall context-mode`.
+**Verify:** type `ctx stats` in an any session, or run any prompt from [Try It](#try-it) and check the savings. `context-mode doctor` confirms MCP + hook registration. Remove with `agy plugin uninstall context-mode`.
 
 **Routing:** the routing rule and skill provide the instruction layer; bounded `PreToolUse` blocks high-flood tools and `PostToolUse` captures sessions. The bundle pins `CONTEXT_MODE_PLATFORM=antigravity-cli` so agy is detected even when Claude Code is co-installed ([#774](https://github.com/mksglu/context-mode/issues/774)).
 

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "340.7k+",
+  "message": "340.4k+",
   "color": "brightgreen",
   "npm": "310.9k+",
-  "marketplace": "29.7k+"
+  "marketplace": "29.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "340.4k+",
+  "message": "347.2k+",
   "color": "brightgreen",
-  "npm": "310.9k+",
+  "npm": "317.8k+",
   "marketplace": "29.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "350.7k+",
+  "message": "350.8k+",
   "color": "brightgreen",
   "npm": "321.2k+",
-  "marketplace": "29.4k+"
+  "marketplace": "29.5k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "340.8k+",
+  "message": "340.7k+",
   "color": "brightgreen",
   "npm": "310.9k+",
-  "marketplace": "29.8k+"
+  "marketplace": "29.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "347.2k+",
+  "message": "350.7k+",
   "color": "brightgreen",
-  "npm": "317.8k+",
+  "npm": "321.2k+",
   "marketplace": "29.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "350.8k+",
+  "message": "354k+",
   "color": "brightgreen",
-  "npm": "321.2k+",
-  "marketplace": "29.5k+"
+  "npm": "324k+",
+  "marketplace": "30k+"
 }


### PR DESCRIPTION
Corrected 'agy' to 'any' in verification instructions inside the README file

