### PR TITLE
fix(security): escape backtick/$ in build-tool redirect to block comm…

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -808,7 +808,18 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
     // These produce extremely verbose output that should stay in sandbox.
     // Word-boundary guard prevents matching `gradle-wrapper-config`, `mvnDocker`, etc.
     if (/(^|\s|&&|\||\;)(\.\/gradlew|gradlew|gradle|\.\/mvnw|mvnw|mvn|\.\/sbt|sbt)(\s|$)/i.test(stripped)) {
-      const safeCmd = command.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+      // safeCmd is interpolated into a double-quoted `echo "…"`. Inside double
+      // quotes the shell still evaluates backticks and `$(…)`/`$var`, so
+      // escaping only `\` and `"` let an embedded command substitution in the
+      // original command (e.g. `mvn install \`touch pwned\``) execute when the
+      // rewritten echo runs — defeating the redirect. Escape every character
+      // that stays active inside double quotes: `\` first, then backtick, `$`,
+      // and `"`.
+      const safeCmd = command
+        .replace(/\\/g, "\\\\")
+        .replace(/`/g, "\\`")
+        .replace(/\$/g, "\\$")
+        .replace(/"/g, '\\"');
       return mcpRedirect({
         action: "modify",
         updatedInput: {

--- a/tests/core/routing.test.ts
+++ b/tests/core/routing.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
 import {
   routePreToolUse,
   resetGuidanceThrottle,
@@ -516,5 +520,44 @@ describe("Issue #856: session_continuity framing is a soft hint, not a standing 
 
   it("still mentions session continuity (the hint is softened, not removed)", () => {
     expect(BLOCK).toContain("session_continuity");
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// Security: build-tool redirect must not let embedded command substitution in
+// the ORIGINAL command execute when the rewritten `echo` runs. The redirect
+// interpolates the user command into a double-quoted echo, where backticks and
+// `$(…)`/`$var` stay active — so the escaper must neutralize `\`, backtick,
+// `$`, and `"`. Regression guard for the S1 command-injection fix.
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("Security: build-tool redirect escapes shell metacharacters", () => {
+  const SENTINEL_DIR = fs.mkdtempSync(join(os.tmpdir(), "ctx-mcp-ready-"));
+
+  beforeEach(() => {
+    // Force isMCPReady() true so the mcpRedirect actually returns the modify
+    // decision (otherwise it passes through as null when no server is live).
+    process.env.CONTEXT_MODE_MCP_SENTINEL_DIR = SENTINEL_DIR;
+    fs.writeFileSync(join(SENTINEL_DIR, `context-mode-mcp-ready-${process.pid}`), String(process.pid));
+  });
+
+  afterEach(() => {
+    delete process.env.CONTEXT_MODE_MCP_SENTINEL_DIR;
+  });
+
+  it("neutralizes backtick and $() so no substitution survives in the echo", () => {
+    const cmd = "mvn install `touch /tmp/PWNED` $(touch /tmp/PWNED2)";
+    const decision = routePreToolUse("Bash", { command: cmd }, "/test", "claude-code", "s-inj");
+    expect(decision?.action).toBe("modify");
+    const rewritten = decision.updatedInput.command;
+    // The rewritten command is a single `echo "…"`. Every backtick and `$`
+    // from the original must be backslash-escaped so the shell treats them as
+    // literals inside the double quotes.
+    expect(rewritten).toContain("\\`touch /tmp/PWNED\\`");
+    expect(rewritten).toContain("\\$(touch /tmp/PWNED2)");
+    // Running it through a real shell must NOT create the sentinel files.
+    execSync(rewritten, { shell: "/bin/bash" });
+    expect(fs.existsSync("/tmp/PWNED")).toBe(false);
+    expect(fs.existsSync("/tmp/PWNED2")).toBe(false);
   });
 });


### PR DESCRIPTION
…and injection

The build-tool redirect (gradle/mvn/sbt) interpolates the original command into a double-quoted `echo "…"` that becomes the rewritten command. Inside double quotes the shell still evaluates backticks and `$(…)`/`$var`, and the escaper only handled `\` and `"`. A command like `mvn install \`touch pwned\`` therefore executed its embedded substitution when the redirect ran — defeating the redirect's purpose of keeping the build out of the conversation and running arbitrary side effects the routing intended to intercept.

Escape every character that stays active inside double quotes: `\` (first), backtick, `$`, then `"`. Adds a regression test that runs the rewritten echo through a real shell and asserts no substitution fires.

## What / Why / How

<!-- Brief: what changed, why, and implementation approach. Link issue: Fixes #000 -->

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [x] All platforms

## Test plan

<!-- What tests were added or modified? -->

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
