### PR TITLE
ci: add codex-plugin-scanner workflow

### DIFF
--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,38 @@
+name: Codex Plugin Scanner CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - 'skills/**'
+      - '.mcp.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.codex-plugin/**'
+      - 'skills/**'
+      - '.mcp.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Plugin Scanner
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Run scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@486d62021d7db1d3027942c92a9d45a5c3c02921
+        with:
+          plugin_dir: "."
+          mode: scan
+          fail_on_severity: critical


### PR DESCRIPTION
I ran the scanner against this repo because mCP server that saves 98% of your context window with session continuity. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and automatic state restore across compactions.

What stood out from the repo:
- MCP server that saves 98% of your context window with session continuity. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and automatic state restore across compactions
- The other half of the context problem
- <sub>Used across teams at</sub>

Local scanner result: 61/100 (grade D).

First-pass findings worth tightening:
- MEDIUM: GitHub Action is not pinned to an immutable commit SHA
- MEDIUM: GitHub Action is not pinned to an immutable commit SHA
- MEDIUM: GitHub Action is not pinned to an immutable commit SHA

This PR only adds the scanner workflow. It does not touch runtime code or release behavior.
If you would rather wire it in a different workflow file, I can adjust the branch.

Note: 43 high-severity findings were left out of this first contact summary because they mostly look like documentation or reference-file patterns.