### PR TITLE
fix(store): add 14-day retention for the sessions/ directory (#949)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { z } from "zod";
 import { PolyglotExecutor } from "./executor.js";
 import { runPool, type PoolJob } from "./runPool.js";
-import { ContentStore, cleanupStaleDBs, cleanupStaleContentDBs, type SearchResult, type IndexResult } from "./store.js";
+import { ContentStore, cleanupStaleDBs, cleanupStaleContentDBs, cleanupStaleSessionFiles, type SearchResult, type IndexResult } from "./store.js";
 import { composeFetchCacheKey } from "./fetch-cache.js";
 import {
   readBashPolicies,
@@ -731,6 +731,10 @@ function getStore(): ContentStore {
       // Also clean legacy shared dir from before platform isolation
       const legacyDir = join(homedir(), ".context-mode", "content");
       if (existsSync(legacyDir)) cleanupStaleContentDBs(legacyDir, 0);
+      // sessions/ mirrors the same retention window — without it, per-session
+      // stats-*.json files and idle per-project session DBs grow without
+      // bound (#949: 5k+ files / 331MB on a two-month install).
+      cleanupStaleSessionFiles(getSessionDir(), 14);
     } catch { /* best-effort */ }
 
     // Also clean old PID-based DBs from migration

--- a/src/store.ts
+++ b/src/store.ts
@@ -260,6 +260,46 @@ export function cleanupStaleContentDBs(contentDir: string, maxAgeDays: number): 
   return cleaned;
 }
 
+/**
+ * Clean up stale files in the sessions/ storage directory (#949).
+ *
+ * content/ has pruned at 14 days since day one, but sessions/ had no
+ * retention at all: per-session `stats-*.json` files (one per server
+ * process, never reread after the session ends) and idle per-project
+ * session DBs accumulate without bound.
+ *
+ * Retention is purely mtime-based — every hook write refreshes the DB's
+ * mtime, so a file untouched for maxAgeDays cannot belong to a live
+ * session. Deliberately NO WAL-liveness heuristic here: guessing owner
+ * death from WAL staleness can delete files under a live handle (#880).
+ * Unknown file types are left alone.
+ */
+export function cleanupStaleSessionFiles(sessionsDir: string, maxAgeDays: number): number {
+  let cleaned = 0;
+  try {
+    if (!existsSync(sessionsDir)) return 0;
+    const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+    for (const file of readdirSync(sessionsDir)) {
+      const isSessionDb = file.endsWith(".db");
+      const isStatsFile = file.startsWith("stats-") && file.endsWith(".json");
+      if (!isSessionDb && !isStatsFile) continue;
+      try {
+        const filePath = join(sessionsDir, file);
+        if (statSync(filePath).mtimeMs >= cutoff) continue;
+        if (isSessionDb) {
+          for (const suffix of ["", "-wal", "-shm"]) {
+            try { unlinkSync(filePath + suffix); } catch { /* ignore */ }
+          }
+        } else {
+          unlinkSync(filePath);
+        }
+        cleaned++;
+      } catch { /* ignore per-file errors */ }
+    }
+  } catch { /* ignore readdir errors */ }
+  return cleaned;
+}
+
 // ── Proximity helpers (pure functions) ──
 
 /** Find all positions of a term in text. */

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -7,12 +7,12 @@
 
 import { describe, test, expect } from "vitest";
 import { strict as assert } from "node:assert";
-import { readFileSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdtempSync, utimesSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
-import { ContentStore, cleanupStaleDBs } from "../src/store.js";
+import { ContentStore, cleanupStaleDBs, cleanupStaleSessionFiles } from "../src/store.js";
 import {
   withRetry,
   closeDB,
@@ -1188,6 +1188,59 @@ describe("DB Cleanup", () => {
     store.cleanup();
     // Second call should not throw
     assert.doesNotThrow(() => store.cleanup());
+  });
+
+  // #949 — sessions/ retention (content/ prunes at 14d; sessions/ never did)
+  test("cleanupStaleSessionFiles removes old session DBs and stats files, keeps fresh ones", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cm-sessions-retention-"));
+    const old = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000);
+
+    // Stale: 20-day-old session DB (with WAL/SHM) + stats file
+    const oldDb = join(dir, "abc123.db");
+    writeFileSync(oldDb, "db");
+    writeFileSync(oldDb + "-wal", "wal");
+    writeFileSync(oldDb + "-shm", "shm");
+    writeFileSync(join(dir, "stats-pid-11111.json"), "{}");
+    for (const f of [oldDb, oldDb + "-wal", oldDb + "-shm", join(dir, "stats-pid-11111.json")]) {
+      utimesSync(f, old, old);
+    }
+
+    // Fresh: current-mtime DB + stats file, plus an unknown file type
+    const freshDb = join(dir, "def456.db");
+    writeFileSync(freshDb, "db");
+    writeFileSync(join(dir, "stats-pid-22222.json"), "{}");
+    writeFileSync(join(dir, "notes.txt"), "unrelated");
+    utimesSync(join(dir, "notes.txt"), old, old);
+
+    const cleaned = cleanupStaleSessionFiles(dir, 14);
+    assert.equal(cleaned, 2, "one DB trio + one stats file");
+    assert.ok(!existsSync(oldDb), "old DB removed");
+    assert.ok(!existsSync(oldDb + "-wal"), "old WAL removed");
+    assert.ok(!existsSync(oldDb + "-shm"), "old SHM removed");
+    assert.ok(!existsSync(join(dir, "stats-pid-11111.json")), "old stats removed");
+    assert.ok(existsSync(freshDb), "fresh DB kept");
+    assert.ok(existsSync(join(dir, "stats-pid-22222.json")), "fresh stats kept");
+    assert.ok(existsSync(join(dir, "notes.txt")), "unknown file types are never touched");
+  });
+
+  test("cleanupStaleSessionFiles has no WAL-liveness heuristic — recent DB with old WAL is kept", () => {
+    // cleanupStaleContentDBs' WAL-staleness guess can delete files under a
+    // live handle (#880); the sessions variant must rely on mtime only.
+    const dir = mkdtempSync(join(tmpdir(), "cm-sessions-wal-"));
+    const db = join(dir, "live.db");
+    writeFileSync(db, "db");
+    writeFileSync(db + "-wal", "wal");
+    const old = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000);
+    utimesSync(db + "-wal", old, old); // stale WAL, fresh DB
+
+    const cleaned = cleanupStaleSessionFiles(dir, 14);
+    assert.equal(cleaned, 0);
+    assert.ok(existsSync(db), "live DB kept despite stale-looking WAL");
+    assert.ok(existsSync(db + "-wal"), "its WAL kept too");
+  });
+
+  test("cleanupStaleSessionFiles returns 0 for a missing directory", () => {
+    assert.equal(cleanupStaleSessionFiles(join(tmpdir(), "cm-does-not-exist-949"), 14), 0);
   });
 });
 


### PR DESCRIPTION
## What / Why / How

Fixes #949.

`content/` has pruned stale per-project DBs at 14 days since day one, but
`sessions/` had no retention path at all: per-session `stats-*.json` files
(one per server process, never reread once the session ends) and idle
per-project session DBs accumulate without bound. The issue reports a
two-month heavy install at **5,294 files / ~331MB** in `sessions/` while
`content/` stayed bounded at ~52MB.

**Fix:** add `cleanupStaleSessionFiles(sessionsDir, maxAgeDays)` next to
`cleanupStaleContentDBs` and run it in the same one-time startup cleanup cycle,
with the same 14-day window.

Two deliberate design points:

- **Purely mtime-based.** Every hook write refreshes the DB mtime, so a file
  untouched for 14 days cannot belong to a live session. No WAL-staleness
  liveness guess — that heuristic can delete files under a live handle (#880),
  so the sessions variant does not inherit it.
- **Conservative file matching.** Only `*.db` (with their `-wal`/`-shm`
  siblings) and `stats-*.json` are considered; unknown file types in the
  directory are never touched.

Note: pruning old `stats-*.json` slightly reduces the Pi lifetime byte
aggregation (`patchPiLifetimeFromStatsFiles` sums all stats files) — the same
class of trade-off the existing 14-day `content/` pruning already makes.

## Affected platforms

- [x] All platforms

## Test plan

- 3 new tests in the existing "DB Cleanup" describe: stale DB trio + stale
  stats removed while fresh files and unknown types are kept; a fresh DB with
  a stale-looking WAL is kept (no WAL heuristic, regression guard for the #880
  class); missing directory returns 0.
- `npx vitest run tests/store.test.ts` → 126 passed;
  `npx vitest run tests/core/server.test.ts` → 499 passed.
- `npx tsc --noEmit` → clean.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes (store + server suites; full build requires Node >=22.5)
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed — n/a
- [x] No Windows path regressions (`join()` throughout, no hardcoded separators)
- [x] Targets `next` branch
