### PR TITLE
fix(batch): export NODE_OPTIONS as a statement so compound shell commands work (#925)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1466,7 +1466,12 @@ export function buildBatchNodeOptionsPrefix(shellPath: string, preloadPath: stri
     return `set "NODE_OPTIONS=${option.replace(/"/g, '""')}" && `;
   }
 
-  return `NODE_OPTIONS=${quotePosixSingle(option)} `;
+  // Emit a standalone `export` statement rather than an inline `VAR=val cmd`
+  // assignment: the inline form is only valid before a *simple* command, so it
+  // breaks when the command starts with a compound construct (`if`, `for`,
+  // `(...)`, `{ ...; }`). The `; ` separator mirrors the PowerShell/cmd
+  // branches above and keeps the assignment a separate statement (#925).
+  return `export NODE_OPTIONS=${quotePosixSingle(option)}; `;
 }
 
 /**

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -3355,7 +3355,23 @@ describe("runBatchCommands edge cases", () => {
 
   test("buildBatchNodeOptionsPrefix formats POSIX shell assignment", () => {
     const prefix = buildBatchNodeOptionsPrefix("bash", "/tmp/cm fs'preload.js");
-    expect(prefix).toBe("NODE_OPTIONS='--require /tmp/cm fs'\\''preload.js' ");
+    expect(prefix).toBe("export NODE_OPTIONS='--require /tmp/cm fs'\\''preload.js'; ");
+  });
+
+  test("buildBatchNodeOptionsPrefix stays valid before a POSIX compound command (#925)", () => {
+    // The inline `VAR=val cmd` form breaks before `if`/`for`/`(...)`; a
+    // standalone `export ...; ` statement composes with any command.
+    const prefix = buildBatchNodeOptionsPrefix("/bin/bash", "/tmp/preload.js");
+    for (const command of [
+      "if command -v example-tool >/dev/null; then example-tool --version; fi",
+      "for x in /tmp/example/*; do [ -x \"$x\" ] && \"$x\" --version; done",
+      '(printf "one\\n"; printf "two\\n") | sed -n "1,10p"',
+    ]) {
+      const script = `${prefix}${command}`;
+      expect(script.startsWith("export NODE_OPTIONS='--require /tmp/preload.js'; ")).toBe(true);
+      // No bare `VAR=val <keyword>` left that a POSIX shell would reject.
+      expect(script).not.toMatch(/^NODE_OPTIONS=\S+ (if|for|while|case|\(|\{)/);
+    }
   });
 
   test("buildBatchNodeOptionsPrefix formats PowerShell assignment", () => {


### PR DESCRIPTION
## What / Why / How

Fixes #925.

Batch shell commands that start with a compound construct (`if`, `for`,
`while`, a `(...)` subshell, or a `{ ...; }` group) failed with
`syntax error near unexpected token`. The failed run was then indexed, so
`ctx_search` surfaced the syntax error instead of the intended output.

Root cause: the POSIX branch of `buildBatchNodeOptionsPrefix` emitted an inline
`NODE_OPTIONS='...' <command>` assignment. That form is only valid before a
*simple* command, so prefixing `if ...`/`for ...`/`(...)` produced invalid
shell.

**Fix:** emit a standalone `export NODE_OPTIONS='...'; ` statement instead. This
mirrors the PowerShell (`$env:...; `) and cmd (`set "..." && `) branches, which
already use a separate statement, and composes with any following command. As a
bonus, the exported value now also reaches `node` invocations *inside* compound
constructs (e.g. a `for` loop body), which the inline form could not do.

## Affected platforms

- [x] All platforms

## Test plan

- Real-shell verification: the old `NODE_OPTIONS='...' if ...; then ...; fi`
  errors at `then`; the new `export NODE_OPTIONS='...'; if ...` runs, as do
  `for` loops and `(...) | sed` subshell pipes. Confirmed `export` propagates
  `NODE_OPTIONS` to child `node` processes.
- Updated the POSIX prefix unit test and added coverage asserting the prefix
  composes with the three compound examples from the issue.
- `npx vitest run tests/core/server.test.ts -t "buildBatchNodeOptionsPrefix"`
  → 4 passed; `runBatchCommands` suite → 25 passed.
- `npx tsc --noEmit` → clean.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes (server suite; full build requires Node >=22.5)
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed — n/a
- [x] No Windows path regressions (Windows/PowerShell/cmd branches unchanged)
- [x] Targets `next` branch
