### PR TITLE
fix(start.mjs): remove chdir

### DIFF
--- a/start.mjs
+++ b/start.mjs
@@ -7,7 +7,6 @@ import { homedir } from "node:os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const originalCwd = process.cwd();
-process.chdir(__dirname);
 
 // Resolve the Claude Code config dir, honoring $CLAUDE_CONFIG_DIR (incl. leading ~).
 // Mirrors hooks/session-helpers.mjs::resolveConfigDir and hooks/run-hook.mjs (#453).

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -46,6 +46,7 @@ import {
 import { ROUTING_BLOCK } from "../../hooks/routing-block.mjs";
 import { sanitizeSchemaForStrictClients, resolveExecTimeout, AGY_DEFAULT_EXEC_TIMEOUT_MS, REGISTERED_CTX_TOOLS } from "../../src/server.js";
 import { stripJsonComments, parseJsonc } from "../../src/util/jsonc.js";
+import { resolveProjectDir } from "../../src/util/project-dir.js";
 
 // ─── Shared setup ───────────────────────────────────────────────────────────
 const runtimes = detectRuntimes();
@@ -1734,6 +1735,28 @@ describe("ctx_insight: execFile migration source guard (#441)", () => {
     expect(serverSrc).toMatch(/export function killProcessOnPort\b/);
     expect(serverSrc).toMatch(/export type BrowserOpenResult\b/);
     expect(serverSrc).toMatch(/export type KillResult\b/);
+  });
+});
+
+describe("start.mjs: server process does not chdir", () => {
+  const startMjs = readFileSync(
+    resolve(__dirname, "../../start.mjs"),
+    "utf-8",
+  );
+
+  test("start.mjs never calls process.chdir", () => {
+    // A chdir moves the server cwd into the plugin dir, where tools read it.
+    expect(startMjs).not.toMatch(/process\.chdir\s*\(/);
+  });
+
+  test("project-dir resolution is immune to a plugin-install-path cwd", () => {
+    // Removing the chdir is safe: resolution ignores a plugin-path cwd.
+    const resolved = resolveProjectDir({
+      env: { CONTEXT_MODE_PROJECT_DIR: "/home/user/project" },
+      cwd: "/home/user/.claude/plugins/cache/context-mode/context-mode/1.0.0",
+      pwd: undefined,
+    });
+    expect(resolved).toBe("/home/user/project");
   });
 });
 


### PR DESCRIPTION
## What / Why / How

On startup the server changed its working directory into the plugin install
directory. That directory then leaks into any tool that reads a process's
working directory to find where the agent is working, for example a terminal
multiplexer opening a new split there instead of in the project. Nothing depends
on the change of directory, so remove it.

## Affected platforms

Server startup path; client-agnostic. No behavior change to project resolution.

- [ ] All platforms

## Test plan

A guard that the server no longer changes directory, and a check that project
resolution still returns the project when the process starts in the plugin
directory.

## Checklist

- [x] Tests added/updated
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)
