### PR TITLE
feat: add ctx_forget for per-source knowledge-base eviction

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Restart Claude Code (or run `/reload-plugins`).
 
 All checks should show `[x]`. The doctor validates runtimes, hooks, FTS5, and plugin registration.
 
-**Routing:** Automatic. The SessionStart hook injects routing instructions at runtime — no file is written to your project. The plugin registers all hooks (PreToolUse, PostToolUse, UserPromptSubmit, PreCompact, SessionStart, Stop) and 11 MCP tools — six sandbox tools (`ctx_batch_execute`, `ctx_execute`, `ctx_execute_file`, `ctx_index`, `ctx_search`, `ctx_fetch_and_index`) plus five meta-tools (`ctx_stats`, `ctx_doctor`, `ctx_upgrade`, `ctx_purge`, `ctx_insight`).
+**Routing:** Automatic. The SessionStart hook injects routing instructions at runtime — no file is written to your project. The plugin registers all hooks (PreToolUse, PostToolUse, UserPromptSubmit, PreCompact, SessionStart, Stop) and 12 MCP tools — six sandbox tools (`ctx_batch_execute`, `ctx_execute`, `ctx_execute_file`, `ctx_index`, `ctx_search`, `ctx_fetch_and_index`) plus six meta-tools (`ctx_stats`, `ctx_doctor`, `ctx_upgrade`, `ctx_purge`, `ctx_forget`, `ctx_insight`).
 
 | Slash Command | What it does |
 |---|---|
@@ -1172,6 +1172,7 @@ npm install -g context-mode
 | `ctx_doctor` | Diagnose installation: runtimes, hooks, FTS5, versions. | — |
 | `ctx_upgrade` | Upgrade to latest version from GitHub, rebuild, reconfigure hooks. | — |
 | `ctx_purge` | Permanently deletes all indexed content from the knowledge base. | — |
+| `ctx_forget` | Delete one indexed source by label, or list indexed sources. Narrower than ctx_purge. | — |
 
 ## How the Sandbox Works
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4844,6 +4844,88 @@ server.registerTool(
   },
 );
 
+// Deletes one indexed source's chunks: destructive, but forgetting a missing
+// source is a no-op (idempotent). No network.
+server.registerTool(
+  "ctx_forget",
+  {
+    title: "Forget Indexed Source",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    description: `Delete one indexed source from the knowledge base by label, or list indexed source labels. Narrower than ctx_purge.
+
+WHEN:
+  - You indexed a source (ctx_index / ctx_fetch_and_index) and want to remove just that one, e.g. before re-indexing a cleaner version.
+  - You want to see which source labels are currently indexed.
+
+WHEN NOT:
+  - You want to clear a whole session or the entire project -> use ctx_purge.
+  - You are re-indexing the same source label -> ctx_index already replaces it atomically, so forgetting first is unnecessary.
+
+RETURNS:
+  With no source: the indexed source labels and their chunk counts. With source + confirm:true: the number of chunks removed. With a source but no confirm: a cancelled notice.
+
+EXAMPLE: ctx_forget()
+EXAMPLE: ctx_forget(source: "react-useeffect-docs", confirm: true)`,
+    inputSchema: z.object({
+      source: z.string().optional().describe(
+        "Label of the source to delete (the `source` passed to ctx_index). Omit to list all indexed source labels."
+      ),
+      confirm: z.preprocess(coerceBoolean, z.boolean()).optional().describe(
+        "MUST be true to delete. Omitted/false with a source returns 'cancelled'; not needed when listing."
+      ),
+    }),
+  },
+  async ({ source, confirm }) => {
+    const store = getStore();
+
+    const listText = (): string => {
+      const sources = store.listSources();
+      if (sources.length === 0) return "No indexed sources in this project's knowledge base.";
+      const lines = sources.map(
+        (s) => `  - ${s.label} (${s.chunkCount} chunk${s.chunkCount === 1 ? "" : "s"})`,
+      );
+      return `Indexed sources (${sources.length}):\n${lines.join("\n")}`;
+    };
+
+    if (!source) {
+      return trackResponse("ctx_forget", {
+        content: [{ type: "text" as const, text: listText() }],
+      });
+    }
+
+    if (!confirm) {
+      return trackResponse("ctx_forget", {
+        content: [{
+          type: "text" as const,
+          text: `Cancelled. Pass confirm: true to delete source '${source}'.`,
+        }],
+      });
+    }
+
+    const { existed, deletedChunks } = store.deleteSource(source);
+    if (!existed) {
+      return trackResponse("ctx_forget", {
+        content: [{
+          type: "text" as const,
+          text: `No such source: '${source}'.\n\n${listText()}`,
+        }],
+        isError: true,
+      });
+    }
+    return trackResponse("ctx_forget", {
+      content: [{
+        type: "text" as const,
+        text: `Forgot source '${source}': removed ${deletedChunks} chunk${deletedChunks === 1 ? "" : "s"}.`,
+      }],
+    });
+  },
+);
+
 // ─────────────────────────────────────────────────────────
 // Server startup
 // ─────────────────────────────────────────────────────────

--- a/src/store.ts
+++ b/src/store.ts
@@ -1473,6 +1473,20 @@ export class ContentStore {
     }>;
   }
 
+  deleteSource(label: string): { existed: boolean; deletedChunks: number } {
+    const meta = this.getSourceMeta(label);
+    const deletedChunks = meta?.chunkCount ?? 0;
+    withRetry(() => {
+      const tx = this.#db.transaction(() => {
+        this.#stmtDeleteChunksByLabel.run(label);
+        this.#stmtDeleteChunksTrigramByLabel.run(label);
+        this.#stmtDeleteSourcesByLabel.run(label);
+      });
+      tx();
+    });
+    return { existed: meta !== null, deletedChunks };
+  }
+
   /**
    * Aggregate snapshot of the persistent content store. Returns total
    * chunk count, source count, and the most recent indexed_at timestamp.

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -6683,6 +6683,7 @@ describe("ctx_* MCP tool annotations (#846)", () => {
     ctx_doctor:          { readOnlyHint: true,  destructiveHint: false, idempotentHint: true,  openWorldHint: false },
     ctx_upgrade:         { readOnlyHint: false, destructiveHint: false, idempotentHint: true,  openWorldHint: false },
     ctx_purge:           { readOnlyHint: false, destructiveHint: true,  idempotentHint: true,  openWorldHint: false },
+    ctx_forget:          { readOnlyHint: false, destructiveHint: true,  idempotentHint: true,  openWorldHint: false },
     ctx_insight:         { readOnlyHint: false, destructiveHint: false, idempotentHint: true,  openWorldHint: true  },
   };
   const tools = REGISTERED_CTX_TOOLS as Array<{ name: string; config: { annotations?: Hints } }>;

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -94,6 +94,7 @@ describe("ContextModePlugin", () => {
         "ctx_execute",
         "ctx_execute_file",
         "ctx_fetch_and_index",
+        "ctx_forget",
         "ctx_index",
         "ctx_insight",
         "ctx_purge",

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -104,6 +104,69 @@ describe("ContextModePlugin", () => {
       ]);
     });
 
+    describe("ctx_forget handler branches", () => {
+      const ctx = (projectDir: string) => ({
+        sessionID: "ctx-forget-sess",
+        messageID: "ctx-forget-msg",
+        agent: "test-agent",
+        directory: projectDir,
+        worktree: projectDir,
+        abort: new AbortController().signal,
+        metadata: () => {},
+        ask: (() => ({}) as any) as any,
+      });
+      const textOf = (r: unknown) =>
+        typeof r === "string" ? r : ((r as { output?: string }).output ?? "");
+
+      it("lists, cancels without confirm, deletes with confirm, and reports unknown labels", async () => {
+        const projectDir = join(tempDir, "ctx-forget-branches");
+        const plugin = await createTestPlugin(projectDir);
+
+        // Empty knowledge base: list mode reports nothing indexed.
+        expect(textOf(await plugin.tool!.ctx_forget.execute({}, ctx(projectDir)))).toContain(
+          "No indexed sources",
+        );
+
+        // Seed one source; list mode now surfaces its label.
+        await plugin.tool!.ctx_index.execute(
+          { content: "# Doc\n\nForget me later.", source: "to-forget" },
+          ctx(projectDir),
+        );
+        expect(textOf(await plugin.tool!.ctx_forget.execute({}, ctx(projectDir)))).toContain(
+          "to-forget",
+        );
+
+        // A source without confirm is a no-op cancel.
+        expect(
+          textOf(await plugin.tool!.ctx_forget.execute({ source: "to-forget" }, ctx(projectDir))),
+        ).toContain("Cancelled");
+
+        // An unknown label is an error (opencode maps the isError response to a
+        // throw) whose message lists what exists.
+        await expect(
+          plugin.tool!.ctx_forget.execute(
+            { source: "never-indexed", confirm: true },
+            ctx(projectDir),
+          ),
+        ).rejects.toThrow(/No such source[\s\S]*to-forget/);
+
+        // Confirm deletes and reports the removed chunk count.
+        expect(
+          textOf(
+            await plugin.tool!.ctx_forget.execute(
+              { source: "to-forget", confirm: true },
+              ctx(projectDir),
+            ),
+          ),
+        ).toMatch(/Forgot source 'to-forget': removed \d+ chunk/);
+
+        // The source is gone from the listing afterward.
+        expect(textOf(await plugin.tool!.ctx_forget.execute({}, ctx(projectDir)))).toContain(
+          "No indexed sources",
+        );
+      });
+    });
+
     // Both KiloCode and recent OpenCode (≥ ~1.14.x) bundle Zod v4 in their
     // bun-compiled host runtime. Pre-fix, raw Zod v3 schemas crashed the host
     // on first message with `TypeError: undefined is not an object

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -522,6 +522,43 @@ describe("BM25 Search", () => {
   });
 });
 
+describe("Source Deletion (deleteSource / ctx_forget)", () => {
+  test("deletes a source and reports the chunk count", () => {
+    const store = createStore();
+    store.index({ content: "# Doc\n\nForget me later.", source: "to-forget" });
+    assert.ok(store.search("forget", 1).length > 0);
+
+    const { existed, deletedChunks } = store.deleteSource("to-forget");
+    assert.equal(existed, true);
+    assert.ok(deletedChunks > 0);
+
+    assert.equal(store.search("forget", 1).length, 0);
+    assert.ok(!store.listSources().some((s) => s.label === "to-forget"));
+    store.close();
+  });
+
+  test("returns existed:false with zero chunks for an unknown label", () => {
+    const store = createStore();
+    const { existed, deletedChunks } = store.deleteSource("never-indexed");
+    assert.equal(existed, false);
+    assert.equal(deletedChunks, 0);
+    store.close();
+  });
+
+  test("leaves sibling sources intact", () => {
+    const store = createStore();
+    store.index({ content: "# Keep\n\nApple pie recipe.", source: "keep" });
+    store.index({ content: "# Drop\n\nBanana bread recipe.", source: "drop" });
+
+    store.deleteSource("drop");
+
+    assert.ok(store.search("apple", 1).length > 0);
+    assert.equal(store.search("banana", 1).length, 0);
+    assert.ok(store.listSources().some((s) => s.label === "keep"));
+    store.close();
+  });
+});
+
 describe("Multi-Source Indexing", () => {
   test("search across multiple indexed sources", () => {
     const store = createStore();


### PR DESCRIPTION
### Summary

Adds `ctx_forget`, a tool to evict a single indexed source from the project knowledge base by label, or to list current source labels. Fills the gap between "keep everything" and `ctx_purge`'s session/project-wide wipe.

### Motivation

`ctx_purge` only clears a whole session or the entire project. There is no surgical way to drop one indexed source (e.g. to re-index a cleaner version of a single doc). This is distinct from the session-scoped purge in #520.

### Design

- New `ctx_forget` tool rather than a `source` param on `ctx_purge`, for discoverability and a clean read-only list mode. Open to folding it into `ctx_purge` if preferred.
- `ContentStore.deleteSource(label)` reuses the existing dedup-by-label delete statements inside a `withRetry` transaction; returns `{ existed, deletedChunks }`.

### API

- `ctx_forget()` -> lists indexed source labels + chunk counts (read-only).
- `ctx_forget(source)` without `confirm:true` -> cancelled, nothing deleted.
- `ctx_forget(source, confirm:true)` -> deletes that source's chunks; an unknown label returns the available labels.

### Tests

- `tests/store.test.ts`: delete + verify removal, unknown label -> `existed:false`, sibling sources unaffected.
- `tests/core/server.test.ts`: `ctx_forget` added to the annotations contract map (`destructiveHint:true, idempotentHint:true, readOnlyHint:false, openWorldHint:false`).
- `tests/opencode-plugin.test.ts`: `ctx_forget` in the native plugin tool map (#574).
- Description conforms to ADR-0002 (`WHEN / WHEN NOT / RETURNS / EXAMPLE`).

### Docs

- README tool table row + registered-tool count updated (11 -> 12).

### Notes

- Reliable source-keyed deletes interact with label consistency (#914).
