### PR TITLE
fix(start.mjs): allow resolve bun from $PATH

### DIFF
--- a/hooks/find-bun.mjs
+++ b/hooks/find-bun.mjs
@@ -1,0 +1,24 @@
+// Resolve a bun binary from the known install locations and $PATH.
+// Raw JS (not runtime.ts) so start.mjs can use it before build/ exists.
+// Pure/injectable for tests.
+import { join } from "node:path";
+import { existsSync as realExistsSync } from "node:fs";
+import { homedir as realHomedir } from "node:os";
+
+export function findBun({
+  env = process.env,
+  platform = process.platform,
+  home = realHomedir(),
+  existsSync = realExistsSync,
+} = {}) {
+  const exe = platform === "win32" ? "bun.exe" : "bun";
+  const delimiter = platform === "win32" ? ";" : ":";
+  const candidates = [
+    env.BUN_INSTALL ? join(env.BUN_INSTALL, "bin", exe) : null,
+    home ? join(home, ".bun", "bin", exe) : null,
+    join("/usr/local/bin", exe),
+    join("/usr/bin", exe),
+    ...(env.PATH || "").split(delimiter).filter(Boolean).map((dir) => join(dir, exe)),
+  ];
+  return candidates.find((p) => p && existsSync(p)) || null;
+}

--- a/start.mjs
+++ b/start.mjs
@@ -65,13 +65,11 @@ if (!process.env.CONTEXT_MODE_PROJECT_DIR && safeOriginalCwd) {
 // a Bun installation and re-exec this file under Bun so the bundle takes the
 // safe path. No-op when already running under Bun or on non-Linux platforms.
 if (typeof globalThis.Bun === "undefined" && process.platform === "linux") {
-  const bunCandidates = [
-    process.env.BUN_INSTALL ? join(process.env.BUN_INSTALL, "bin", "bun") : null,
-    join(homedir(), ".bun", "bin", "bun"),
-    "/usr/local/bin/bun",
-    "/usr/bin/bun",
-  ].filter(Boolean);
-  const bunBin = bunCandidates.find((p) => existsSync(p));
+  let bunBin = null;
+  try {
+    const { findBun } = await import("./hooks/find-bun.mjs");
+    bunBin = findBun();
+  } catch { /* best effort — fall through to Node */ }
   if (bunBin) {
     const child = spawn(bunBin, [fileURLToPath(import.meta.url)], {
       stdio: ["pipe", "inherit", "inherit"],

--- a/tests/hook-runtime-resolution.test.ts
+++ b/tests/hook-runtime-resolution.test.ts
@@ -29,6 +29,48 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 // test-infra fragility while still exercising the same logic on Ubuntu+macOS.
 const itPosix = process.platform === "win32" ? test.skip : test;
 
+describe("findBun — resolves bun from install locations AND $PATH", () => {
+  // Pure resolver used by start.mjs's Linux re-exec (#564). Deps are injected,
+  // so no fs/env mocking is needed.
+  let findBun: (typeof import("../hooks/find-bun.mjs"))["findBun"];
+  beforeEach(async () => {
+    ({ findBun } = await import("../hooks/find-bun.mjs"));
+  });
+
+  const has = (...present: string[]) => (p: string) => present.includes(p);
+
+  test("finds bun on $PATH when no hardcoded install location has it", () => {
+    const bunOnPath = "/opt/bin/bun";
+    const result = findBun({
+      platform: "linux",
+      home: "/home/user",
+      env: { PATH: "/nowhere:/opt/bin" },
+      existsSync: has(bunOnPath),
+    });
+    expect(result).toBe(bunOnPath);
+  });
+
+  test("prefers a hardcoded install location over $PATH", () => {
+    const result = findBun({
+      platform: "linux",
+      home: "/home/user",
+      env: { PATH: "/opt/bin" },
+      existsSync: has("/home/user/.bun/bin/bun", "/opt/bin/bun"),
+    });
+    expect(result).toBe("/home/user/.bun/bin/bun");
+  });
+
+  test("returns null when bun is nowhere (install dirs nor $PATH)", () => {
+    const result = findBun({
+      platform: "linux",
+      home: "/home/user",
+      env: { PATH: "/usr/bin:/bin" },
+      existsSync: () => false,
+    });
+    expect(result).toBeNull();
+  });
+});
+
 describe("resolveHookRuntime — auto-detect bun ≥1.0, fall back to node (#738)", () => {
   beforeEach(() => {
     vi.resetModules();


### PR DESCRIPTION
## What / Why / How

On Linux the server re-execs under Bun to avoid a native SQLite crash. Bun was
only looked for in a few fixed install directories, never on $PATH, so when bun
is on $PATH but not one of those directories the re-exec was skipped. Now $PATH
is searched too.

## Affected platforms

Linux re-exec path only; client-agnostic. No behavior change where bun was
already found.

- [ ] All platforms

## Test plan

Unit tests for bun resolution from $PATH, preferring install dirs, and the
not-found case.

## Checklist

- [x] Tests added/updated
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)
