### PR TITLE
fix(hooks): downgrade WebFetch hard-deny to once-per-session advisory

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -273,13 +273,13 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform) {
     return guidanceOnce("grep", grepGuidance);
   }
 
-  // ─── WebFetch: deny + redirect to sandbox ───
+  // ─── WebFetch: nudge toward ctx_fetch_and_index (once per session) ───
+  // Hook stdin carries no per-agent tool list, so a hard deny strands
+  // subagents that don't have the ctx_* MCP tools with no web access at all.
   if (canonical === "WebFetch") {
     const url = toolInput.url ?? "";
-    return {
-      action: "deny",
-      reason: `context-mode: WebFetch blocked. Use ${t("ctx_fetch_and_index")}(url: "${url}", source: "...") to fetch this URL in sandbox. Then use ${t("ctx_search")}(queries: [...]) to query results. Do NOT use curl, wget, mcp_web_fetch, or mcp_fetch_tool.`,
-    };
+    const webFetchGuidance = `context-mode: prefer ${t("ctx_fetch_and_index")}(url: "${url}", source: "...") to fetch this URL in sandbox, then ${t("ctx_search")}(queries: [...]) to query results. Falling back to WebFetch is allowed if ctx_* tools are unavailable.`;
+    return guidanceOnce("webfetch", webFetchGuidance);
   }
 
   // ─── Agent/Task: inject context-mode routing into subagent prompts ───


### PR DESCRIPTION
## Problem

The PreToolUse routing hook hard-denies `WebFetch` and redirects to `ctx_fetch_and_index`. But hook stdin carries no per-agent tool list, so the deny also fires for subagents whose tool allowlists don't include the context-mode MCP tools (common for orchestrator-spawned agents with restricted tools). Those agents are pointed at a tool they cannot call — leaving them with **no web access at all**.

Observed in practice: across a 3-week audit of my session transcripts, 20 WebFetch blocks inside such subagents produced **0 successful fallbacks** — every one was a dead end.

## Fix

Downgrade the deny to the same `guidanceOnce()` once-per-session nudge already used for Read/Grep. Sessions that have the ctx_* tools still get steered to the sandbox; sessions without them keep a working WebFetch.

## Testing

Fed a crafted `WebFetch` PreToolUse payload to `pretooluse.mjs` via stdin: first call returns the advisory (no deny), repeat call passes through silently. Existing Read/Grep nudge behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)