### PR TITLE
fix(ctx_execute): prevent hang when background=true without timeout

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1753,6 +1753,7 @@ EXAMPLE: ctx_execute(language: "javascript", code: "const out = require('child_p
     try {
       // For JS/TS: wrap in async IIFE with fetch + http/https interceptors to track network bytes
       let instrumentedCode = code;
+      const effTimeout = resolveExecTimeout(timeout);
       if (language === "javascript" || language === "typescript") {
         // Wrap user code in a closure that shadows CJS require with http/https interceptor.
         // globalThis.require does NOT work because CJS require is module-scoped, not global.
@@ -1815,10 +1816,9 @@ if(__cm_req.cache)require.cache=__cm_req.cache;}
 async function __cm_main(){
 ${code}
 }
-__cm_main().catch(e=>{console.error(e);process.exitCode=1});${background ? '\nsetInterval(()=>{},2147483647);' : ''}
+__cm_main().catch(e=>{console.error(e);process.exitCode=1});${background && effTimeout !== undefined ? '\nsetInterval(()=>{},2147483647);' : ''}
 })(typeof require!=='undefined'?require:null);`;
       }
-      const effTimeout = resolveExecTimeout(timeout);
       const result = await executor.execute({ language, code: instrumentedCode, timeout: effTimeout, background, cwd });
 
       // Echo the executed source code before stdout so users can audit


### PR DESCRIPTION
## Problem

When `ctx_execute` is called with `background: true` but **no explicit `timeout`**, the tool call hangs forever and the session becomes stuck.

### Root cause

Two conflicting code paths:

1. **server.ts** appends a permanent `setInterval(()=>{}, 2147483647)` to keep the backgrounded process alive
2. **executor.ts** only creates the timer that triggers detach when `timeout` is explicitly set

With `background: true` and no `timeout`:
- The infinite interval keeps the Node process alive **forever**
- No timer fires to trigger the detach logic
- The process never exits → "close" event never fires → `res()` never called → tool call hangs

## Fix

Only append the keepalive interval when a timeout is actually configured (`effTimeout !== undefined`). Without a timeout, the process exits naturally when its code finishes, the "close" event fires, and the tool call completes normally.

## Changes

- `src/server.ts`: Move `effTimeout = resolveExecTimeout(timeout)` before the instrumented code template, and gate the infinite interval on `background && effTimeout !== undefined`

## Impact

| Scenario | Before | After |
|----------|--------|-------|
| `background: true` + `timeout` | ✅ Normal (detach on timeout) | ✅ Unchanged |
| `background: true` + **no timeout** | ❌ Tool call hangs forever | ✅ Process exits naturally, tool call completes |
| No background flag | ✅ Normal | ✅ Unchanged |