### PR TITLE
feat(codex): load Windows guidance as a platform overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,14 +674,24 @@ The Codex plugin manifest provides MCP via `.codex-plugin/mcp.json`, skills via
    >
    > `PreCompact` support is runtime-gated: it is present in Codex CLI 0.130.0, while the public Codex hooks docs may lag the shipped hook-event list. Older Codex builds that do not emit `PreCompact` will not create pre-compaction snapshots.
 
-4. Copy routing instructions (recommended even with hooks for full routing awareness):
+4. Copy routing instructions (recommended even with hooks for full routing awareness).
+   On macOS and Linux, copy the platform-neutral core instructions:
 
    ```bash
    CM_ROOT="$(npm root -g)/context-mode"
    cp "$CM_ROOT/configs/codex/AGENTS.md" ./AGENTS.md
    ```
 
-   For global use: `CM_ROOT="$(npm root -g)/context-mode"; cp "$CM_ROOT/configs/codex/AGENTS.md" ~/.codex/AGENTS.md`. Global applies to all projects. If both exist, Codex CLI merges them.
+   On Windows, combine the core instructions with the packaged Windows overlay:
+
+   ```bash
+   CM_ROOT="$(npm root -g)/context-mode"
+   cat "$CM_ROOT/configs/codex/AGENTS.md" "$CM_ROOT/configs/codex/AGENTS.windows.md" > ./AGENTS.md
+   ```
+
+   For global use, replace `./AGENTS.md` with `~/.codex/AGENTS.md` in the command for your platform. Global applies to all projects. If both files exist, Codex CLI merges them.
+
+   With hooks enabled, Codex SessionStart appends the Windows overlay at runtime on Windows; macOS and Linux receive only the neutral routing block. This runtime overlay never writes global or project `AGENTS.md` files. If you manually copied an older combined template, refresh it once with the commands above; SessionStart recognizes the legacy Windows block and will not inject a duplicate.
 
 5. Restart Codex CLI.
 
@@ -754,17 +764,20 @@ The Codex plugin manifest provides MCP via `.codex-plugin/mcp.json`, skills via
 
    > **Note:** Kimi Code uses the same JSON stdin/stdout wire protocol as Codex, but accepts `additionalContext`, `updatedInput`, and `permissionDecision: "ask"` in PreToolUse responses (Codex rejects these). The kimi hook normalizes `ContentPart[]` prompt arrays to strings for downstream extractors.
 
-5. (Optional) Copy the routing instructions file for your project:
+5. (Optional) Copy the routing instructions file for your project. On macOS and Linux:
 
    ```bash
    cp "$(npm root -g)/context-mode/configs/codex/AGENTS.md" ./AGENTS.md
    ```
 
-   Or for global use:
+   On Windows, Kimi reuses the Codex instructions, so combine the core file with its Windows overlay:
 
    ```bash
-   CM_ROOT="$(npm root -g)/context-mode"; cp "$CM_ROOT/configs/codex/AGENTS.md" ~/.kimi-code/AGENTS.md
+   CM_ROOT="$(npm root -g)/context-mode"
+   cat "$CM_ROOT/configs/codex/AGENTS.md" "$CM_ROOT/configs/codex/AGENTS.windows.md" > ./AGENTS.md
    ```
+
+   For global use, replace `./AGENTS.md` with `~/.kimi-code/AGENTS.md` in the command for your platform. If you manually copied an older combined template, refresh it once so the platform-neutral core and packaged Windows guidance stay independently updateable.
 
 Full documentation: [`docs/adapters/kimi-code.md`](docs/adapters/kimi-code.md)
 

--- a/configs/codex/AGENTS.md
+++ b/configs/codex/AGENTS.md
@@ -87,13 +87,3 @@ If search returns 0 results, proceed as a fresh session.
 | `ctx purge` | Call `purge` MCP tool with confirm: true. Warns before wiping knowledge base. |
 
 After /clear or /compact: knowledge base and session stats preserved. Use `ctx purge` to start fresh.
-
-## Windows notes
-
-**PowerShell cmdlets** — Sandbox uses bash. PowerShell cmdlets (`Format-List`, `Get-Culture`, etc.) fail with `command not found`. Wrap with `pwsh -NoProfile -Command "..."`.
-
-**Relative paths** — Sandbox CWD is temp dir, not project root. Convert to absolute paths. Ask user to confirm if unknown.
-
-**Windows drive letters** — Sandbox runs Git Bash / MSYS2. `X:\path` → `/x/path` (lowercase, no `/mnt/`). Never emit `/mnt/<letter>/`.
-
-**Quote paths** — Spaces in paths cause splits. Always double-quote: `rg "symbol" "$REPO_ROOT/some dir/Source"`.

--- a/configs/codex/AGENTS.windows.md
+++ b/configs/codex/AGENTS.windows.md
@@ -1,0 +1,9 @@
+## Windows notes
+
+**PowerShell cmdlets** — Sandbox uses bash. PowerShell cmdlets (`Format-List`, `Get-Culture`, etc.) fail with `command not found`. Wrap with `pwsh -NoProfile -Command "..."`.
+
+**Relative paths** — Sandbox CWD is temp dir, not project root. Convert to absolute paths. Ask user to confirm if unknown.
+
+**Windows drive letters** — Sandbox runs Git Bash / MSYS2. `X:\path` → `/x/path` (lowercase, no `/mnt/`). Never emit `/mnt/<letter>/`.
+
+**Quote paths** — Spaces in paths cause splits. Always double-quote: `rg "symbol" "$REPO_ROOT/some dir/Source"`.

--- a/hooks/codex/platform-overlay.mjs
+++ b/hooks/codex/platform-overlay.mjs
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export const WINDOWS_OVERLAY_PATH = fileURLToPath(
+  new URL("../../configs/codex/AGENTS.windows.md", import.meta.url),
+);
+
+function hasLegacyWindowsGuidance(content) {
+  if (typeof content !== "string") return false;
+
+  return /^## Windows notes\s*$/m.test(content)
+    && content.includes("**PowerShell cmdlets**")
+    && content.includes("/mnt/<letter>/");
+}
+
+export function getCodexPlatformOverlay({
+  platform = process.platform,
+  existingInstructionContents = [],
+  overlayPath = WINDOWS_OVERLAY_PATH,
+} = {}) {
+  if (platform !== "win32") return "";
+
+  if (Array.isArray(existingInstructionContents)
+    && existingInstructionContents.some(hasLegacyWindowsGuidance)) {
+    return "";
+  }
+
+  try {
+    return readFileSync(overlayPath, "utf8").trim();
+  } catch {
+    // Platform guidance is additive; never break SessionStart if it is unavailable.
+    return "";
+  }
+}

--- a/hooks/codex/sessionstart.mjs
+++ b/hooks/codex/sessionstart.mjs
@@ -8,6 +8,7 @@ import "../ensure-deps.mjs";
 
 import { createRoutingBlock } from "../routing-block.mjs";
 import { createToolNamer } from "../core/tool-naming.mjs";
+import { getCodexPlatformOverlay } from "./platform-overlay.mjs";
 
 const toolNamer = createToolNamer("codex");
 const ROUTING_BLOCK = createRoutingBlock(toolNamer);
@@ -38,22 +39,31 @@ const OPTS = CODEX_OPTS;
 
 let additionalContext = ROUTING_BLOCK;
 
-function captureCodexInstructionRules(db, sessionId, projectDir) {
+function readCodexInstructionRules(projectDir) {
   const paths = [];
   for (const baseDir of [resolveConfigDir(OPTS), projectDir]) {
     paths.push(join(baseDir, "AGENTS.md"));
     paths.push(join(baseDir, "AGENTS.override.md"));
   }
 
+  const rules = [];
   for (const p of [...new Set(paths)]) {
     try {
       if (!existsSync(p)) continue;
       const content = readFileSync(p, "utf8");
-      db.insertEvent(sessionId, { type: "rule", category: "rule", data: p, priority: 1 });
-      db.insertEvent(sessionId, { type: "rule_content", category: "rule", data: content, priority: 1 });
+      rules.push({ path: p, content });
     } catch {
       // Missing or unreadable rule files should never break SessionStart.
     }
+  }
+
+  return rules;
+}
+
+function captureCodexInstructionRules(db, sessionId, rules) {
+  for (const { path, content } of rules) {
+    db.insertEvent(sessionId, { type: "rule", category: "rule", data: path, priority: 1 });
+    db.insertEvent(sessionId, { type: "rule_content", category: "rule", data: content, priority: 1 });
   }
 }
 
@@ -62,6 +72,11 @@ try {
   const input = parseStdin(raw);
   const source = input.source ?? "startup";
   const projectDir = getInputProjectDir(input, CODEX_OPTS);
+  const instructionRules = readCodexInstructionRules(projectDir);
+  const platformOverlay = getCodexPlatformOverlay({
+    existingInstructionContents: instructionRules.map(({ content }) => content),
+  });
+  if (platformOverlay) additionalContext += `\n\n${platformOverlay}`;
 
   if (source === "compact" || source === "resume") {
     const { SessionDB } = await loadSessionDB();
@@ -106,7 +121,7 @@ try {
 
     const sessionId = getSessionId(input, OPTS);
     db.ensureSession(sessionId, projectDir);
-    captureCodexInstructionRules(db, sessionId, projectDir);
+    captureCodexInstructionRules(db, sessionId, instructionRules);
 
     db.close();
   }

--- a/tests/adapters/codex.test.ts
+++ b/tests/adapters/codex.test.ts
@@ -1103,6 +1103,98 @@ describe("Codex precompact hook script", () => {
 });
 
 describe("Codex sessionstart hook script", () => {
+  const sharedInstructionsPath = resolve(__dirname, "../../configs/codex/AGENTS.md");
+  const windowsOverlayPath = resolve(__dirname, "../../configs/codex/AGENTS.windows.md");
+
+  it("keeps the shared Codex instructions platform-neutral", () => {
+    const instructions = readFileSync(sharedInstructionsPath, "utf8");
+
+    expect(instructions).not.toContain("## Windows notes");
+    expect(instructions).not.toContain("pwsh -NoProfile");
+    expect(instructions).not.toContain("/mnt/<letter>/");
+    expect(instructions).not.toContain("Always double-quote");
+  });
+
+  it("ships all Windows-specific guidance in the platform overlay", () => {
+    const overlay = readFileSync(windowsOverlayPath, "utf8");
+
+    expect(overlay).toContain("## Windows notes");
+    expect(overlay).toContain("**PowerShell cmdlets**");
+    expect(overlay).toContain("**Relative paths**");
+    expect(overlay).toContain("**Windows drive letters**");
+    expect(overlay).toContain("**Quote paths**");
+  });
+
+  it("loads the Windows overlay only for win32", async () => {
+    const { getCodexPlatformOverlay } = await import("../../hooks/codex/platform-overlay.mjs");
+    const overlay = readFileSync(windowsOverlayPath, "utf8").trim();
+
+    for (const platform of ["darwin", "linux", "freebsd"]) {
+      expect(getCodexPlatformOverlay({ platform })).toBe("");
+    }
+
+    const windowsResult = getCodexPlatformOverlay({ platform: "win32" });
+    expect(windowsResult).toBe(overlay);
+    expect(windowsResult.match(/^## Windows notes$/gm)).toHaveLength(1);
+  });
+
+  it("does not duplicate legacy Windows guidance copied into AGENTS.md", async () => {
+    const { getCodexPlatformOverlay } = await import("../../hooks/codex/platform-overlay.mjs");
+    const legacyInstructions = [
+      "# Project instructions",
+      "## Windows notes",
+      "**PowerShell cmdlets** — wrap commands with pwsh.",
+      "**Windows drive letters** — never emit /mnt/<letter>/.",
+    ].join("\r\n");
+
+    expect(getCodexPlatformOverlay({
+      platform: "win32",
+      existingInstructionContents: [legacyInstructions],
+    })).toBe("");
+  });
+
+  it("fails open when the Windows overlay cannot be read", async () => {
+    const { getCodexPlatformOverlay } = await import("../../hooks/codex/platform-overlay.mjs");
+
+    expect(getCodexPlatformOverlay({
+      platform: "win32",
+      overlayPath: join(tmpdir(), "context-mode-missing-windows-overlay.md"),
+    })).toBe("");
+  });
+
+  it("applies the current-platform overlay consistently to every SessionStart source", () => {
+    const hookScript = resolve(__dirname, "../../hooks/codex/sessionstart.mjs");
+    const codexHome = mkdtempSync(join(tmpdir(), "context-mode-codex-overlay-"));
+    const projectDir = join(codexHome, "project");
+
+    mkdirSync(projectDir, { recursive: true });
+
+    try {
+      for (const source of ["startup", "clear", "compact", "resume"]) {
+        const stdout = execFileSync(process.execPath, [hookScript], {
+          input: JSON.stringify({
+            session_id: `test-sessionstart-overlay-${source}`,
+            cwd: projectDir,
+            hook_event_name: "SessionStart",
+            source,
+          }),
+          encoding: "utf-8",
+          timeout: 10000,
+          env: { ...process.env, CODEX_HOME: codexHome },
+        });
+        const parsed = JSON.parse(stdout.trim());
+        const context = parsed.hookSpecificOutput.additionalContext as string;
+        const windowsHeadings = context.match(/^## Windows notes$/gm) ?? [];
+
+        expect(parsed.hookSpecificOutput.hookEventName).toBe("SessionStart");
+        expect(context).toContain("context-mode");
+        expect(windowsHeadings).toHaveLength(process.platform === "win32" ? 1 : 0);
+      }
+    } finally {
+      try { rmSync(codexHome, { recursive: true, force: true }); } catch { /* Windows may release SQLite handles late */ }
+    }
+  });
+
   it("injects a compact resume snapshot before marking it consumed", () => {
     const hookScript = resolve(__dirname, "../../hooks/codex/sessionstart.mjs");
     const codexHome = mkdtempSync(join(tmpdir(), "context-mode-codex-home-"));


### PR DESCRIPTION
## What / Why / How

Fixes #940

### What

- Move Windows-only Codex guidance out of the platform-neutral template and into a packaged `AGENTS.windows.md` overlay.
- Append that overlay to every Codex SessionStart source on Windows without writing user files.
- Update manual-copy documentation for Codex and Kimi users.

### Why

The shared Codex instructions currently send PowerShell, drive-letter, and Windows path guidance to macOS and Linux sessions. Those rules are useful on Windows but irrelevant elsewhere and consume prompt space.

### How

- Load the packaged overlay only for `win32` sessions.
- Suppress duplicate injection when a legacy manually copied `AGENTS.md` already contains the Windows guidance.
- Fail open when the overlay is missing or unreadable.
- Preserve the existing architecture: context-mode does not automatically modify global or project `AGENTS.md` files.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [x] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

- TDD regression: captured failure before adding the platform overlay implementation.
- `npx vitest run tests/adapters/codex.test.ts` — 76/76 tests passed.
- Coverage includes neutral templates, simulated Windows loading, legacy duplicate suppression, missing/unreadable overlays, and all current-platform SessionStart sources.
- `npm run build` — passed, including bundle and asymmetric-drift assertions.
- `env -u CONTEXT_MODE_PLATFORM npm test` — 210/210 files passed; 4,724 tests passed and 24 skipped.
- `npm run typecheck` — passed.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

CI runs on Ubuntu, macOS, and Windows. The overlay helper accepts an explicit platform for deterministic tests, while SessionStart uses the current runtime platform. Path handling uses Node path APIs and packaged file URLs; no hardcoded Windows separators are introduced.

</details>
