### PR TITLE
fix(codex): omit empty hook context

### DIFF
--- a/hooks/codex/posttooluse.mjs
+++ b/hooks/codex/posttooluse.mjs
@@ -62,5 +62,5 @@ try {
 
 // Codex PostToolUse requires hookEventName in hookSpecificOutput
 process.stdout.write(JSON.stringify({
-  hookSpecificOutput: { hookEventName: "PostToolUse", additionalContext: "" },
+  hookSpecificOutput: { hookEventName: "PostToolUse" },
 }) + "\n");

--- a/hooks/codex/userpromptsubmit.mjs
+++ b/hooks/codex/userpromptsubmit.mjs
@@ -71,5 +71,5 @@ try {
 }
 
 process.stdout.write(JSON.stringify({
-  hookSpecificOutput: { hookEventName: "UserPromptSubmit", additionalContext: "" },
+  hookSpecificOutput: { hookEventName: "UserPromptSubmit" },
 }) + "\n");

--- a/tests/adapters/codex.test.ts
+++ b/tests/adapters/codex.test.ts
@@ -1,6 +1,6 @@
 import "../setup-home";
 import { describe, it, expect, beforeEach } from "vitest";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -956,8 +956,39 @@ describe("Codex pretooluse hook script", () => {
   });
 });
 
+describe("Codex posttooluse hook script", () => {
+  it("outputs valid JSON without empty additionalContext", () => {
+    const hookScript = resolve(__dirname, "../../hooks/codex/posttooluse.mjs");
+    const input = JSON.stringify({
+      tool_name: "Bash",
+      tool_input: { command: "echo hi" },
+      tool_response: "hi\n",
+      session_id: "test-posttooluse",
+      cwd: tmpdir(),
+      hook_event_name: "PostToolUse",
+      model: "o3",
+      permission_mode: "default",
+      tool_use_id: "tu1",
+      transcript_path: null,
+      turn_id: "t1",
+    });
+
+    const result = spawnSync(process.execPath, [hookScript], {
+      input,
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout.trim());
+    expect(parsed.hookSpecificOutput).toBeDefined();
+    expect(parsed.hookSpecificOutput.hookEventName).toBe("PostToolUse");
+    expect(parsed.hookSpecificOutput).not.toHaveProperty("additionalContext");
+  });
+});
+
 describe("Codex userpromptsubmit hook script", () => {
-  it("outputs valid JSON with UserPromptSubmit hookEventName", () => {
+  it("outputs valid JSON without empty additionalContext", () => {
     const hookScript = resolve(__dirname, "../../hooks/codex/userpromptsubmit.mjs");
     const input = JSON.stringify({
       session_id: "test-userprompt",
@@ -970,15 +1001,17 @@ describe("Codex userpromptsubmit hook script", () => {
       turn_id: "t1",
     });
 
-    const stdout = execFileSync(process.execPath, [hookScript], {
+    const result = spawnSync(process.execPath, [hookScript], {
       input,
       encoding: "utf-8",
       timeout: 10000,
     });
 
-    const parsed = JSON.parse(stdout.trim());
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout.trim());
     expect(parsed.hookSpecificOutput).toBeDefined();
     expect(parsed.hookSpecificOutput.hookEventName).toBe("UserPromptSubmit");
+    expect(parsed.hookSpecificOutput).not.toHaveProperty("additionalContext");
   });
 });
 


### PR DESCRIPTION
## What / Why / How

Codex displays empty hook context entries when the `UserPromptSubmit` or
`PostToolUse` hook returns `additionalContext: ""`. A no-op response only
needs the required `hookEventName`.

This change removes the empty field from both hook outputs and adds regression
coverage that checks the scripts still return valid JSON without
`additionalContext`.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [x] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

- `npx vitest run tests/adapters/codex.test.ts` — 71 tests passed.
- `npm run typecheck` — passed.
- The full suite completed with 4,704 passing tests, 38 skipped tests, and one
  unrelated timeout in
  `tests/statusline-sqlite.test.ts > resolves per-session KPI from the stdin payload session_id`.
  The same test times out when run alone.

## Checklist

- [x] Tests added/updated
- [ ] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (no documentation changes required)
- [x] No Windows path regressions (no path handling changed)
- [x] Targets `next` branch
