### PR TITLE
fix: avoid deprecated gh issue project cards query

### DIFF
--- a/.claude/skills/context-mode-ops/triage-issue.md
+++ b/.claude/skills/context-mode-ops/triage-issue.md
@@ -12,8 +12,8 @@ Use `ctx_batch_execute` to gather everything in ONE call:
 
 ```javascript
 commands: [
-  { label: "issue-body", command: "gh issue view {N} --json title,body,labels,state,comments,author,createdAt" },
-  { label: "issue-comments", command: "gh issue view {N} --comments" },
+  { label: "issue-body", command: "gh issue view {N} --json number,title,body,labels,state,comments,author,createdAt" },
+  { label: "issue-comments", command: "gh issue view {N} --json number,comments" },
   { label: "recent-related-prs", command: "gh pr list --state all --limit 10 --json number,title,state,headRefName" },
   { label: "source-tree", command: "find src -type f -name '*.ts' | sort" },
   { label: "test-tree", command: "find tests -type f -name '*.test.ts' | sort" },

--- a/src/server.ts
+++ b/src/server.ts
@@ -4177,8 +4177,8 @@ RETURNS:
 
 EXAMPLE: ctx_batch_execute(
   commands: [
-    {label: "issue 1", command: "gh issue view 1"},
-    {label: "issue 2", command: "gh issue view 2"},
+    {label: "issue 1", command: "gh issue view 1 --json number,title,body,comments"},
+    {label: "issue 2", command: "gh issue view 2 --json number,title,body,comments"},
     {label: "summarize", command: "echo done"}
   ],
   queries: ["root cause", "proposed fix"],

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -3028,6 +3028,29 @@ describe("batch_execute FS read tracking", () => {
   });
 });
 
+describe("ctx_batch_execute GitHub issue examples", () => {
+  const ISSUE_GUIDANCE_SOURCE_PATHS = [
+    resolve(__dirname, "../../src/server.ts"),
+    resolve(__dirname, "../../.claude/skills/context-mode-ops/triage-issue.md"),
+  ];
+  const DEPRECATED_PROJECT_CARDS_ERROR = "repository.issue.projectCards";
+  const BARE_ISSUE_VIEW_COMMAND = /gh issue view \d+(?![^\"]*--json)/;
+  const SAFE_ISSUE_VIEW_COMMAND =
+    /gh issue view \d+ --json number,title,body,comments/;
+
+  test("avoid bare gh issue view commands that request deprecated projectCards", () => {
+    const source = ISSUE_GUIDANCE_SOURCE_PATHS.map((sourcePath) =>
+      readFileSync(sourcePath, "utf-8"),
+    ).join("\n");
+
+    expect(
+      BARE_ISSUE_VIEW_COMMAND.test(source),
+      `Bare gh issue view can fail with ${DEPRECATED_PROJECT_CARDS_ERROR}`,
+    ).toBe(false);
+    expect(source).toMatch(SAFE_ISSUE_VIEW_COMMAND);
+  });
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // runBatchCommands — concurrency, ordering, timeout semantics
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What
Replace bare `gh issue view` examples with explicit `--json` field selections so GitHub CLI does not request the deprecated `repository.issue.projectCards` field.

Fixes #890.

## Why
The bare issue-view examples can fail in current GitHub CLI flows because the default GraphQL query includes deprecated project card data. The guidance now asks only for the fields needed by context-mode issue triage.

## Coverage added
- Added regression coverage that scans the server guidance and ops triage guide for bare `gh issue view` examples.
- Locks the safe `--json number,title,body,comments` example shape.

## Test plan
- [x] `rtk test npx vitest run tests/core/server.test.ts -t "ctx_batch_execute GitHub issue examples"`
- [x] RED proof: reverted `src/server.ts` and `.claude/skills/context-mode-ops/triage-issue.md`, then reran the same focused test and observed failure.
- [x] `rtk test npm run typecheck`
- [x] `gh issue view 890 --repo mksglu/context-mode --json number,title,body,comments --jq .number` returned `890`
