### PR TITLE
fix(codex): omit empty additionalContext in hook output

### DIFF
--- a/hooks/codex/posttooluse.mjs
+++ b/hooks/codex/posttooluse.mjs
@@ -62,5 +62,5 @@ try {
 
 // Codex PostToolUse requires hookEventName in hookSpecificOutput
 process.stdout.write(JSON.stringify({
-  hookSpecificOutput: { hookEventName: "PostToolUse", additionalContext: "" },
+  hookSpecificOutput: { hookEventName: "PostToolUse" },
 }) + "\n");

--- a/hooks/codex/userpromptsubmit.mjs
+++ b/hooks/codex/userpromptsubmit.mjs
@@ -71,5 +71,5 @@ try {
 }
 
 process.stdout.write(JSON.stringify({
-  hookSpecificOutput: { hookEventName: "UserPromptSubmit", additionalContext: "" },
+  hookSpecificOutput: { hookEventName: "UserPromptSubmit" },
 }) + "\n");

--- a/tests/adapters/codex.test.ts
+++ b/tests/adapters/codex.test.ts
@@ -979,6 +979,36 @@ describe("Codex userpromptsubmit hook script", () => {
     const parsed = JSON.parse(stdout.trim());
     expect(parsed.hookSpecificOutput).toBeDefined();
     expect(parsed.hookSpecificOutput.hookEventName).toBe("UserPromptSubmit");
+    expect(parsed.hookSpecificOutput).not.toHaveProperty("additionalContext");
+  });
+});
+
+describe("Codex posttooluse hook script", () => {
+  it("outputs valid JSON with PostToolUse hookEventName and omits empty additionalContext", () => {
+    const hookScript = resolve(__dirname, "../../hooks/codex/posttooluse.mjs");
+    const input = JSON.stringify({
+      tool_name: "Read",
+      tool_input: { file_path: "/tmp/demo.ts" },
+      tool_response: "const x = 1;",
+      session_id: "test-posttooluse",
+      cwd: "/tmp",
+      hook_event_name: "PostToolUse",
+      model: "o3",
+      permission_mode: "default",
+      transcript_path: null,
+      turn_id: "t1",
+    });
+
+    const stdout = execFileSync(process.execPath, [hookScript], {
+      input,
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.hookSpecificOutput).toBeDefined();
+    expect(parsed.hookSpecificOutput.hookEventName).toBe("PostToolUse");
+    expect(parsed.hookSpecificOutput).not.toHaveProperty("additionalContext");
   });
 });
 


### PR DESCRIPTION
## Summary
Remove empty `additionalContext` from Codex `PostToolUse` and `UserPromptSubmit` hook output.

## Why
An empty string produces a blank `hook context:` section in the Codex UI.

## Verification
- added tests that assert both hook scripts omit `additionalContext`
- `node hooks/codex/posttooluse.mjs` -> `{"hookSpecificOutput":{"hookEventName":"PostToolUse"}}`
- `node hooks/codex/userpromptsubmit.mjs` -> `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit"}}`