### PR TITLE
fix(db): replace SQLITE_BUSY busy-wait backoff with Atomics.wait sleep (#985)

### DIFF
--- a/src/db-base.ts
+++ b/src/db-base.ts
@@ -441,9 +441,14 @@ export function withRetry<T>(fn: () => T, delays: number[] = [100, 500, 2000]): 
       }
       lastError = err instanceof Error ? err : new Error(msg);
       if (attempt < delays.length) {
-        const delay = delays[attempt];
-        const start = Date.now();
-        while (Date.now() - start < delay) { /* busy-wait for sync retry */ }
+        // Block the thread without spinning a CPU core. better-sqlite3 is
+        // synchronous, so we cannot await a timer here; Atomics.wait provides a
+        // real blocking sleep. The previous spin-loop backoff pegged a core for
+        // the full 100+500+2000ms window, which under multi-session write
+        // contention accumulated hundreds of CPU-seconds per instance (#985).
+        // A zero delay still returns immediately, preserving the [0, 0, 0]
+        // test contract above.
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delays[attempt]);
       }
     }
   }

--- a/tests/util/with-retry.test.ts
+++ b/tests/util/with-retry.test.ts
@@ -1,0 +1,70 @@
+/**
+ * withRetry backoff — issue #985.
+ *
+ * better-sqlite3 is synchronous, so the SQLITE_BUSY retry backoff cannot await
+ * a timer. It previously slept with a `while (Date.now() - start < delay)`
+ * busy-wait, which pins a CPU core for the full 100+500+2000ms backoff; under
+ * multi-session write contention on the shared per-project content DB this
+ * accumulated hundreds of CPU-seconds per instance. The fix replaces the spin
+ * with a real blocking sleep via `Atomics.wait`.
+ *
+ * Source-level guard: assert the busy-wait is gone and Atomics.wait is used.
+ * Runtime guards: retry-then-succeed, non-BUSY rethrow, exhaustion, and that a
+ * real (non-zero) delay actually elapses.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { withRetry } from "../../src/db-base.js";
+
+describe("withRetry backoff (#985)", () => {
+  const src = readFileSync(resolve(__dirname, "..", "..", "src", "db-base.ts"), "utf8");
+
+  it("no longer busy-waits; uses Atomics.wait for the backoff sleep", () => {
+    expect(src).not.toMatch(/while\s*\(\s*Date\.now\(\)\s*-\s*start\s*<\s*delay\s*\)/);
+    expect(src).toContain("Atomics.wait(");
+  });
+
+  it("retries on SQLITE_BUSY and eventually succeeds", () => {
+    let calls = 0;
+    const result = withRetry(() => {
+      calls++;
+      if (calls < 3) throw new Error("SQLITE_BUSY: database is locked");
+      return "ok";
+    }, [0, 0, 0]);
+    expect(result).toBe("ok");
+    expect(calls).toBe(3);
+  });
+
+  it("rethrows non-BUSY errors immediately without retrying", () => {
+    let calls = 0;
+    expect(() =>
+      withRetry(() => {
+        calls++;
+        throw new Error("SQLITE_CONSTRAINT: boom");
+      }, [0, 0, 0]),
+    ).toThrow("SQLITE_CONSTRAINT");
+    expect(calls).toBe(1);
+  });
+
+  it("throws a descriptive error after exhausting all retries", () => {
+    expect(() =>
+      withRetry(() => {
+        throw new Error("database is locked");
+      }, [0, 0]),
+    ).toThrow(/database is locked after 2 retries/);
+  });
+
+  it("actually sleeps for a non-zero delay between retries", () => {
+    let calls = 0;
+    const start = Date.now();
+    const result = withRetry(() => {
+      calls++;
+      if (calls < 2) throw new Error("SQLITE_BUSY");
+      return "ok";
+    }, [25]);
+    expect(result).toBe("ok");
+    // Allow scheduler slack, but the ~25ms sleep must have elapsed.
+    expect(Date.now() - start).toBeGreaterThanOrEqual(20);
+  });
+});


### PR DESCRIPTION
Fixes the CPU-spin half of #985.

`withRetry` (src/db-base.ts) backs off between `SQLITE_BUSY` retries, but because better-sqlite3 is synchronous it cannot `await` a timer, so it slept with a `while (Date.now() - start < delay)` busy-wait. That pins a CPU core for the full 100+500+2000 ms window; under multi-session write contention on the shared per-project `content/<hash>.db` this accumulated hundreds of CPU-seconds per instance (observed: 99% of a core, 665 lifetime CPU-s).

**Change:** replace the spin with `Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delay)` — a real blocking sleep with no CPU cost. Behavior is otherwise identical: it still blocks `delay` ms between attempts, and a zero delay returns immediately (preserving the `[0, 0, 0]` test contract).

Adds `tests/util/with-retry.test.ts` covering retry-then-succeed, non-BUSY rethrow, exhaustion, the source-level guard, and that a non-zero delay elapses.

Does not address the underlying contention (shared per-project DB); that's the other half of #985 and a larger change.