### PR TITLE
fix(batch): export NODE_OPTIONS as a statement so compound shell comm…

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1466,7 +1466,12 @@ export function buildBatchNodeOptionsPrefix(shellPath: string, preloadPath: stri
     return `set "NODE_OPTIONS=${option.replace(/"/g, '""')}" && `;
   }
 
-  return `NODE_OPTIONS=${quotePosixSingle(option)} `;
+  // Emit a standalone `export` statement rather than an inline `VAR=val cmd`
+  // assignment: the inline form is only valid before a *simple* command, so it
+  // breaks when the command starts with a compound construct (`if`, `for`,
+  // `(...)`, `{ ...; }`). The `; ` separator mirrors the PowerShell/cmd
+  // branches above and keeps the assignment a separate statement (#925).
+  return `export NODE_OPTIONS=${quotePosixSingle(option)}; `;
 }
 
 /**

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -3355,7 +3355,23 @@ describe("runBatchCommands edge cases", () => {
 
   test("buildBatchNodeOptionsPrefix formats POSIX shell assignment", () => {
     const prefix = buildBatchNodeOptionsPrefix("bash", "/tmp/cm fs'preload.js");
-    expect(prefix).toBe("NODE_OPTIONS='--require /tmp/cm fs'\\''preload.js' ");
+    expect(prefix).toBe("export NODE_OPTIONS='--require /tmp/cm fs'\\''preload.js'; ");
+  });
+
+  test("buildBatchNodeOptionsPrefix stays valid before a POSIX compound command (#925)", () => {
+    // The inline `VAR=val cmd` form breaks before `if`/`for`/`(...)`; a
+    // standalone `export ...; ` statement composes with any command.
+    const prefix = buildBatchNodeOptionsPrefix("/bin/bash", "/tmp/preload.js");
+    for (const command of [
+      "if command -v example-tool >/dev/null; then example-tool --version; fi",
+      "for x in /tmp/example/*; do [ -x \"$x\" ] && \"$x\" --version; done",
+      '(printf "one\\n"; printf "two\\n") | sed -n "1,10p"',
+    ]) {
+      const script = `${prefix}${command}`;
+      expect(script.startsWith("export NODE_OPTIONS='--require /tmp/preload.js'; ")).toBe(true);
+      // No bare `VAR=val <keyword>` left that a POSIX shell would reject.
+      expect(script).not.toMatch(/^NODE_OPTIONS=\S+ (if|for|while|case|\(|\{)/);
+    }
   });
 
   test("buildBatchNodeOptionsPrefix formats PowerShell assignment", () => {


### PR DESCRIPTION
…ands work (#925)

The POSIX branch of buildBatchNodeOptionsPrefix emitted an inline `NODE_OPTIONS='...' <command>` assignment. That form is only valid before a *simple* command, so any batch command starting with a compound construct (`if`, `for`, `while`, a `(...)` subshell, or a `{ ...; }` group) was rewritten into invalid shell and failed with `syntax error near unexpected token`. The failed run was then indexed, surfacing the syntax error instead of the intended output.

Emit a standalone `export NODE_OPTIONS='...'; ` statement instead. This mirrors the PowerShell (`$env:...; `) and cmd (`set "..." && `) branches, which already use a separate statement, and composes with any following command. As a bonus the exported value now also reaches `node` invocations *inside* compound constructs (e.g. a `for` loop body), which the inline form could not do.

Updates the POSIX prefix test and adds real-compound-command coverage.

## What / Why / How

<!-- Brief: what changed, why, and implementation approach. Link issue: Fixes #000 -->

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

<!-- What tests were added or modified? -->

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
