### PR TITLE
fix(runPool): don't report capped when pool is larger than workload (#915)

### DIFF
--- a/src/runPool.ts
+++ b/src/runPool.ts
@@ -35,7 +35,10 @@ export interface RunPoolResult<T> {
   settled: PromiseSettledResult<T>[];
   /** Concurrency actually used after all caps applied. */
   effectiveConcurrency: number;
-  /** True when effectiveConcurrency < requested concurrency. */
+  /**
+   * True only when a CPU/explicit cap reduced concurrency below requested.
+   * A pool larger than its workload (jobs.length < requested) is NOT a cap.
+   */
   capped: boolean;
 }
 
@@ -52,7 +55,9 @@ export async function runPool<T>(
   const requested = Math.max(1, concurrency);
   const cpuCap = capByCpuCount ? Math.max(1, cpus().length) : requested;
   const effectiveConcurrency = Math.min(requested, cpuCap, jobs.length);
-  const capped = effectiveConcurrency < requested;
+  // `capped` reflects only a CPU/explicit cap, not the job-count clamp — a pool
+  // larger than its workload (jobs.length < requested) is not a real cap.
+  const capped = Math.min(requested, cpuCap) < requested;
 
   const settled: PromiseSettledResult<T>[] = new Array(jobs.length);
   let nextIdx = 0;

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -3515,11 +3515,12 @@ describe("runPool primitive", () => {
     expect(capped).toBe(false);
   });
 
-  test("auto-clamp to job count when concurrency > jobs.length", async () => {
+  test("auto-clamp to job count when concurrency > jobs.length is not a cap", async () => {
     const jobs: PoolJob<number>[] = [{ run: async () => 1 }, { run: async () => 2 }];
     const { effectiveConcurrency, capped } = await runPool(jobs, { concurrency: 8 });
     expect(effectiveConcurrency).toBe(2);
-    expect(capped).toBe(true);
+    // A pool larger than its workload is not a CPU/explicit cap (#915).
+    expect(capped).toBe(false);
   });
 
   test("capByCpuCount caps by os.cpus().length", async () => {


### PR DESCRIPTION
## What / Why / How

Fixes #915.

`runPool` reported `capped: true` whenever fewer jobs than the requested
concurrency were passed, even though no CPU or explicit cap was applied.

`capped` was derived from `effectiveConcurrency`, which includes `jobs.length`
in its `Math.min(...)`. So `runPool([j1, j2], { concurrency: 8 })` dropped
`effectiveConcurrency` to `2` and flipped `capped` to `true` — a pool merely
larger than its workload, not a real cap.

In `ctx_fetch_and_index` this surfaced as a misleading `cap=N/Mcpu` note
implying the host CPU count throttled the batch.

**Fix:** derive `capped` from the CPU/explicit cap only —
`Math.min(requested, cpuCap) < requested` — ignoring the job-count clamp.
`effectiveConcurrency` is unchanged.

## Affected platforms

- [x] All platforms

## Test plan

- Updated the `runPool` test that asserted the old behavior
  (`concurrency: 8` over 2 jobs now expects `capped: false`,
  `effectiveConcurrency: 2`).
- Existing `capByCpuCount` test still passes (a real CPU cap still reports
  `capped: true`).
- `npx vitest run tests/core/server.test.ts -t "runPool"` → 7 passed.
- `npx tsc --noEmit` → clean.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes (runPool suite; full build requires Node >=22.5)
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed — n/a
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch
