### PR TITLE
fix(packaging): guard packaged helper scripts

### DIFF
--- a/scripts/assert-asymmetric-drift.mjs
+++ b/scripts/assert-asymmetric-drift.mjs
@@ -49,6 +49,12 @@ const REQUIRED_PLUGIN_RUNTIME_FILES = [
   "server.bundle.mjs",
   "cli.bundle.mjs",
 ];
+const REQUIRED_PACKAGED_SCRIPT_FILES = [
+  "scripts/postinstall.mjs",
+  "scripts/heal-better-sqlite3.mjs",
+  "scripts/heal-installed-plugins.mjs",
+  "scripts/plugin-cache-integrity.mjs",
+];
 
 function parseArgs(argv) {
   const out = { root: null };
@@ -103,6 +109,7 @@ function main() {
   const exampleJsonPath = resolve(root, ".mcp.json.example");
   const pluginJsonPath = resolve(root, ".claude-plugin", "plugin.json");
   const localMcpJsonPath = resolve(root, ".mcp.json");
+  const packageJsonPath = resolve(root, "package.json");
 
   /** @type {string[]} */
   const violations = [];
@@ -110,6 +117,7 @@ function main() {
   const example = readArgs0(exampleJsonPath);
   const plg = readArgs0(pluginJsonPath);
   const pluginJson = readJson(pluginJsonPath);
+  const packageJson = readJson(packageJsonPath);
 
   if (!example.ok) violations.push(example.error);
   if (!plg.ok) violations.push(plg.error);
@@ -154,6 +162,32 @@ function main() {
     }
   }
 
+  if (packageJson.ok) {
+    const files = packageJson.value && packageJson.value.files;
+    if (!Array.isArray(files)) {
+      violations.push(`package.json files[] must be an array in ${packageJsonPath}`);
+    } else {
+      for (const rel of REQUIRED_PACKAGED_SCRIPT_FILES) {
+        if (!files.includes(rel)) {
+          violations.push(
+            `package.json files[] must include ${rel}. Without it, npm pack can omit a helper that ctx doctor/postinstall expects.`,
+          );
+        }
+      }
+    }
+  } else {
+    violations.push(packageJson.error);
+  }
+
+  for (const rel of REQUIRED_PACKAGED_SCRIPT_FILES) {
+    if (!existsSync(resolve(root, rel))) {
+      violations.push(
+        `missing packaged helper script at ${resolve(root, rel)}. ` +
+          `package.json files[] declares ${rel}, so the published tarball integrity surface depends on it.`,
+      );
+    }
+  }
+
   // Contributor's local .mcp.json (if present) — must match the template.
   // Absence is fine; the file is .gitignored after the #531 architectural untrack.
   if (existsSync(localMcpJsonPath)) {
@@ -175,7 +209,7 @@ function main() {
   }
 
   process.stdout.write(
-    `asymmetric-drift: OK (.mcp.json.example + .claude-plugin/plugin.json both pin args[0] to ${PLACEHOLDER}; plugin skills path is ${SKILLS_PATH}; runtime files present)\n`,
+    `asymmetric-drift: OK (.mcp.json.example + .claude-plugin/plugin.json both pin args[0] to ${PLACEHOLDER}; plugin skills path is ${SKILLS_PATH}; runtime files and packaged helper scripts present)\n`,
   );
 }
 

--- a/tests/scripts/asymmetric-drift-assert.test.ts
+++ b/tests/scripts/asymmetric-drift-assert.test.ts
@@ -45,6 +45,12 @@ const REQUIRED_PLUGIN_RUNTIME_FILES = [
   "server.bundle.mjs",
   "cli.bundle.mjs",
 ];
+const REQUIRED_PACKAGED_SCRIPT_FILES = [
+  "scripts/postinstall.mjs",
+  "scripts/heal-better-sqlite3.mjs",
+  "scripts/heal-installed-plugins.mjs",
+  "scripts/plugin-cache-integrity.mjs",
+];
 
 interface McpJson {
   mcpServers?: Record<string, { args?: unknown[] }>;
@@ -135,6 +141,18 @@ describe("Issue #531 — asymmetric-drift invariant", () => {
     );
   });
 
+  test("package manifest ships postinstall and doctor integrity helper scripts (#889)", () => {
+    const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf-8")) as {
+      files?: string[];
+    };
+    expect(pkg.files).toEqual(expect.arrayContaining(REQUIRED_PACKAGED_SCRIPT_FILES));
+    for (const rel of REQUIRED_PACKAGED_SCRIPT_FILES) {
+      expect(existsSync(resolve(ROOT, rel)), `${rel} must exist in the plugin root`).toBe(
+        true,
+      );
+    }
+  });
+
   test("npm pack dry-run contains the Claude manifest, runtime bundles, start.mjs, and skills (#658)", () => {
     const r = npmPackDryRunJson();
     const spawnErr = r.error
@@ -148,6 +166,9 @@ describe("Issue #531 — asymmetric-drift invariant", () => {
     const files = new Set(pack[0]?.files?.map((f) => f.path) ?? []);
     expect(files).toContain(".claude-plugin/plugin.json");
     for (const rel of REQUIRED_PLUGIN_RUNTIME_FILES) {
+      expect(files).toContain(rel);
+    }
+    for (const rel of REQUIRED_PACKAGED_SCRIPT_FILES) {
       expect(files).toContain(rel);
     }
     expect([...files].some((p) => p.startsWith("skills/"))).toBe(true);
@@ -247,6 +268,60 @@ describe("Issue #531 — asymmetric-drift invariant", () => {
       expect(r.status, `asserter should fail on missing runtime files`).not.toBe(0);
       expect(r.stderr + r.stdout).toMatch(/missing plugin runtime file/);
       expect(r.stderr + r.stdout).toMatch(/start\.mjs|server\.bundle\.mjs/);
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  test("build-chain asserter script exits non-zero when packaged helper scripts are missing (#889)", () => {
+    const { mkdtempSync, mkdirSync, writeFileSync, rmSync } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require("node:fs") as typeof import("node:fs");
+    const { tmpdir } = require("node:os") as typeof import("node:os");
+    const { join } = require("node:path") as typeof import("node:path");
+
+    const scratch = mkdtempSync(join(tmpdir(), "packaged-scripts-missing-"));
+    try {
+      mkdirSync(join(scratch, ".claude-plugin"), { recursive: true });
+      mkdirSync(join(scratch, "skills", "context-mode"), { recursive: true });
+      writeFileSync(
+        join(scratch, ".mcp.json.example"),
+        JSON.stringify({
+          mcpServers: { "context-mode": { command: "node", args: [PLACEHOLDER] } },
+        }),
+      );
+      writeFileSync(
+        join(scratch, ".claude-plugin", "plugin.json"),
+        JSON.stringify({
+          name: "context-mode",
+          skills: SKILLS_PATH,
+          mcpServers: { "context-mode": { command: "node", args: [PLACEHOLDER] } },
+        }),
+      );
+      for (const rel of REQUIRED_PLUGIN_RUNTIME_FILES) {
+        writeFileSync(join(scratch, rel), "");
+      }
+      writeFileSync(
+        join(scratch, "package.json"),
+        JSON.stringify({
+          name: "context-mode",
+          files: [
+            ".claude-plugin",
+            "skills",
+            ...REQUIRED_PLUGIN_RUNTIME_FILES,
+            ...REQUIRED_PACKAGED_SCRIPT_FILES,
+          ],
+        }),
+      );
+
+      const r = spawnSync(
+        process.execPath,
+        [resolve(ROOT, "scripts", "assert-asymmetric-drift.mjs"), "--root", scratch],
+        { encoding: "utf-8", timeout: 10_000 },
+      );
+      expect(r.status, "asserter should fail on missing packaged scripts").not.toBe(0);
+      expect(r.stderr + r.stdout).toMatch(/missing packaged helper script/);
+      expect(r.stderr + r.stdout).toMatch(/plugin-cache-integrity\.mjs/);
     } finally {
       rmSync(scratch, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What
Add a packaging guard for helper scripts required by install, heal, and plugin-cache integrity flows.

Fixes #889.

## Why
The package drift assertion did not fail when helper scripts such as `postinstall.mjs`, heal helpers, or `plugin-cache-integrity.mjs` were missing from the packaged script set. That allowed broken tarballs to pass the existing guard.

## Coverage added
- Verifies required helper scripts are declared in package metadata.
- Verifies required helper scripts are present in pack-list and tarball-style file lists.
- Locks regression behavior in `tests/scripts/asymmetric-drift-assert.test.ts`.

## Test plan
- [x] `rtk test npx vitest run tests/scripts/asymmetric-drift-assert.test.ts`
- [x] RED proof: reverted `scripts/assert-asymmetric-drift.mjs`, reran the same focused test, and observed the missing-helper-scripts assertion fail.
- [x] `rtk test npm run typecheck`
