### PR TITLE
fix: dedupe chunks across queries in a multi-query ctx_search call

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -55,7 +55,7 @@ import {
 } from "./session/event-emit.js";
 import { persistToolCallCounter, restoreSessionStats } from "./session/persist-tool-calls.js";
 import { appendRetrievalBytes } from "./session/retrieval-marker.js";
-import { searchAllSources } from "./search/unified.js";
+import { searchAllSources, type UnifiedSearchResult } from "./search/unified.js";
 import {
   buildCtxSearchInputSchema,
   CTX_SEARCH_SHARED_MODE,
@@ -1417,6 +1417,27 @@ export function formatBatchQueryResults(
   return sections;
 }
 
+/**
+ * Cross-query dedup for a multi-query ctx_search call. A chunk that matches
+ * more than one query would otherwise print verbatim under each query's
+ * section. Results carry no stable chunk id (see SearchResult /
+ * UnifiedSearchResult), so identity is the query-independent
+ * `source\0title\0content` tuple; the emitted snippet is windowed per query
+ * and cannot be used as a key. `seen` is shared across the call's queries and
+ * mutated in place, so the first occurrence of a chunk is kept and later
+ * repeats are dropped.
+ */
+export function dedupeAcrossQueries<
+  T extends { source: string; title: string; content: string },
+>(results: T[], seen: Set<string>): T[] {
+  return results.filter((r) => {
+    const key = [r.source, r.title, r.content].join("\u0000");
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 // ─────────────────────────────────────────────────────────
 // batch_execute runner — used by ctx_batch_execute handler
 // ─────────────────────────────────────────────────────────
@@ -2703,6 +2724,11 @@ EXAMPLE: ctx_search(queries: ["last user prompt", "active skills", "open blocker
 
       const configDir = _detectedAdapter?.getConfigDir() ?? resolveClaudeConfigDir();
 
+      // Track chunks already emitted by an earlier query so a chunk matching
+      // multiple queries prints once (multi-query calls only; see
+      // dedupeAcrossQueries).
+      const seenChunks = new Set<string>();
+
       try {
       for (const q of queryList) {
         if (totalSize > MAX_TOTAL) {
@@ -2741,7 +2767,19 @@ EXAMPLE: ctx_search(queries: ["last user prompt", "active skills", "open blocker
           continue;
         }
 
-        const formatted = results
+        // For multi-query calls, drop chunks already shown under an earlier
+        // query so the same chunk never prints twice. Single-query output is
+        // left byte-identical.
+        let emitResults: Array<SearchResult | UnifiedSearchResult> = results;
+        if (queryList.length > 1) {
+          emitResults = dedupeAcrossQueries<SearchResult | UnifiedSearchResult>(results, seenChunks);
+          if (emitResults.length === 0) {
+            sections.push(`## ${q}\n(all matches already shown above)`);
+            continue;
+          }
+        }
+
+        const formatted = emitResults
           .map((r, i) => {
             const origin = (r as any).origin || "current-session";
             const ts = (r as any).timestamp ? (r as any).timestamp.slice(0, 16).replace("T", " ") : "";

--- a/tests/core/search.test.ts
+++ b/tests/core/search.test.ts
@@ -21,7 +21,7 @@ import { ContentStore } from "../../src/store.js";
 import { SessionDB, hashProjectDirCanonical } from "../../src/session/db.js";
 import { searchAllSources, type UnifiedSearchResult } from "../../src/search/unified.js";
 import { searchAutoMemory } from "../../src/search/auto-memory.js";
-import { extractSnippet, formatBatchQueryResults, positionsFromHighlight } from "../../src/server.js";
+import { dedupeAcrossQueries, extractSnippet, formatBatchQueryResults, positionsFromHighlight } from "../../src/server.js";
 
 // ─────────────────────────────────────────────────────────
 // Shared helpers
@@ -764,6 +764,33 @@ describe("Multi-source isolation (batch_execute path)", () => {
     assert.ok(!output.includes("24 hours"), "Should not leak older source content when current batch matches");
 
     store.close();
+  });
+});
+
+describe("ctx_search cross-query dedup (dedupeAcrossQueries)", () => {
+  const chunk = (content: string) => ({ source: "docs: auth", title: "JWT", content });
+
+  test("a chunk matching two queries is emitted once, first occurrence kept", () => {
+    const seen = new Set<string>();
+    const c = chunk("JWT tokens expire after 24 hours.");
+
+    const firstQuery = dedupeAcrossQueries([c], seen);
+    assert.equal(firstQuery.length, 1, "first query emits the chunk");
+
+    const secondQuery = dedupeAcrossQueries([c], seen);
+    assert.equal(secondQuery.length, 0, "same chunk under a later query is dropped");
+  });
+
+  test("distinct chunks sharing source and title are not falsely deduped", () => {
+    const seen = new Set<string>();
+    const emitted = dedupeAcrossQueries(
+      [
+        chunk("Access tokens expire after 24 hours."),
+        chunk("Refresh tokens rotate weekly."),
+      ],
+      seen,
+    );
+    assert.equal(emitted.length, 2, "different content is a different chunk");
   });
 });
 


### PR DESCRIPTION
## What / Why / How

**Root cause:** `ctx_search` runs each query in `queryList` independently and pushes a `## ${q}` section per query, with no state shared across the loop. A chunk that matches more than one query is printed verbatim under every matching query's section, spending context on duplicates.

**Fix:** dedupe chunks across the call's queries with a shared `Set` that keeps the first occurrence. It lives in a small exported helper, `dedupeAcrossQueries`, so tests can hit it directly. Neither `SearchResult` nor `UnifiedSearchResult` has a stable chunk id. The key is therefore the query-independent `source` + `title` + `content` tuple; the per-query snippet cannot serve, because `extractSnippet` windows it around each query's terms. Single-query output stays byte-identical: the dedup only runs when `queryList.length > 1`. A later query whose matches were all shown earlier now reads `(all matches already shown above)`.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [x] All platforms

## Test plan

- `npx tsc -b --noEmit` clean.
- `npx vitest run tests/core/search.test.ts` green. Added `ctx_search cross-query dedup`, covering: a chunk matching two queries is emitted once with the first occurrence kept, and distinct chunks that share `source` and `title` are not falsely deduped.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
