### PR TITLE
fix: state ctx_search throttle thresholds as absolute call numbers

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2771,15 +2771,14 @@ EXAMPLE: ctx_search(queries: ["last user prompt", "active skills", "open blocker
       // already truncated. Soft warning after SEARCH_MAX_RESULTS_AFTER calls;
       // gentle informational line before that.
       const throttleRemaining = Math.max(0, SEARCH_BLOCK_AFTER - searchCallCount);
-      const softCapRemaining = Math.max(0, SEARCH_MAX_RESULTS_AFTER - searchCallCount);
       if (searchCallCount >= SEARCH_MAX_RESULTS_AFTER) {
         output += `\n\n⚠ search call #${searchCallCount}/${SEARCH_BLOCK_AFTER} in this window. ` +
           `Results limited to ${effectiveLimit}/query. ${throttleRemaining} call(s) remaining before block. ` +
           `Batch queries: ctx_search(queries: ["q1","q2","q3"]) or use ctx_batch_execute.`;
       } else {
-        output += `\n\n> Throttle: call #${searchCallCount}/${SEARCH_BLOCK_AFTER} in this window. ` +
-          `${softCapRemaining} call(s) before soft cap. ` +
-          `Prefer ctx_search(queries: [...]) array form for multi-query workloads — it counts as a single call.`;
+        output += `\n\n> Throttle: search call #${searchCallCount} this window. ` +
+          `Soft cap (fewer results/query) at call #${SEARCH_MAX_RESULTS_AFTER}, hard block at #${SEARCH_BLOCK_AFTER}. ` +
+          `Prefer ctx_search(queries: [...]) array form; it counts as one call.`;
       }
 
       if (output.trim().length === 0) {

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -6430,8 +6430,11 @@ describe("ctx_search progressive throttle observability (issue #697)", () => {
   });
 
   test("throttle counter line is surfaced on every response, not only after soft cap", () => {
-    // Branch before the soft cap — should still inform the agent.
-    expect(serverSrc).toMatch(/Throttle:\s*call\s+#\$\{searchCallCount\}/);
+    // Branch before the soft cap — should still inform the agent, stating the
+    // soft-cap and hard-block call numbers as absolute thresholds.
+    expect(serverSrc).toMatch(/Throttle:\s*search call\s+#\$\{searchCallCount\}/);
+    expect(serverSrc).toMatch(/Soft cap[\s\S]{0,80}call\s+#\$\{SEARCH_MAX_RESULTS_AFTER\}/);
+    expect(serverSrc).toMatch(/hard block at #\$\{SEARCH_BLOCK_AFTER\}/);
     // Branch at/after soft cap keeps the historical warning shape.
     expect(serverSrc).toMatch(/⚠ search call #\$\{searchCallCount\}/);
   });


### PR DESCRIPTION
## What / Why / How

**Root cause:** the pre-soft-cap `ctx_search` throttle line printed `> Throttle: call #${searchCallCount}/${SEARCH_BLOCK_AFTER} in this window. ${softCapRemaining} call(s) before soft cap.` That mixes two different limits in one sentence. The `#N/8` denominator is the hard-block cap (`SEARCH_BLOCK_AFTER`), while "before soft cap" counts down to `SEARCH_MAX_RESULTS_AFTER` (default `3`). Since the soft cap engages at `searchCallCount >= SEARCH_MAX_RESULTS_AFTER`, call `#3` is already truncated, so on call `#1` the old text read "2 call(s) before soft cap" and reported one more full-result call than actually remained.

**Fix:** state both thresholds as absolute call numbers and drop the ambiguous countdown. On call `#1` with defaults the line now reads `> Throttle: search call #1 this window. Soft cap (fewer results/query) at call #3, hard block at #8. Prefer ctx_search(queries: [...]) array form; it counts as one call.` The now-unused `softCapRemaining` local is removed. The at/after-soft-cap `⚠` branch is left unchanged.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [x] All platforms

## Test plan

- `npx tsc -b --noEmit` clean.
- `npx vitest run tests/core/server.test.ts` green (499 tests). The source-text assertion in `ctx_search progressive throttle observability` that pinned the old wording was updated to the absolute-threshold phrasing.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
