### PR TITLE
fix: trim the per-call ctx_batch_execute footer

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1368,12 +1368,23 @@ export function extractSnippet(
 
 export type BatchQueryScope = "batch" | "global";
 
+// The batch-scope tip is identical on every non-global ctx_batch_execute call,
+// so it is emitted once per server process (the first non-global batch) instead
+// of repeated on every call. resetBatchFooterState() restores the initial state
+// so tests are deterministic under vitest's shared fork pool.
+let batchScopeTipShown = false;
+
+export function resetBatchFooterState(): void {
+  batchScopeTipShown = false;
+}
+
 export function formatBatchQueryResults(
   store: ContentStore,
   queries: string[],
   source: string,
   maxOutput = 80 * 1024,
   scope: BatchQueryScope = "batch",
+  stats?: { anyMiss: boolean },
 ): string[] {
   const sections: string[] = [];
   let outputSize = 0;
@@ -1404,13 +1415,15 @@ export function formatBatchQueryResults(
       continue;
     }
 
+    if (stats) stats.anyMiss = true;
     sections.push("No matching sections found.");
     sections.push("");
   }
 
   if (scope === "global") {
     sections.push(`\n> **Scope:** Queries searched the entire persistent index (query_scope: "global").`);
-  } else {
+  } else if (!batchScopeTipShown) {
+    batchScopeTipShown = true;
     sections.push(`\n> **Tip:** Results are scoped to this batch only. To search across all indexed sources, use \`ctx_search(queries: [...])\` or call ctx_batch_execute with \`query_scope: "global"\`.`);
   }
 
@@ -3853,10 +3866,13 @@ EXAMPLE: ctx_batch_execute(
       // When the caller passes query_scope: "global", searches reach the entire
       // persistent index in the same round trip. Cross-source search remains
       // available via explicit ctx_search() as well.
-      const queryResults = formatBatchQueryResults(store, queries, source, undefined, query_scope);
+      const batchStats = { anyMiss: false };
+      const queryResults = formatBatchQueryResults(store, queries, source, undefined, query_scope, batchStats);
 
-      // Get searchable terms for edge cases where follow-up is needed
-      const distinctiveTerms = store.getDistinctiveTerms
+      // Searchable terms help the agent reformulate after a miss. Surface them
+      // only when at least one query returned nothing (the follow-up case),
+      // not on the common all-hit path, to keep the batch footer lean.
+      const distinctiveTerms = batchStats.anyMiss && store.getDistinctiveTerms
         ? store.getDistinctiveTerms(indexed.sourceId)
         : [];
 

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -26,7 +26,7 @@ import { join, dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
-import { describe, test, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { describe, test, expect, beforeAll, beforeEach, afterAll, afterEach } from "vitest";
 
 import { classifyNonZeroExit } from "../../src/exit-classify.js";
 import { PolyglotExecutor } from "../../src/executor.js";
@@ -6385,6 +6385,14 @@ describe("ctx_batch_execute query_scope (issue #696)", () => {
     "utf-8",
   );
 
+  // The batch scope tip is emitted once per process; reset the module-level
+  // flag before each test so the "first call" assertions are deterministic
+  // under vitest's shared fork pool.
+  beforeEach(async () => {
+    const { resetBatchFooterState } = await import("../../src/server.js");
+    resetBatchFooterState();
+  });
+
   test("schema declares query_scope enum with batch default", () => {
     expect(serverSrc).toMatch(/query_scope:\s*z\s*\.enum\(\["batch",\s*"global"\]\)/);
     expect(serverSrc).toContain('.default("batch")');
@@ -6395,14 +6403,19 @@ describe("ctx_batch_execute query_scope (issue #696)", () => {
     expect(serverSrc).toMatch(/query_scope[\s\S]{0,2000}searches the entire persistent index/i);
   });
 
-  test("formatBatchQueryResults default scope keeps batch-local tip", async () => {
+  test("formatBatchQueryResults shows the batch scope tip once per process", async () => {
     const { formatBatchQueryResults } = await import("../../src/server.js");
     const store = new ContentStore(":memory:");
     store.index({ content: "# Section A\n\nValidation of frontmatter is critical.\n", source: "batch:cmd1" });
-    const lines = formatBatchQueryResults(store, ["validation"], "batch:cmd1");
-    const text = lines.join("\n");
-    expect(text).toMatch(/Results are scoped to this batch only/);
-    expect(text).toMatch(/query_scope:\s*"global"/);
+
+    // First non-global batch call in a fresh process surfaces the tip.
+    const first = formatBatchQueryResults(store, ["validation"], "batch:cmd1").join("\n");
+    expect(first).toMatch(/Results are scoped to this batch only/);
+    expect(first).toMatch(/query_scope:\s*"global"/);
+
+    // A second call in the same process omits the now-redundant tip.
+    const second = formatBatchQueryResults(store, ["validation"], "batch:cmd1").join("\n");
+    expect(second).not.toMatch(/Results are scoped to this batch only/);
   });
 
   test("formatBatchQueryResults global scope drops batch tip and notes global scope", async () => {
@@ -6413,6 +6426,20 @@ describe("ctx_batch_execute query_scope (issue #696)", () => {
     const text = lines.join("\n");
     expect(text).toMatch(/query_scope:\s*"global"/);
     expect(text).not.toMatch(/Results are scoped to this batch only/);
+  });
+
+  test("formatBatchQueryResults reports a miss so follow-up terms stay gated", async () => {
+    const { formatBatchQueryResults } = await import("../../src/server.js");
+    const store = new ContentStore(":memory:");
+    store.index({ content: "# Section A\n\nValidation of frontmatter is critical.\n", source: "batch:cmd1" });
+
+    const allHit = { anyMiss: false };
+    formatBatchQueryResults(store, ["validation"], "batch:cmd1", undefined, "batch", allHit);
+    expect(allHit.anyMiss).toBe(false);
+
+    const withMiss = { anyMiss: false };
+    formatBatchQueryResults(store, ["nonexistent-term-xyz"], "batch:cmd1", undefined, "batch", withMiss);
+    expect(withMiss.anyMiss).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What / Why / How

**Root cause:** `ctx_batch_execute` appended two footers on every call. The `Searchable terms for follow-up:` line fired whenever `store.getDistinctiveTerms` returned terms, though the adjacent comment scopes it to "edge cases where follow-up is needed". Separately, `formatBatchQueryResults` repeated its `> **Tip:** Results are scoped to this batch only...` line on every non-global call. On a batch whose queries all matched, that is roughly 140 tokens of trailing footer with nothing to act on.

**Fix:** two changes, each tying a footer to when it is actually useful.

- `formatBatchQueryResults` takes an optional `stats` out-parameter and sets `stats.anyMiss` when a query returns no matches. The handler computes `distinctiveTerms` only when `batchStats.anyMiss` is true, so the searchable-terms line shows only on the follow-up case the comment describes. The return type stays `string[]`, so existing callers are unaffected.
- The batch scoping tip is emitted once per server process (the first non-global batch call) via a module-level flag, rather than on every call. The `query_scope: "global"` line is unchanged. An exported `resetBatchFooterState()` restores the flag so tests stay deterministic under vitest's shared fork pool; production never calls it.

The flag lives inside the formatter for locality. It could equally sit at the handler call site if you prefer to keep the formatter free of module state.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [x] All platforms

## Test plan

- `npx tsc -b --noEmit` clean.
- `npx vitest run tests/core/server.test.ts` green (500 tests). Added coverage: `stats.anyMiss` is `false` for an all-hit batch and `true` when a query misses. A separate case asserts the scoping tip shows on the first batch call in a fresh process and is omitted on a second call in the same process.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
