### PR TITLE
docs(codex): make JavaScript the default ctx_execute runtime

### DIFF
--- a/configs/codex/AGENTS.md
+++ b/configs/codex/AGENTS.md
@@ -4,7 +4,7 @@ context-mode MCP tools available. Rules protect context window from flooding. On
 
 ## Think in Code — MANDATORY
 
-Analyze/count/filter/compare/search/parse/transform data: **write code** via `ctx_execute(language, code)`, `console.log()` only the answer. Do NOT read raw data into context. PROGRAM the analysis, not COMPUTE it. Pure JavaScript — Node.js built-ins only (`fs`, `path`, `child_process`). `try/catch`, handle `null`/`undefined`. One script replaces ten tool calls.
+Analyze/count/filter/compare/search/parse/transform data: **write code** via `ctx_execute(language, code)`, `console.log()` only the answer. Do NOT read raw data into context. PROGRAM the analysis, not COMPUTE it. Use JavaScript by default for sandbox analysis. Use another supported runtime when materially better. Prefer standard libraries. `try/catch`, handle `null`/`undefined`. One script replaces ten tool calls.
 
 ## BLOCKED — do NOT use
 

--- a/tests/adapters/codex.test.ts
+++ b/tests/adapters/codex.test.ts
@@ -303,6 +303,15 @@ describe("CodexAdapter", () => {
       expect(adapter.getSessionDir()).toContain("sessions");
     });
 
+    it("documents JavaScript as the default rather than the exclusive runtime", () => {
+      const instructions = adapter.getRoutingInstructions();
+
+      expect(instructions).toContain("Use JavaScript by default for sandbox analysis.");
+      expect(instructions).toContain("Use another supported runtime when materially better.");
+      expect(instructions).toContain("Prefer standard libraries.");
+      expect(instructions).not.toContain("Pure JavaScript — Node.js built-ins only");
+    });
+
     it("honors CODEX_HOME for settings, hooks, and session paths", () => {
       const savedCodexHome = process.env.CODEX_HOME;
       const codexHome = join(homedir(), "custom-codex-home");


### PR DESCRIPTION
Fixes #941

## What / Why / How

**What**

Change the Codex Think-in-Code guidance from JavaScript-only to JavaScript-by-default:

> Use JavaScript by default for sandbox analysis. Use another supported runtime when materially better. Prefer standard libraries.

**Why**

`ctx_execute` supports multiple runtimes. The shipped instructions should recommend JavaScript as the normal choice without incorrectly prohibiting Python, shell, Go, or other supported runtimes.

**How**

- Replace only the JavaScript-exclusive sentence.
- Preserve the remaining Think-in-Code requirements.
- Test the shipped text through `CodexAdapter.getRoutingInstructions()`.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [x] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

- RED: new routing-instructions regression failed before the wording change.
- GREEN: targeted test passed 1/1.
- Full Codex adapter suite passed 71/71.
- `npm run build` passed all bundle and drift assertions in a disposable worktree.
- `npm test` passed: 210/210 files, 4,714 passed, 29 skipped.
- `npm run typecheck` passed.
- Codex 0.143 `debug prompt-input` confirmed all three new sentences are model-visible and the old exclusivity phrase is absent.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)
