### PR TITLE
fix(batch): re-create the fs-preload temp file if an OS cleaner removed it (#951)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -424,10 +424,23 @@ const executor = new PolyglotExecutor({
 // Instead, we inject it as an inline shell env prefix in each batch command.
 // This temp file is loaded via --require when batch commands spawn Node processes.
 const CM_FS_PRELOAD = join(tmpdir(), `cm-fs-preload-${process.pid}.js`);
-writeFileSync(
-  CM_FS_PRELOAD,
-  `(function(){var __cm_fs=0;process.on('exit',function(){if(__cm_fs>0)try{process.stderr.write('__CM_FS__:'+__cm_fs+'\\n')}catch(e){}});try{var f=require('fs');var ors=f.readFileSync;f.readFileSync=function(){var r=ors.apply(this,arguments);if(Buffer.isBuffer(r))__cm_fs+=r.length;else if(typeof r==='string')__cm_fs+=Buffer.byteLength(r);return r;};}catch(e){}})();\n`,
-);
+const CM_FS_PRELOAD_SRC =
+  `(function(){var __cm_fs=0;process.on('exit',function(){if(__cm_fs>0)try{process.stderr.write('__CM_FS__:'+__cm_fs+'\\n')}catch(e){}});try{var f=require('fs');var ors=f.readFileSync;f.readFileSync=function(){var r=ors.apply(this,arguments);if(Buffer.isBuffer(r))__cm_fs+=r.length;else if(typeof r==='string')__cm_fs+=Buffer.byteLength(r);return r;};}catch(e){}})();\n`;
+/**
+ * Write the preload file if it is not on disk, and return its path.
+ *
+ * The file lives in the OS temp dir, which periodic cleaners (macOS
+ * $TMPDIR purge, systemd-tmpfiles) can empty while this server process is
+ * still alive. If we keep injecting `NODE_OPTIONS=--require <missing file>`
+ * after that, every node/npm/npx child dies at preload with MODULE_NOT_FOUND
+ * (#951) — so callers must re-check existence at injection time, not rely on
+ * the write at module load.
+ */
+export function ensureFsPreload(): string {
+  if (!existsSync(CM_FS_PRELOAD)) writeFileSync(CM_FS_PRELOAD, CM_FS_PRELOAD_SRC);
+  return CM_FS_PRELOAD;
+}
+ensureFsPreload();
 // In the stdio MCP path, main() also removes this file during graceful
 // shutdown. Plugin-native OpenCode/Kilo imports skip main() (#574), so
 // register a top-level best-effort cleanup too to avoid leaking preload
@@ -3786,7 +3799,10 @@ EXAMPLE: ctx_batch_execute(
       // Inject NODE_OPTIONS for FS read tracking in spawned Node processes.
       // The executor denies NODE_OPTIONS in its env (security), so we set it
       // as an inline shell prefix. This only affects child `node` invocations.
-      const nodeOptsPrefix = buildBatchNodeOptionsPrefix(runtimes.shell, CM_FS_PRELOAD);
+      // ensureFsPreload re-creates the temp file if an OS temp cleaner removed
+      // it since startup — injecting a missing --require kills every node
+      // child with MODULE_NOT_FOUND (#951).
+      const nodeOptsPrefix = buildBatchNodeOptionsPrefix(runtimes.shell, ensureFsPreload());
 
       // Full stdout is preserved per-command and indexed into FTS5 (Issue #61, #197).
       // Concurrency>1 switches to a worker pool with per-command timeouts.

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -21,6 +21,7 @@ import {
   rmSync,
   readFileSync,
   existsSync,
+  unlinkSync,
 } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
@@ -3034,6 +3035,7 @@ describe("batch_execute FS read tracking", () => {
 
 import {
   buildBatchNodeOptionsPrefix,
+  ensureFsPreload,
   runBatchCommands,
   type BatchCommand,
 } from "../../src/server.js";
@@ -3372,6 +3374,23 @@ describe("runBatchCommands edge cases", () => {
       "C:\\Temp\\cm-fs-preload.js",
     );
     expect(prefix).toBe('set "NODE_OPTIONS=--require C:\\Temp\\cm-fs-preload.js" && ');
+  });
+
+  // #951 — OS temp cleaners can remove the preload file while the server is
+  // still alive; injection must re-create it rather than point node children
+  // at a missing --require target.
+  test("ensureFsPreload re-creates the preload file after external deletion (#951)", () => {
+    const p = ensureFsPreload();
+    expect(existsSync(p)).toBe(true);
+
+    unlinkSync(p);
+    expect(existsSync(p)).toBe(false);
+
+    const p2 = ensureFsPreload();
+    expect(p2).toBe(p);
+    expect(existsSync(p)).toBe(true);
+    // Restored file must be the real tracker, not an empty placeholder.
+    expect(readFileSync(p, "utf-8")).toContain("__CM_FS__");
   });
 });
 


### PR DESCRIPTION
## What / Why / How

Fixes the stale-preload half of #951.

The `cm-fs-preload-<pid>.js` FS-tracking snippet is written once at module load
into the OS temp dir. macOS `$TMPDIR` periodic purges (and systemd-tmpfiles on
Linux) can delete it while the MCP server process is still alive. The server
then keeps injecting `NODE_OPTIONS=--require <missing file>` into every batch
command, so **all node/npm/npx children die at preload with `MODULE_NOT_FOUND`**
until the affected server PID is killed. Non-node commands are unaffected,
which makes the failure look like a broken npm rather than a stale temp file.

**Fix:** extract the preload write into `ensureFsPreload()` — write-if-missing,
return the path — and call it at the `ctx_batch_execute` injection site so a
deleted file is restored before the prefix references it. The module-load write
is kept (same startup behavior and failure mode); the added cost is a single
`existsSync` per batch call.

The `/reload-plugins` worker-accumulation aggravation described in #951 is a
host lifecycle concern and intentionally out of scope here.

## Affected platforms

- [x] All platforms

## Test plan

- New test: delete the preload file externally, call `ensureFsPreload()`,
  assert the same path is restored with the real tracker content
  (`__CM_FS__`), not an empty placeholder.
- `npx vitest run tests/core/server.test.ts` → 500 passed (incl. the 25
  `runBatchCommands` cases).
- `npx tsc --noEmit` → clean.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes (server suite; full build requires Node >=22.5)
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed — n/a
- [x] No Windows path regressions (uses existing `join(tmpdir(), ...)` path)
- [x] Targets `next` branch
