### PR TITLE
fix(routing): let claude.ai Artifact URLs pass through WebFetch (#938)

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -641,6 +641,26 @@ function getWebFetchUrl(toolInput) {
   return "";
 }
 
+// claude.ai Artifact pages (#938) are a client-rendered SPA shell gated
+// behind the caller's authenticated claude.ai session. Native WebFetch has
+// a documented exception for these URLs — it fetches them using that
+// session — while ctx_fetch_and_index does a bare unauthenticated fetch and
+// can only ever retrieve the empty shell (~0.1KB, no real content). Parsed
+// via the URL constructor (not a substring/regex check on the raw string)
+// so a lookalike host like claude.ai.evil.com can't slip through.
+function isClaudeArtifactUrl(url) {
+  if (typeof url !== "string" || url === "") return false;
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  if (parsed.hostname !== "claude.ai" && parsed.hostname !== "preview.claude.ai") return false;
+  return parsed.pathname.startsWith("/code/artifact/");
+}
+
 function getCodexConfigDir(env = process.env) {
   const codexHome = env.CODEX_HOME;
   if (codexHome && codexHome.trim() !== "") return resolve(codexHome);
@@ -874,6 +894,10 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
   // ─── WebFetch: deny + redirect to sandbox ───
   if (canonical === "WebFetch") {
     const url = getWebFetchUrl(toolInput);
+    // Let claude.ai Artifact URLs through untouched — see isClaudeArtifactUrl (#938).
+    if (isClaudeArtifactUrl(url)) {
+      return null;
+    }
     return mcpRedirect({
       action: "deny",
       reason: `context-mode: WebFetch redirected. Call ${t("ctx_fetch_and_index")}(url: "${url}", source: "...") to fetch + index the page, then ${t("ctx_search")}(queries: [...]) to query the indexed content — the raw page bytes stay in storage instead of entering your conversation. Or call ${t("ctx_execute")}(language, code) when you want to derive your answer in one round trip (parse, extract, count) without persisting the response. Both have full network access. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH).`,

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -395,6 +395,43 @@ describe("routePreToolUse", () => {
       expect(result!.reason).toContain(url);
     });
 
+    it("passes claude.ai Artifact URLs through untouched (#938)", () => {
+      const url = "https://claude.ai/code/artifact/51de1b8d-61cb-488e-a964-547ef217f5e9";
+      const result = routePreToolUse("WebFetch", { url });
+      // Native WebFetch fetches these using the caller's authenticated
+      // claude.ai session; ctx_fetch_and_index cannot (no session cookies)
+      // and would only ever get back the empty SPA shell.
+      expect(result).toBeNull();
+    });
+
+    it("passes preview.claude.ai Artifact URLs through untouched (#938)", () => {
+      const url = "https://preview.claude.ai/code/artifact/51de1b8d-61cb-488e-a964-547ef217f5e9";
+      const result = routePreToolUse("WebFetch", { url });
+      expect(result).toBeNull();
+    });
+
+    it("still redirects non-artifact claude.ai URLs (#938)", () => {
+      const result = routePreToolUse("WebFetch", { url: "https://claude.ai/settings" });
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("deny");
+    });
+
+    it("still redirects a lookalike host, not just a substring match (#938)", () => {
+      const result = routePreToolUse("WebFetch", {
+        url: "https://claude.ai.evil.com/code/artifact/51de1b8d-61cb-488e-a964-547ef217f5e9",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("deny");
+    });
+
+    it("still redirects a plain-http claude.ai Artifact URL (#938)", () => {
+      const result = routePreToolUse("WebFetch", {
+        url: "http://claude.ai/code/artifact/51de1b8d-61cb-488e-a964-547ef217f5e9",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("deny");
+    });
+
     it("treats agy read_url_content URL payloads as WebFetch", () => {
       const url = "https://example.com/docs";
       const result = routePreToolUse(


### PR DESCRIPTION
## What / Why / How

Fixes #938.

**What:** The `WebFetch` PreToolUse hook (`hooks/core/routing.mjs`) unconditionally denied and redirected every `WebFetch` call to `ctx_fetch_and_index`, with no exception for `claude.ai/code/artifact/{uuid}` URLs.

**Why:** Artifact pages are a client-rendered SPA shell gated behind the caller's authenticated claude.ai session. Native `WebFetch` has a documented exception for these URLs — it fetches them using that session — while `ctx_fetch_and_index` does a bare unauthenticated fetch and can only ever retrieve the empty shell (~0.1KB, no real content, confirmed via the repro in #938). So the redirect here isn't just overhead like #817 — it makes the tool call strictly worse than useless: the agent gets back a plausible-looking but permanently empty page with no signal that it's empty-by-design vs. a genuinely empty artifact.

**How:** Added `isClaudeArtifactUrl(url)`, parsed via the `URL` constructor rather than a substring/regex check on the raw string (so a lookalike host like `claude.ai.evil.com` can't slip through), and let `WebFetch` pass through untouched (`return null`) for `claude.ai` / `preview.claude.ai` `/code/artifact/` URLs specifically, before the existing deny+redirect logic. Every other URL — including other `claude.ai` paths — keeps redirecting exactly as before; verified with `git diff` scoped to just these two lines of new branching logic.

## Affected platforms

- [x] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

(`WebFetch` is Claude Code's native tool name; this hook path is specific to that adapter's tool surface.)

## Test plan

Added 5 new cases to the existing `describe("WebFetch tool", ...)` block in `tests/hooks/core-routing.test.ts`:
- `claude.ai/code/artifact/...` passes through untouched (`result === null`)
- `preview.claude.ai/code/artifact/...` passes through untouched
- a non-artifact `claude.ai` URL (e.g. `/settings`) still redirects
- a lookalike host (`claude.ai.evil.com/code/artifact/...`) still redirects — regression guard on the URL-parsing approach
- a plain-`http://` artifact URL still redirects (the exception is HTTPS-only)

Ran locally: full suite `npx vitest run` → 4718 passed, 0 failed, 29 skipped (no regressions). `npx tsc --noEmit` → no errors.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md) — n/a, this is an internal routing exception, not user-facing config
- [x] No Windows path regressions (forward slashes only) — change is pure URL parsing, no filesystem paths touched
- [x] Targets `next` branch (unless hotfix)