### PR TITLE
fix(hooks): exit explicitly after writing the response (Windows orphan leak)

### DIFF
--- a/hooks/codex/posttooluse.mjs
+++ b/hooks/codex/posttooluse.mjs
@@ -6,7 +6,7 @@ import "../ensure-deps.mjs";
  * Codex CLI postToolUse hook — session event capture.
  */
 
-import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, CODEX_OPTS } from "../session-helpers.mjs";
+import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, flushAndExit, CODEX_OPTS } from "../session-helpers.mjs";
 import { createSessionLoaders, attributeAndInsertEvents } from "../session-loaders.mjs";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -61,6 +61,6 @@ try {
 }
 
 // Codex PostToolUse requires hookEventName in hookSpecificOutput
-process.stdout.write(JSON.stringify({
+flushAndExit({
   hookSpecificOutput: { hookEventName: "PostToolUse", additionalContext: "" },
-}) + "\n");
+});

--- a/hooks/codex/precompact.mjs
+++ b/hooks/codex/precompact.mjs
@@ -13,6 +13,7 @@ import {
   getSessionDBPath,
   getInputProjectDir,
   resolveConfigDir,
+  flushAndExit,
   CODEX_OPTS,
 } from "../session-helpers.mjs";
 import { createSessionLoaders } from "../session-loaders.mjs";
@@ -67,4 +68,4 @@ try {
 }
 
 // Codex PreCompact accepts universal hook fields only; no hookSpecificOutput.
-process.stdout.write(JSON.stringify({}) + "\n");
+flushAndExit({});

--- a/hooks/codex/pretooluse.mjs
+++ b/hooks/codex/pretooluse.mjs
@@ -13,7 +13,7 @@ import "../suppress-stderr.mjs";
 
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readStdin, parseStdin, getInputProjectDir, getSessionId, CODEX_OPTS } from "../session-helpers.mjs";
+import { readStdin, parseStdin, getInputProjectDir, getSessionId, flushAndExit, CODEX_OPTS } from "../session-helpers.mjs";
 import { routePreToolUse, initSecurity } from "../core/routing.mjs";
 import { formatDecision } from "../core/formatters.mjs";
 import { codexSupportsUpdatedInput } from "../core/codex-caps.mjs";
@@ -39,4 +39,4 @@ const response = formatDecision(
 const output = response ?? {
   hookSpecificOutput: { hookEventName: "PreToolUse" },
 };
-process.stdout.write(JSON.stringify(output) + "\n");
+flushAndExit(output);

--- a/hooks/codex/sessionstart.mjs
+++ b/hooks/codex/sessionstart.mjs
@@ -25,6 +25,7 @@ import {
   getCleanupFlagPath,
   getInputProjectDir,
   resolveConfigDir,
+  flushAndExit,
   CODEX_OPTS,
 } from "../session-helpers.mjs";
 import { createSessionLoaders } from "../session-loaders.mjs";
@@ -116,6 +117,6 @@ try {
 }
 
 // Codex SessionStart requires hookEventName in hookSpecificOutput
-process.stdout.write(JSON.stringify({
+flushAndExit({
   hookSpecificOutput: { hookEventName: "SessionStart", additionalContext },
-}) + "\n");
+});

--- a/hooks/codex/stop.mjs
+++ b/hooks/codex/stop.mjs
@@ -10,7 +10,7 @@ import "../ensure-deps.mjs";
  * lifecycle events on platforms that expose one.
  */
 
-import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, CODEX_OPTS } from "../session-helpers.mjs";
+import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, flushAndExit, CODEX_OPTS } from "../session-helpers.mjs";
 import { createSessionLoaders, attributeAndInsertEvents } from "../session-loaders.mjs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -135,4 +135,4 @@ try {
   // Codex hooks must not block the session.
 }
 
-process.stdout.write("{}\n");
+flushAndExit("{}\n");

--- a/hooks/codex/userpromptsubmit.mjs
+++ b/hooks/codex/userpromptsubmit.mjs
@@ -6,7 +6,7 @@ import "../ensure-deps.mjs";
  * Codex CLI UserPromptSubmit hook — capture user prompts for continuity.
  */
 
-import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, CODEX_OPTS } from "../session-helpers.mjs";
+import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, flushAndExit, CODEX_OPTS } from "../session-helpers.mjs";
 import { createSessionLoaders, attributeAndInsertEvents } from "../session-loaders.mjs";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -70,6 +70,6 @@ try {
   // Codex hooks must not block the session.
 }
 
-process.stdout.write(JSON.stringify({
+flushAndExit({
   hookSpecificOutput: { hookEventName: "UserPromptSubmit", additionalContext: "" },
-}) + "\n");
+});

--- a/hooks/run-hook.mjs
+++ b/hooks/run-hook.mjs
@@ -92,4 +92,10 @@ export async function runHook(handler) {
     logError(e);
     process.exit(0);
   }
+
+  // Same #22999 safety net as session-helpers.mjs::flushAndExit, inlined here
+  // to keep this wrapper dependency-free (see the header note). The handler has
+  // already written its payload; an empty write's callback fires only once the
+  // queue ahead of it has flushed, so nothing is truncated.
+  process.stdout.write("", () => process.exit(0));
 }

--- a/hooks/session-helpers.mjs
+++ b/hooks/session-helpers.mjs
@@ -426,3 +426,31 @@ export function getSessionEventsPath(opts = CLAUDE_OPTS, projectDirOverride) {
 export function getCleanupFlagPath(opts = CLAUDE_OPTS, projectDirOverride) {
   return _resolveProjectFile(opts, projectDirOverride, ".cleanup");
 }
+
+/**
+ * Write the hook's response, then exit explicitly.
+ *
+ * On Windows, node intermittently fails to release the stdin handle
+ * (nodejs/node#22999 — "50% exit, 50% don't"), so the event loop never drains
+ * and the hook process outlives its parent. Windows does not reap orphaned
+ * children, so they accumulate: a four-day-old install was found holding six
+ * leaked hook processes. PR #719 documented the symptom ("orphaned hook
+ * subprocesses accumulate") but shipped no exit() safety net. This is that net;
+ * unref()/destroy() are unreliable on Windows for the same reason (#22999).
+ *
+ * The exit fires from the write callback, never before it: this payload IS the
+ * hook's decision, and process.exit() may truncate a pipe that has not flushed.
+ * A dropped `permissionDecision: "deny"` would be a silent security regression.
+ *
+ * IMPORTANT: this queues the write and RETURNS — the exit happens later, from
+ * the callback. Call it as the last statement on the path. Any code after it
+ * still runs, and a `process.exit()` there would truncate the very payload this
+ * function exists to protect. Paths that write nothing must exit on their own.
+ *
+ * @param {object|string} payload  Object is JSON-serialized with a trailing newline.
+ * @param {number} [code=0]
+ */
+export function flushAndExit(payload, code = 0) {
+  const chunk = typeof payload === "string" ? payload : JSON.stringify(payload) + "\n";
+  process.stdout.write(chunk, () => process.exit(code));
+}


### PR DESCRIPTION
# fix(hooks): exit explicitly after writing the response (Windows orphan leak)

## Problem

On Windows, context-mode hook processes outlive their parent and accumulate.

Measured on one machine (Windows 11, node v22.19.0, codex-cli 0.143.0, context-mode 1.0.169):

| leaked process | age when found |
|---|---|
| `hooks/codex/*` × 3, plus their shell parents × 3 | **4 days** |
| `context-mode statusline` (`cli.bundle.mjs`) | 1 day |
| MCP server (`mcp/server.bundle.mjs`) | 4 days |

528 MB held. Nothing reaps them; killing them by hand was the only recourse.

## Root cause

Three things compose:

1. **[nodejs/node#22999](https://github.com/nodejs/node/issues/22999)** — on Windows, releasing `process.stdin`'s handle is a race. The reporter measured *"50% exit, 50% don't."* `unref()` and listener removal are both reported ineffective; the workaround the thread converges on is an explicit `process.exit()`.
2. **No entry point calls `process.exit()` on its success path.** `runHook` calls it from `uncaughtException`, `unhandledRejection`, and the handler-throw path — never after a clean `await handler()`. The six `hooks/codex/*` entry points don't use `runHook` at all: they `await` at top level and write directly.
3. **Windows does not reap orphaned children.** Once a hook outlives its parent, it stays forever.

`readStdin()`'s `cleanup()` already calls `pause()` + `destroy()`. That isn't enough — `process._getActiveHandles()` still lists the stdin `Socket` well after cleanup has run.

This is the symptom #719 named (*"orphaned hook subprocesses accumulate"*) without shipping the safety net.

## Fix

- `hooks/session-helpers.mjs` — new `flushAndExit(payload, code = 0)`.
- `hooks/run-hook.mjs` — exit once the handler resolves. Inlined rather than imported, honouring this wrapper's own dependency-free contract.
- `hooks/codex/*.mjs` (6 entry points) — final write routed through `flushAndExit`.

**Why the write callback rather than a bare `process.exit()`:** the payload *is* the hook's decision. `process.exit()` can truncate a pipe that hasn't flushed, and a dropped `permissionDecision: "deny"` would be a silent security regression. The exit fires from the write callback, never before it.

**One sharp edge, documented on the function:** `flushAndExit` queues the write and *returns* — the exit happens later, from the callback. It must therefore be the last statement on its path. All six codex entry points satisfy this (top-level, last statement, outside `try`). Paths that write nothing have to exit on their own.

## Verification

- **stdout is byte-identical** before/after for every touched entry point.
- 4 KB and 100 KB payloads flush intact through a pipe before exit (the truncation path, checked explicitly).
- `npm run assert-bundle` and `npm run assert-asymmetric-drift` both pass.
- `node --check` on all 8 changed files.

Honest limitation: I could not reproduce the *hook* variant locally. MSYS bash pipes differ from Codex Desktop's Windows anonymous pipes, and #22999 is a race — 0 hangs in 100 trials under bash. What I did catch live is a `statusline` orphan (parent dead, CPU 0 s, 1 thread), which shares the mechanism exactly.

## Scope, and why it stops here

The nine other adapters — `cursor`, `gemini-cli`, `copilot-cli`, `kimi`, `kiro`, `qwen-code`, `antigravity-cli`, `jetbrains-copilot`, `vscode-copilot` — also run outside `runHook` and share the exposure. I deliberately did **not** extend the fix to them, for reasons worth stating:

- Five of them guard the write behind `if (response !== null)` inside a **fail-open `try/catch`** (*"Fail OPEN. Empty stdout + exit 0 lets the agent continue the tool call"*). Fixing those means adding an exit to the **no-write path** too — i.e. touching security-decision control flow.
- `kiro/pretooluse.mjs` already calls `process.exit()`, so it doesn't leak. It writes immediately before exiting, so it has the *truncation* bug instead — a different fix.
- I have no cursor / gemini / kimi runtime to exercise any of it. Shipping 16 more untested files through fail-open paths seemed worse than shipping the six I could verify byte-for-byte.

Happy to do the uniform rollout in a follow-up, or to leave it to you if you'd rather own the shape. The `statusline` path in `cli.bundle.mjs` is a third surface (it leaked here too) and is untouched.

Related: #719, #862, #854, [nodejs/node#22999](https://github.com/nodejs/node/issues/22999)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
