### PR TITLE
fix(exec): add CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS opt-in bound for exec calls (#936)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1489,16 +1489,30 @@ function truncateCommandForEcho(command: string): string {
  * interrupt. Every other host enforces its own RPC timeout, so we keep the
  * no-server-timer behavior there (Issue #406 — long builds need an unbounded
  * run). A caller can still pass an explicit `timeout` to override on any host.
+ *
+ * Some hosts' RPC timeouts are effectively unbounded in practice — Claude Code
+ * stdio before v2.1.203 exempted stdio MCP servers from the idle timeout, so a
+ * hung ctx_execute blocked the agent until manual interruption (#936).
+ * CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS lets users opt into a bounded default on
+ * any host; an explicit per-call `timeout` still wins, and under agy the
+ * platform-specific CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS takes precedence over it.
  */
 export const AGY_DEFAULT_EXEC_TIMEOUT_MS = 120_000;
 export function resolveExecTimeout(timeout: number | undefined): number | undefined {
   if (timeout !== undefined) return timeout;
-  // Only agy gets a default — every other host enforces its own RPC timeout, so
-  // keep the unbounded behavior there. Detected via the env the agy bundle pins
-  // (CONTEXT_MODE_PLATFORM=antigravity-cli). Tunable via CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS.
-  if (detectPlatform().platform !== "antigravity-cli") return undefined;
+  const generic = Number(process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS);
+  const genericValid = Number.isFinite(generic) && generic > 0;
+  // Only agy gets a built-in default — every other host enforces its own RPC
+  // timeout, so keep the unbounded behavior there unless the user opted in via
+  // CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS. Detected via the env the agy bundle
+  // pins (CONTEXT_MODE_PLATFORM=antigravity-cli). Tunable via CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS.
+  if (detectPlatform().platform !== "antigravity-cli") {
+    return genericValid ? generic : undefined;
+  }
   const override = Number(process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS);
-  return Number.isFinite(override) && override > 0 ? override : AGY_DEFAULT_EXEC_TIMEOUT_MS;
+  if (Number.isFinite(override) && override > 0) return override;
+  if (genericValid) return generic;
+  return AGY_DEFAULT_EXEC_TIMEOUT_MS;
 }
 
 /**

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -6628,11 +6628,14 @@ describe("parseJsonc / stripJsonComments (src/util/jsonc)", () => {
 describe("resolveExecTimeout (agy default execution timeout)", () => {
   const savedPlatform = process.env.CONTEXT_MODE_PLATFORM;
   const savedOverride = process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS;
+  const savedGeneric = process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS;
   afterEach(() => {
     if (savedPlatform === undefined) delete process.env.CONTEXT_MODE_PLATFORM;
     else process.env.CONTEXT_MODE_PLATFORM = savedPlatform;
     if (savedOverride === undefined) delete process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS;
     else process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS = savedOverride;
+    if (savedGeneric === undefined) delete process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS;
+    else process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = savedGeneric;
   });
 
   test("passes an explicit timeout through on any platform", () => {
@@ -6645,11 +6648,13 @@ describe("resolveExecTimeout (agy default execution timeout)", () => {
   test("applies the agy default ONLY under antigravity-cli when no timeout is given", () => {
     process.env.CONTEXT_MODE_PLATFORM = "antigravity-cli";
     delete process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS;
+    delete process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS;
     expect(resolveExecTimeout(undefined)).toBe(AGY_DEFAULT_EXEC_TIMEOUT_MS);
   });
 
   test("leaves the timeout unbounded (undefined) on non-agy hosts", () => {
     process.env.CONTEXT_MODE_PLATFORM = "claude-code";
+    delete process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS;
     expect(resolveExecTimeout(undefined)).toBeUndefined();
   });
 
@@ -6657,6 +6662,42 @@ describe("resolveExecTimeout (agy default execution timeout)", () => {
     process.env.CONTEXT_MODE_PLATFORM = "antigravity-cli";
     process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS = "1500";
     expect(resolveExecTimeout(undefined)).toBe(1500);
+  });
+
+  // #936 — opt-in bounded default on hosts whose RPC timeout is effectively
+  // unbounded (e.g. Claude Code stdio before v2.1.203).
+  test("honors CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS on non-agy hosts (#936)", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "claude-code";
+    process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = "120000";
+    expect(resolveExecTimeout(undefined)).toBe(120000);
+  });
+
+  test("explicit timeout still wins over the generic default (#936)", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "claude-code";
+    process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = "120000";
+    expect(resolveExecTimeout(5000)).toBe(5000);
+  });
+
+  test("agy-specific override beats the generic default under agy (#936)", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "antigravity-cli";
+    process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS = "1500";
+    process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = "120000";
+    expect(resolveExecTimeout(undefined)).toBe(1500);
+  });
+
+  test("generic default beats the agy built-in default under agy (#936)", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "antigravity-cli";
+    delete process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS;
+    process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = "90000";
+    expect(resolveExecTimeout(undefined)).toBe(90000);
+  });
+
+  test("invalid generic values are ignored (#936)", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "claude-code";
+    for (const bad of ["0", "-1", "abc", ""]) {
+      process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = bad;
+      expect(resolveExecTimeout(undefined)).toBeUndefined();
+    }
   });
 });
 


### PR DESCRIPTION
## What / Why / How

Fixes #936.

`ctx_execute` / `ctx_execute_file` without an explicit `timeout` run with no
server-side timer on non-Antigravity hosts, on the assumption that the MCP
host's RPC timeout governs. That assumption fails on Claude Code stdio:
`MCP_TOOL_TIMEOUT` defaults to ~28 hours and, before Claude Code v2.1.203,
stdio servers were exempt from the idle timeout — the issue documents a call
that blocked the agent for 42+ minutes until manual interruption.

**Fix:** add an opt-in `CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS` env var consulted
on all hosts when no per-call timeout is given. **Behavior is unchanged unless
the variable is set** — no default is imposed (Issue #406: long builds need an
unbounded run). Precedence: explicit per-call `timeout` >
`CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS` (under agy) > generic default > agy built-in
default > unbounded. Invalid values (non-numeric, zero, negative) are ignored,
matching the AGY override's validation.

## Affected platforms

- [x] All platforms

## Test plan

- Extended the existing `resolveExecTimeout` describe with 5 cases: generic
  default honored on non-agy hosts; explicit timeout still wins; agy-specific
  env beats generic under agy; generic beats the agy built-in default; invalid
  values ignored. All pre-existing cases unchanged and passing.
- `npx vitest run tests/core/server.test.ts` → 504 passed.
- `npx tsc --noEmit` → clean.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes (server suite; full build requires Node >=22.5)
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed — n/a (CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS is likewise undocumented)
- [x] No Windows path regressions (no path handling touched)
- [x] Targets `next` branch
