### PR TITLE
refactor(cache-heal): extract inline healScript to hooks/cache-heal.mjs

### DIFF
--- a/hooks/cache-heal.mjs
+++ b/hooks/cache-heal.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// context-mode plugin cache self-heal (auto-deployed)
+// Fixes anthropics/claude-code#46915: auto-update breaks CLAUDE_PLUGIN_ROOT
+// Issue #727: also normalizes stale version paths in existing installPaths
+// Honors CLAUDE_CONFIG_DIR (#577) — checked at this script's runtime so users
+// who set CLAUDE_CONFIG_DIR after install still get healed correctly.
+// Pure Node.js — no bash/shell dependency.
+import{existsSync,readdirSync,statSync,symlinkSync,lstatSync,unlinkSync,readFileSync}from"node:fs";
+import{dirname,join,resolve,sep}from"node:path";
+import{homedir}from"node:os";
+function cfgDir(){const e=process.env.CLAUDE_CONFIG_DIR;if(e&&e.trim()!==""){return e.startsWith("~")?resolve(homedir(),e.replace(/^~[/\\]?/,"")):resolve(e)}return resolve(homedir(),".claude")}
+try{
+  const f=resolve(cfgDir(),"plugins","installed_plugins.json");
+  if(!existsSync(f))process.exit(0);
+  const cacheRoot=resolve(cfgDir(),"plugins","cache");
+  const ip=JSON.parse(readFileSync(f,"utf-8"));
+  for(const[k,es]of Object.entries(ip.plugins||{})){
+    if(k!=="context-mode@context-mode")continue;
+    for(const e of es){
+      const p=e.installPath;
+      if(!p)continue;
+      if(!resolve(p).startsWith(cacheRoot+sep))continue;
+      if(existsSync(p)){
+        // Issue #727: normalize stale version paths in existing installPaths.
+        // CC's auto-update can carry forward hooks.json/plugin.json with paths
+        // baked to a previous version dir. Import normalize-hooks from the
+        // installPath itself and let it detect + rewrite stale segments.
+        try{
+          // #713: narrow helper only — installPath belongs to a different
+          // version's cache dir; writing plugin.json there is the #711 vector.
+          const nhPath=join(p,"hooks","normalize-hooks.mjs");
+          if(existsSync(nhPath)){
+            const mod=await import(nhPath);
+            const fn=mod.normalizeHooksJsonOnly||mod.normalizeHooksOnStartup;
+            if(fn)fn({pluginRoot:p,nodePath:process.execPath,platform:process.platform});
+          }
+        }catch{}
+        continue;
+      }
+      const parent=dirname(p);
+      if(!existsSync(parent))continue;
+      try{if(lstatSync(p).isSymbolicLink())unlinkSync(p)}catch{}
+      const dirs=readdirSync(parent).filter(d=>/^\d+\.\d+/.test(d)&&statSync(join(parent,d)).isDirectory());
+      if(!dirs.length)continue;
+      dirs.sort((a,b)=>{const pa=a.split(".").map(Number),pb=b.split(".").map(Number);for(let i=0;i<3;i++){if((pa[i]||0)!==(pb[i]||0))return(pa[i]||0)-(pb[i]||0)}return 0});
+      try{symlinkSync(join(parent,dirs[dirs.length-1]),p,process.platform==="win32"?"junction":undefined)}catch{}
+    }
+  }
+}catch{}

--- a/start.mjs
+++ b/start.mjs
@@ -318,56 +318,14 @@ try {
     try { unlinkSync(oldBashHook); } catch {}
   }
   if (!existsSync(globalHooksDir)) mkdirSync(globalHooksDir, { recursive: true });
-  const healScript = `#!/usr/bin/env node
-// context-mode plugin cache self-heal (auto-deployed)
-// Fixes anthropics/claude-code#46915: auto-update breaks CLAUDE_PLUGIN_ROOT
-// Issue #727: also normalizes stale version paths in existing installPaths
-// Honors CLAUDE_CONFIG_DIR (#577) — checked at this script's runtime so users
-// who set CLAUDE_CONFIG_DIR after install still get healed correctly.
-// Pure Node.js — no bash/shell dependency.
-import{existsSync,readdirSync,statSync,symlinkSync,lstatSync,unlinkSync,readFileSync}from"node:fs";
-import{dirname,join,resolve,sep}from"node:path";
-import{homedir}from"node:os";
-function cfgDir(){const e=process.env.CLAUDE_CONFIG_DIR;if(e&&e.trim()!==""){return e.startsWith("~")?resolve(homedir(),e.replace(/^~[/\\\\]?/,"")):resolve(e)}return resolve(homedir(),".claude")}
-try{
-  const f=resolve(cfgDir(),"plugins","installed_plugins.json");
-  if(!existsSync(f))process.exit(0);
-  const cacheRoot=resolve(cfgDir(),"plugins","cache");
-  const ip=JSON.parse(readFileSync(f,"utf-8"));
-  for(const[k,es]of Object.entries(ip.plugins||{})){
-    if(k!=="context-mode@context-mode")continue;
-    for(const e of es){
-      const p=e.installPath;
-      if(!p)continue;
-      if(!resolve(p).startsWith(cacheRoot+sep))continue;
-      if(existsSync(p)){
-        // Issue #727: normalize stale version paths in existing installPaths.
-        // CC's auto-update can carry forward hooks.json/plugin.json with paths
-        // baked to a previous version dir. Import normalize-hooks from the
-        // installPath itself and let it detect + rewrite stale segments.
-        try{
-          // #713: narrow helper only — installPath belongs to a different
-          // version's cache dir; writing plugin.json there is the #711 vector.
-          const nhPath=join(p,"hooks","normalize-hooks.mjs");
-          if(existsSync(nhPath)){
-            const mod=await import(nhPath);
-            const fn=mod.normalizeHooksJsonOnly||mod.normalizeHooksOnStartup;
-            if(fn)fn({pluginRoot:p,nodePath:process.execPath,platform:process.platform});
-          }
-        }catch{}
-        continue;
-      }
-      const parent=dirname(p);
-      if(!existsSync(parent))continue;
-      try{if(lstatSync(p).isSymbolicLink())unlinkSync(p)}catch{}
-      const dirs=readdirSync(parent).filter(d=>/^\\d+\\.\\d+/.test(d)&&statSync(join(parent,d)).isDirectory());
-      if(!dirs.length)continue;
-      dirs.sort((a,b)=>{const pa=a.split(".").map(Number),pb=b.split(".").map(Number);for(let i=0;i<3;i++){if((pa[i]||0)!==(pb[i]||0))return(pa[i]||0)-(pb[i]||0)}return 0});
-      try{symlinkSync(join(parent,dirs[dirs.length-1]),p,process.platform==="win32"?"junction":undefined)}catch{}
-    }
-  }
-}catch{}
-`;
+  // The heal hook body lives in hooks/cache-heal.mjs — a real, lintable
+  // file with a single source of truth — instead of an inline template
+  // literal, so downstream packagers can deploy it verbatim without
+  // running this script.
+  const healScript = readFileSync(
+    resolve(__dirname, "hooks", "cache-heal.mjs"),
+    "utf-8",
+  );
   // Deploy or update the heal hook when content changes (not just when missing).
   // Allows new heal logic (e.g. #727 path normalization) to propagate on next boot.
   let needsWrite = !existsSync(healHookPath);

--- a/tests/util/start-mjs-self-heal.test.ts
+++ b/tests/util/start-mjs-self-heal.test.ts
@@ -226,26 +226,28 @@ describe("start.mjs — Issue #577 CLAUDE_CONFIG_DIR honoring", () => {
     );
   });
 
-  test("auto-deployed heal script template honors CLAUDE_CONFIG_DIR at its own runtime", () => {
-    // The embedded `healScript` template literal becomes
-    // $CLAUDE_CONFIG_DIR/hooks/context-mode-cache-heal.mjs. Its OWN runtime
-    // — i.e. when Claude Code spawns it on SessionStart — must also honor
-    // CLAUDE_CONFIG_DIR. So the template literal itself has to embed the
-    // env-var read; baking the value at start.mjs render time would freeze
-    // the heal script to whatever CLAUDE_CONFIG_DIR was set to at install.
-    const startOfTpl = startSrc.indexOf("const healScript = `");
-    expect(startOfTpl).toBeGreaterThan(-1);
-    const endMarker = "writeFileSync(healHookPath, healScript";
-    const endIdx = startSrc.indexOf(endMarker, startOfTpl);
-    expect(endIdx).toBeGreaterThan(startOfTpl);
-    const tpl = startSrc.slice(startOfTpl, endIdx);
+  test("auto-deployed heal script honors CLAUDE_CONFIG_DIR at its own runtime", () => {
+    // The heal body is deployed verbatim to
+    // $CLAUDE_CONFIG_DIR/hooks/context-mode-cache-heal.mjs. Its OWN runtime —
+    // i.e. when Claude Code spawns it on SessionStart — must also honor
+    // CLAUDE_CONFIG_DIR, so the body must embed the env-var read rather than
+    // bake a value at deploy time. The body is the standalone hooks/cache-heal.mjs
+    // (start.mjs reads it verbatim), not an inline template literal.
+    const healSrc = readFileSync(
+      resolve(ROOT, "hooks", "cache-heal.mjs"),
+      "utf-8",
+    );
 
-    expect(tpl).toContain("CLAUDE_CONFIG_DIR");
+    // start.mjs must load the body from the standalone file (single source of truth).
+    expect(startSrc).toMatch(
+      /readFileSync\(\s*resolve\(__dirname,\s*["']hooks["'],\s*["']cache-heal\.mjs["']\)/,
+    );
 
-    // Embedded resolve() calls inside the template must NOT be the
-    // hardcoded ~/.claude form.
-    const tplBadForm =
+    expect(healSrc).toContain("CLAUDE_CONFIG_DIR");
+
+    // resolve() calls inside the body must NOT be the hardcoded ~/.claude form.
+    const badForm =
       /resolve\(\s*homedir\(\)\s*,\s*["']\.claude["']\s*,\s*["']plugins["']/;
-    expect(tpl).not.toMatch(tplBadForm);
+    expect(healSrc).not.toMatch(badForm);
   });
 });


### PR DESCRIPTION
## What / Why / How

**What:** Move the cache-heal hook body out of the inline `healScript` template literal in `start.mjs` into a standalone `hooks/cache-heal.mjs`, which `start.mjs` now reads verbatim.

**Why:** As an inline, escape-doubled template literal the body has no single source of truth — it can't be linted/tested as a real file, the backslash-doubling (`/^~[/\\\\]?/`) is easy to get wrong, and downstream packagers can't deploy the hook without executing `start.mjs`.

**How:** Replaced the ~50-line literal with `readFileSync(resolve(__dirname, "hooks", "cache-heal.mjs"), "utf-8")`. The deploy/compare/register logic is unchanged, and the **deployed bytes are identical** to before. `hooks/` is already in the `package.json` `files` allowlist, so it ships via npm and marketplace install.

## Affected platforms

- [x] All platforms

<sub>Pure refactor of shared `start.mjs` — deployed hook bytes are byte-for-byte unchanged, so no behavior change on any platform.</sub>

## Test plan

Updated `tests/util/start-mjs-self-heal.test.ts` — the test that asserted the heal body honors `CLAUDE_CONFIG_DIR` now reads the standalone `hooks/cache-heal.mjs`, and additionally asserts `start.mjs` loads the body from that file (single source of truth).

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes — one unrelated test (`cache-heal-self-heal › stale breadcrumb … re-pointed at the live root`) fails on a clean `next` checkout too; not touched by this change
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md) — n/a, internal refactor
- [x] No Windows path regressions (forward slashes only) — uses `resolve()` segments, no hardcoded separators
- [x] Targets `next` branch (unless hotfix)