### PR TITLE
fix(standalone): use mcp__context-mode__ prefix when CLAUDE_PLUGIN_ROOT is absent

### DIFF
--- a/hooks/core/tool-naming.mjs
+++ b/hooks/core/tool-naming.mjs
@@ -5,7 +5,8 @@
  * Evidence-based naming conventions (from official docs):
  * | Platform           | Pattern                                                    |
  * |--------------------|------------------------------------------------------------|
- * | Claude Code        | mcp__plugin_context-mode_context-mode__<tool>               |
+ * | Claude Code (plugin) | mcp__plugin_context-mode_context-mode__<tool>             |
+ * | Claude Code (standalone / MacPorts) | mcp__context-mode__<tool>              |
  * | Gemini CLI         | mcp__context-mode__<tool>                                  |
  * | Antigravity        | mcp__context-mode__<tool>                                  |
  * | Antigravity CLI    | context-mode/<tool>                                        |
@@ -17,7 +18,12 @@
  */
 
 const TOOL_PREFIXES = {
-  "claude-code":    (tool) => `mcp__plugin_context-mode_context-mode__${tool}`,
+  // CLAUDE_PLUGIN_ROOT is set only when Claude Code manages hooks via its plugin system.
+  // Standalone installs (MacPorts, npm global) write absolute-path hooks to settings.json
+  // and register the MCP server as "context-mode" → prefix is mcp__context-mode__.
+  "claude-code":    (tool) => process.env.CLAUDE_PLUGIN_ROOT
+    ? `mcp__plugin_context-mode_context-mode__${tool}`
+    : `mcp__context-mode__${tool}`,
   "gemini-cli":     (tool) => `mcp__context-mode__${tool}`,
   "antigravity":    (tool) => `mcp__context-mode__${tool}`,
   "antigravity-cli": (tool) => `context-mode/${tool}`,

--- a/src/adapters/claude-code/hooks.ts
+++ b/src/adapters/claude-code/hooks.ts
@@ -63,6 +63,9 @@ export const PRE_TOOL_USE_MATCHERS = [
   "mcp__plugin_context-mode_context-mode__ctx_execute",
   "mcp__plugin_context-mode_context-mode__ctx_execute_file",
   "mcp__plugin_context-mode_context-mode__ctx_batch_execute",
+  // Note: standalone installs register as "context-mode" → mcp__context-mode__ctx_* names.
+  // These are matched by EXTERNAL_MCP_MATCHER_PATTERN ("mcp__") below, so no explicit entries
+  // are needed here. Keeping this list plugin-specific preserves the hooks.json drift guard.
   EXTERNAL_MCP_MATCHER_PATTERN,
 ] as const;
 

--- a/tests/core/routing.test.ts
+++ b/tests/core/routing.test.ts
@@ -76,7 +76,8 @@ describe("Routing: Subagents (Agent only — Task removed per #241)", () => {
     const prompt = decision.updatedInput.prompt;
     expect(prompt).toContain("deferred_tool_bootstrap");
     expect(prompt).toContain("ToolSearch");
-    expect(prompt).toContain("select:mcp__plugin_context-mode_context-mode__ctx_batch_execute");
+    // No CLAUDE_PLUGIN_ROOT in test env → standalone prefix.
+    expect(prompt).toContain("select:mcp__context-mode__ctx_batch_execute");
   });
 
   it("Agent block omits the ToolSearch bootstrap on platforms without deferred tools (#724)", () => {

--- a/tests/hooks/integration.test.ts
+++ b/tests/hooks/integration.test.ts
@@ -621,66 +621,60 @@ describe("Security Policy Enforcement", () => {
   });
 });
 
-describe("Plugin Tool Name Format in ROUTING_BLOCK", () => {
-  // When installed via Claude Code plugin marketplace, tool names follow:
-  //   mcp__plugin_<plugin-id>_<server-name>__<tool-name>
-  // For context-mode: mcp__plugin_context-mode_context-mode__<tool-name>
-  // The short form mcp__context-mode__* only works for direct MCP registration.
-
+// These tests run without CLAUDE_PLUGIN_ROOT → standalone prefix (mcp__context-mode__*).
+// In plugin installs (CLAUDE_PLUGIN_ROOT set), the guidance uses the plugin prefix.
+describe("Standalone Tool Name Format in ROUTING_BLOCK", () => {
+  const STANDALONE_PREFIX = "mcp__context-mode__";
   const PLUGIN_PREFIX = "mcp__plugin_context-mode_context-mode__";
-  const SHORT_PREFIX = "mcp__context-mode__";
 
-  test("Agent routing block uses plugin-format tool names", () => {
+  test("Agent routing block uses standalone-format tool names", () => {
     const result = runHook({ tool_name: "Agent", tool_input: { prompt: "Do something." } });
     assert.equal(result.exitCode, 0);
     const parsed = JSON.parse(result.stdout);
     const prompt = parsed.hookSpecificOutput.updatedInput.prompt;
-    assert.ok(prompt.includes(PLUGIN_PREFIX + "ctx_batch_execute"), "Expected plugin-format ctx_batch_execute");
-    assert.ok(prompt.includes(PLUGIN_PREFIX + "ctx_search"), "Expected plugin-format ctx_search");
-    assert.ok(prompt.includes(PLUGIN_PREFIX + "ctx_execute"), "Expected plugin-format ctx_execute");
-    assert.ok(prompt.includes(PLUGIN_PREFIX + "ctx_fetch_and_index"), "Expected plugin-format ctx_fetch_and_index");
-    assert.ok(!prompt.includes(SHORT_PREFIX + "ctx_batch_execute"), "Must not contain short-form ctx_batch_execute");
+    assert.ok(prompt.includes(STANDALONE_PREFIX + "ctx_batch_execute"), "Expected standalone ctx_batch_execute");
+    assert.ok(prompt.includes(STANDALONE_PREFIX + "ctx_search"), "Expected standalone ctx_search");
+    assert.ok(prompt.includes(STANDALONE_PREFIX + "ctx_execute"), "Expected standalone ctx_execute");
+    assert.ok(prompt.includes(STANDALONE_PREFIX + "ctx_fetch_and_index"), "Expected standalone ctx_fetch_and_index");
+    assert.ok(!prompt.includes(PLUGIN_PREFIX + "ctx_batch_execute"), "Must not contain plugin-format names in standalone mode");
   });
 
-  test("Read nudge uses plugin-format execute_file tool name", () => {
+  test("Read nudge uses standalone-format execute_file tool name", () => {
     const result = runHook({ tool_name: "Read", tool_input: { file_path: "/some/file.ts" } });
     assert.equal(result.exitCode, 0);
     const parsed = JSON.parse(result.stdout);
     const ctx = parsed.hookSpecificOutput.additionalContext;
-    assert.ok(ctx.includes(PLUGIN_PREFIX + "ctx_execute_file"), "Expected plugin-format ctx_execute_file in Read nudge");
-    assert.ok(!ctx.includes(SHORT_PREFIX + "ctx_execute_file"), "Read nudge must not contain short-form ctx_execute_file");
+    assert.ok(ctx.includes(STANDALONE_PREFIX + "ctx_execute_file"), "Expected standalone ctx_execute_file in Read nudge");
+    assert.ok(!ctx.includes(PLUGIN_PREFIX + "ctx_execute_file"), "Read nudge must not contain plugin-format names in standalone mode");
   });
 
-  test("Grep nudge uses plugin-format execute tool name", () => {
+  test("Grep nudge uses standalone-format execute tool name", () => {
     const result = runHook({ tool_name: "Grep", tool_input: { pattern: "TODO" } });
     assert.equal(result.exitCode, 0);
     const parsed = JSON.parse(result.stdout);
     const ctx = parsed.hookSpecificOutput.additionalContext;
-    assert.ok(ctx.includes(PLUGIN_PREFIX + "ctx_execute"), "Expected plugin-format ctx_execute in Grep nudge");
-    assert.ok(!ctx.includes(SHORT_PREFIX + "ctx_execute"), "Grep nudge must not contain short-form ctx_execute");
+    assert.ok(ctx.includes(STANDALONE_PREFIX + "ctx_execute"), "Expected standalone ctx_execute in Grep nudge");
+    assert.ok(!ctx.includes(PLUGIN_PREFIX + "ctx_execute"), "Grep nudge must not contain plugin-format names in standalone mode");
   });
 
-  test("WebFetch deny reason uses plugin-format fetch_and_index tool name", () => {
+  test("WebFetch deny reason uses standalone-format fetch_and_index tool name", () => {
     const result = runHook({ tool_name: "WebFetch", tool_input: { url: "https://example.com" } });
     assert.equal(result.exitCode, 0);
     const parsed = JSON.parse(result.stdout);
     const reason = parsed.hookSpecificOutput.permissionDecisionReason;
-    assert.ok(reason.includes(PLUGIN_PREFIX + "ctx_fetch_and_index"), "Expected plugin-format ctx_fetch_and_index in WebFetch deny");
-    assert.ok(!reason.includes(SHORT_PREFIX + "ctx_fetch_and_index"), "WebFetch deny must not contain short-form");
+    assert.ok(reason.includes(STANDALONE_PREFIX + "ctx_fetch_and_index"), "Expected standalone ctx_fetch_and_index in WebFetch deny");
+    assert.ok(!reason.includes(PLUGIN_PREFIX + "ctx_fetch_and_index"), "WebFetch deny must not contain plugin-format names in standalone mode");
   });
 
-  test("Bash inline-HTTP redirect uses plugin-format execute tool name (in deny reason)", () => {
-    // CC v2.1.x Bash tool ignores updatedInput.command — the formatter now
-    // emits deny + permissionDecisionReason. The plugin-format tool name
-    // assertion moves from updatedInput.command to permissionDecisionReason.
+  test("Bash inline-HTTP redirect uses standalone-format execute tool name (in deny reason)", () => {
     const bashCmd = "python3 -c 'import requests; requests.get(url)'";
     const result = runHook({ tool_name: "Bash", tool_input: { command: bashCmd } });
     assert.equal(result.exitCode, 0);
     const parsed = JSON.parse(result.stdout);
     const reason = parsed.hookSpecificOutput.permissionDecisionReason;
     assert.ok(typeof reason === "string" && reason.length > 0, "Expected non-empty permissionDecisionReason");
-    assert.ok(reason.includes(PLUGIN_PREFIX + "ctx_execute"), "Expected plugin-format ctx_execute in inline-HTTP redirect reason");
-    assert.ok(!reason.includes(SHORT_PREFIX + "ctx_execute"), "Inline-HTTP redirect must not contain short-form ctx_execute");
+    assert.ok(reason.includes(STANDALONE_PREFIX + "ctx_execute"), "Expected standalone ctx_execute in inline-HTTP redirect reason");
+    assert.ok(!reason.includes(PLUGIN_PREFIX + "ctx_execute"), "Inline-HTTP redirect must not contain plugin-format names in standalone mode");
   });
 });
 

--- a/tests/hooks/tool-naming.test.ts
+++ b/tests/hooks/tool-naming.test.ts
@@ -70,10 +70,29 @@ afterEach(() => {
 // ═══════════════════════════════════════════════════════════════════
 
 describe("getToolName", () => {
-  it("returns correct name for claude-code", () => {
-    expect(getToolName("claude-code", "ctx_fetch_and_index")).toBe(
-      "mcp__plugin_context-mode_context-mode__ctx_fetch_and_index",
-    );
+  it("returns plugin-namespaced name for claude-code when CLAUDE_PLUGIN_ROOT is set", () => {
+    const prev = process.env.CLAUDE_PLUGIN_ROOT;
+    process.env.CLAUDE_PLUGIN_ROOT = "/tmp/fake-plugin-root";
+    try {
+      expect(getToolName("claude-code", "ctx_fetch_and_index")).toBe(
+        "mcp__plugin_context-mode_context-mode__ctx_fetch_and_index",
+      );
+    } finally {
+      if (prev === undefined) delete process.env.CLAUDE_PLUGIN_ROOT;
+      else process.env.CLAUDE_PLUGIN_ROOT = prev;
+    }
+  });
+
+  it("returns standalone-namespaced name for claude-code when CLAUDE_PLUGIN_ROOT is absent", () => {
+    const prev = process.env.CLAUDE_PLUGIN_ROOT;
+    delete process.env.CLAUDE_PLUGIN_ROOT;
+    try {
+      expect(getToolName("claude-code", "ctx_fetch_and_index")).toBe(
+        "mcp__context-mode__ctx_fetch_and_index",
+      );
+    } finally {
+      if (prev !== undefined) process.env.CLAUDE_PLUGIN_ROOT = prev;
+    }
   });
 
   it("returns correct name for gemini-cli", () => {
@@ -136,10 +155,16 @@ describe("getToolName", () => {
     expect(getToolName("pi", "ctx_batch_execute")).toBe("ctx_batch_execute");
   });
 
-  it("falls back to claude-code for unknown platforms", () => {
-    expect(getToolName("unknown-platform", "ctx_search")).toBe(
-      "mcp__plugin_context-mode_context-mode__ctx_search",
-    );
+  it("falls back to claude-code for unknown platforms (standalone)", () => {
+    const prev = process.env.CLAUDE_PLUGIN_ROOT;
+    delete process.env.CLAUDE_PLUGIN_ROOT;
+    try {
+      expect(getToolName("unknown-platform", "ctx_search")).toBe(
+        "mcp__context-mode__ctx_search",
+      );
+    } finally {
+      if (prev !== undefined) process.env.CLAUDE_PLUGIN_ROOT = prev;
+    }
   });
 });
 
@@ -262,46 +287,33 @@ describe("createExternalMcpGuidance (#529)", () => {
 // Backward Compat — Static Exports
 // ═══════════════════════════════════════════════════════════════════
 
+// Static exports default to claude-code naming. The exact prefix depends on
+// CLAUDE_PLUGIN_ROOT at module load time: set → plugin prefix, absent → standalone prefix.
+// Tests run without CLAUDE_PLUGIN_ROOT so they assert the standalone prefix.
 describe("backward compat static exports", () => {
-  it("ROUTING_BLOCK uses claude-code naming", () => {
-    expect(ROUTING_BLOCK).toContain(
-      "mcp__plugin_context-mode_context-mode__ctx_batch_execute",
-    );
-    expect(ROUTING_BLOCK).toContain(
-      "mcp__plugin_context-mode_context-mode__ctx_search",
-    );
+  it("ROUTING_BLOCK uses claude-code standalone naming", () => {
+    expect(ROUTING_BLOCK).toContain("mcp__context-mode__ctx_batch_execute");
+    expect(ROUTING_BLOCK).toContain("mcp__context-mode__ctx_search");
+    expect(ROUTING_BLOCK).not.toContain("mcp__plugin_context-mode_context-mode__");
   });
 
-  it("READ_GUIDANCE uses claude-code naming", () => {
-    expect(READ_GUIDANCE).toContain(
-      "mcp__plugin_context-mode_context-mode__ctx_execute_file",
-    );
+  it("READ_GUIDANCE uses claude-code standalone naming", () => {
+    expect(READ_GUIDANCE).toContain("mcp__context-mode__ctx_execute_file");
   });
 
-  it("GREP_GUIDANCE uses claude-code naming", () => {
-    expect(GREP_GUIDANCE).toContain(
-      "mcp__plugin_context-mode_context-mode__ctx_execute",
-    );
+  it("GREP_GUIDANCE uses claude-code standalone naming", () => {
+    expect(GREP_GUIDANCE).toContain("mcp__context-mode__ctx_execute");
   });
 
-  it("BASH_GUIDANCE uses claude-code naming", () => {
-    expect(BASH_GUIDANCE).toContain(
-      "mcp__plugin_context-mode_context-mode__ctx_batch_execute",
-    );
+  it("BASH_GUIDANCE uses claude-code standalone naming", () => {
+    expect(BASH_GUIDANCE).toContain("mcp__context-mode__ctx_batch_execute");
   });
 
-  it("EXTERNAL_MCP_GUIDANCE uses claude-code naming and matches the factory (#529)", () => {
-    expect(EXTERNAL_MCP_GUIDANCE).toContain(
-      "mcp__plugin_context-mode_context-mode__ctx_execute",
-    );
-    expect(EXTERNAL_MCP_GUIDANCE).toContain(
-      "mcp__plugin_context-mode_context-mode__ctx_fetch_and_index",
-    );
-    expect(EXTERNAL_MCP_GUIDANCE).toContain(
-      "mcp__plugin_context-mode_context-mode__ctx_search",
-    );
-    // Drift guard: the static export must equal the factory output with the
-    // default (claude-code) namer — they share a single template.
+  it("EXTERNAL_MCP_GUIDANCE uses claude-code standalone naming and matches the factory (#529)", () => {
+    expect(EXTERNAL_MCP_GUIDANCE).toContain("mcp__context-mode__ctx_execute");
+    expect(EXTERNAL_MCP_GUIDANCE).toContain("mcp__context-mode__ctx_fetch_and_index");
+    expect(EXTERNAL_MCP_GUIDANCE).toContain("mcp__context-mode__ctx_search");
+    // Drift guard: static export must equal factory output with default (claude-code) namer.
     const claudeCodeT = createToolNamer("claude-code");
     expect(EXTERNAL_MCP_GUIDANCE).toBe(createExternalMcpGuidance(claudeCodeT));
   });
@@ -322,11 +334,13 @@ describe("routePreToolUse with platform parameter", () => {
     expect(cmd).not.toContain("mcp__plugin_context-mode_context-mode__");
   });
 
-  it("curl block message uses claude-code tool names when platform is omitted", () => {
+  it("curl block message uses claude-code standalone tool names when platform is omitted", () => {
+    // No CLAUDE_PLUGIN_ROOT in test env → standalone prefix mcp__context-mode__.
     const result = routePreToolUse("Bash", { command: "curl https://example.com" }, "/tmp");
     expect(result).not.toBeNull();
     const cmd = (result!.updatedInput as Record<string, string>).command;
-    expect(cmd).toContain("mcp__plugin_context-mode_context-mode__ctx_fetch_and_index");
+    expect(cmd).toContain("mcp__context-mode__ctx_fetch_and_index");
+    expect(cmd).not.toContain("mcp__plugin_context-mode_context-mode__");
   });
 
   it("inline HTTP block uses cursor bare names when platform=cursor", () => {


### PR DESCRIPTION
## Context

Complements #810 (merged) which fixed standalone installs (MacPorts, npm global) silently skipping `settings.json` hook wiring.

## Problem

Standalone installs register the MCP server as `context-mode` via `settings.json`, which yields `mcp__context-mode__<tool>` names. Plugin installs set `CLAUDE_PLUGIN_ROOT` and yield the plugin-namespaced form instead. Guidance text and ToolSearch bootstraps were hardcoded to the plugin-namespaced form regardless of install mode, so standalone installs got incorrect tool-name references.

## Fix

`hooks/core/tool-naming.mjs`'s claude-code branch now checks `CLAUDE_PLUGIN_ROOT` at runtime and emits the correct prefix for the actual install mode. `src/adapters/claude-code/hooks.ts` gets a clarifying comment that `mcp__` covers both forms. Tests updated to assert the standalone form (no `CLAUDE_PLUGIN_ROOT` in env).

## Testing

- Existing test suite updated (`tests/core/routing.test.ts`, `tests/hooks/integration.test.ts`, `tests/hooks/tool-naming.test.ts`) to cover both plugin and standalone install modes.
- Verified live on a MacPorts standalone install: tools now surface as `mcp__context-mode__ctx_*`.

## Affected platforms

- [x] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch