### PR TITLE
fix(gitSetupShell): do not hardcode bash location

### DIFF
--- a/tests/integration/cross-project-attribution.test.ts
+++ b/tests/integration/cross-project-attribution.test.ts
@@ -36,7 +36,7 @@ function platformConfigFile(fakeHome: string): string {
   return join(fakeHome, ".context-mode", "platform.json");
 }
 
-const gitSetupShell = process.platform === "win32" ? undefined : "/bin/bash";
+const gitSetupShell = process.platform === "win32" ? undefined : "bash";
 
 function shellPath(path: string): string {
   return path.replace(/\\/g, "/");


### PR DESCRIPTION
## What / Why / How

The `cross-project-attribution` test sets up temp git repos through
`shell: "/bin/bash"`. That path does not exist on NixOS, where bash lives in the
Nix profile rather than /bin, so the whole suite fails at setup with ENOENT.

Switch the hardcoded `/bin/bash` to a bare `"bash"` so Node resolves it from
PATH. This keeps bash semantics (the setup runs `git init && git remote add`)
and matches how shipped code already picks a shell (`commandExists("bash")` in
src/runtime.ts). win32 keeps execSync's default shell, unchanged.

## Affected platforms

Test-only change; no adapter or product behavior changes. Impacts any host
where bash is not at /bin/bash (NixOS, and other non-FHS layouts).

- [ ] All platforms

## Test plan

Existing `tests/integration/cross-project-attribution.test.ts` is the coverage.
On a host without /bin/bash it goes from 5 failing (ENOENT in beforeAll setup)
to 5 passing. No product code changed, so no new test was added; adding one
would only re-test Node + bash.

Verified locally:
- before (bare next): 5 failed, all ENOENT from /bin/bash
- after: 5 passed

## Checklist

- [x] Tests added/updated (the fixed suite is the coverage; see Test plan)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (n/a)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch
