### PR TITLE
fix(docs): avoid GraphQL issue listing

### DIFF
--- a/.claude/skills/context-mode-ops/marketing.md
+++ b/.claude/skills/context-mode-ops/marketing.md
@@ -53,7 +53,7 @@ Before writing, read these files and use ONLY verified numbers:
 | Adapter count | `tests/adapters/` (count test files) |
 | GitHub stars | `gh api repos/mksglu/context-mode --jq '.stargazers_count'` |
 | GitHub forks | `gh api repos/mksglu/context-mode --jq '.forks_count'` |
-| Open issues | `gh issue list --state open --json number --jq 'length'` |
+| Open issues | `gh api 'search/issues?q=repo:mksglu/context-mode+is:issue+is:open' --jq '.total_count'` |
 | Recent release | `gh release list --limit 1` |
 
 If you cannot verify a number, do not use it.

--- a/tests/ops/marketing-github-api.test.ts
+++ b/tests/ops/marketing-github-api.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "../..");
+const MARKETING_SKILL_PATH = resolve(REPO_ROOT, ".claude/skills/context-mode-ops/marketing.md");
+const GRAPHQL_ISSUE_LIST_COMMAND = "gh issue list";
+const REST_OPEN_ISSUES_QUERY = "search/issues?q=repo:mksglu/context-mode+is:issue+is:open";
+
+describe("context-mode ops marketing GitHub API commands", () => {
+  it("counts open issues through REST instead of GraphQL issue listing", () => {
+    const marketingSkill = readFileSync(MARKETING_SKILL_PATH, "utf-8");
+
+    expect(marketingSkill).not.toContain(GRAPHQL_ISSUE_LIST_COMMAND);
+    expect(marketingSkill).toContain(REST_OPEN_ISSUES_QUERY);
+  });
+});


### PR DESCRIPTION
## What
Update the marketing ops issue query guidance to use REST search through `gh api` instead of `gh issue list`.

## Why
The `gh issue list` path can route through GitHub GraphQL fields affected by Projects classic deprecations. The REST search endpoint avoids that path for the open-issue marketing workflow.

## Coverage added
- Adds a regression test for the marketing ops guide.
- Locks the expected REST `search/issues` query shape.

## Test plan
- [x] `rtk test npx vitest run tests/ops/marketing-github-api.test.ts`
- [x] RED proof: reverted `.claude/skills/context-mode-ops/marketing.md`, reran the same focused test, and observed failure.
- [x] `rtk test npm run typecheck`
