### PR TITLE
fix(security): honor Pi project permission settings

### DIFF
--- a/src/security.ts
+++ b/src/security.ts
@@ -1,7 +1,10 @@
 import { readFileSync, realpathSync } from "node:fs";
 import { relative, resolve, sep } from "node:path";
 
-import { resolveAdapterGlobalSettingsPaths } from "./util/claude-config.js";
+import {
+  resolveAdapterGlobalSettingsPaths,
+  resolveAdapterProjectSettingsPaths,
+} from "./util/claude-config.js";
 
 // ==============================================================================
 // Types
@@ -351,13 +354,16 @@ function readSingleSettings(path: string): SecurityPolicy | null {
 }
 
 /**
- * Read Bash permission policies from up to 3 settings files.
+ * Read Bash permission policies from adapter-aware project settings and global
+ * settings files.
  *
- * Returns policies in precedence order (most local first):
- *   1. .claude/settings.local.json  (project-local)
- *   2. .claude/settings.json        (project-shared)
- *   3. ~/.claude/settings.json      (global)
+ * Project precedence is resolved by `resolveAdapterProjectSettingsPaths`.
+ * Claude Code keeps its existing order:
+ *   1. .claude/settings.local.json
+ *   2. .claude/settings.json
  *
+ * Adapters with a documented native project settings path place it before
+ * those Claude compatibility paths. Global settings follow all project files.
  * Missing or invalid files are silently skipped.
  */
 export function readBashPolicies(
@@ -367,13 +373,10 @@ export function readBashPolicies(
   const policies: SecurityPolicy[] = [];
 
   if (projectDir) {
-    const localPath = resolve(projectDir, ".claude", "settings.local.json");
-    const localPolicy = readSingleSettings(localPath);
-    if (localPolicy) policies.push(localPolicy);
-
-    const sharedPath = resolve(projectDir, ".claude", "settings.json");
-    const sharedPolicy = readSingleSettings(sharedPath);
-    if (sharedPolicy) policies.push(sharedPolicy);
+    for (const projectPath of resolveAdapterProjectSettingsPaths(projectDir)) {
+      const projectPolicy = readSingleSettings(projectPath);
+      if (projectPolicy) policies.push(projectPolicy);
+    }
   }
 
   // Issue #451 round-3: read settings from EVERY adapter-specific global path
@@ -396,9 +399,10 @@ export function readBashPolicies(
 /**
  * Read deny patterns for a specific tool from settings files.
  *
- * Reads the same 3-tier settings as `readBashPolicies`, but extracts
- * only deny globs for the given tool. Used for Read and Grep enforcement
- * — checks if file paths should be blocked by deny patterns.
+ * Reads the same adapter-aware project and global settings as
+ * `readBashPolicies`, but extracts only deny globs for the given tool. Used for
+ * Read and Grep enforcement — checks if file paths should be blocked by deny
+ * patterns.
  *
  * Returns an array of arrays (one per settings file, in precedence order).
  * Each inner array contains the extracted glob strings.
@@ -413,7 +417,8 @@ export function readToolDenyPatterns(
 
 /**
  * Read `permissions.{deny|allow}` globs for a tool from every settings file in
- * precedence order (project local → project shared → adapter globals).
+ * precedence order (adapter project paths → Claude project compatibility →
+ * adapter globals).
  *
  * Generalizes the original deny-only reader so the project-boundary guard
  * (#852) can consult the SAME `permissions.allow` rules the user already
@@ -461,15 +466,10 @@ export function readToolPermissionPatterns(
   };
 
   if (projectDir) {
-    const localGlobs = extractGlobs(
-      resolve(projectDir, ".claude", "settings.local.json"),
-    );
-    if (localGlobs !== null) result.push(localGlobs);
-
-    const sharedGlobs = extractGlobs(
-      resolve(projectDir, ".claude", "settings.json"),
-    );
-    if (sharedGlobs !== null) result.push(sharedGlobs);
+    for (const projectPath of resolveAdapterProjectSettingsPaths(projectDir)) {
+      const projectGlobs = extractGlobs(projectPath);
+      if (projectGlobs !== null) result.push(projectGlobs);
+    }
   }
 
   // Issue #451 round-3: union over every adapter-specific global path PLUS

--- a/src/util/claude-config.ts
+++ b/src/util/claude-config.ts
@@ -24,6 +24,7 @@
 import { resolve } from "node:path";
 import { homedir } from "node:os";
 import { detectPlatform, getSessionDirSegments } from "../adapters/detect.js";
+import type { PlatformId } from "../adapters/types.js";
 
 export function resolveClaudeConfigDir(env: NodeJS.ProcessEnv = process.env): string {
   const envVal = env.CLAUDE_CONFIG_DIR;
@@ -41,6 +42,50 @@ export function resolveClaudeGlobalSettingsPath(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
   return resolve(resolveClaudeConfigDir(env), "settings.json");
+}
+
+type ProjectSettingsSegments = readonly (readonly string[])[];
+
+const CLAUDE_PROJECT_SETTINGS_SEGMENTS: ProjectSettingsSegments = [
+  [".claude", "settings.local.json"],
+  [".claude", "settings.json"],
+];
+
+/**
+ * Documented project-level permission settings paths for adapters that do not
+ * use Claude Code's `.claude` convention. Add new adapters here instead of
+ * branching inside the security readers.
+ *
+ * Pi documents `.pi/settings.json` as its only project settings file; it does
+ * not define a project `settings.local.json` convention.
+ */
+const ADAPTER_PROJECT_SETTINGS_SEGMENTS: Readonly<
+  Partial<Record<PlatformId, ProjectSettingsSegments>>
+> = {
+  pi: [[".pi", "settings.json"]],
+};
+
+/**
+ * Resolve project settings in policy precedence order.
+ *
+ * Adapter-native paths come first, followed by Claude Code's existing local
+ * and shared paths as compatibility fallbacks. The result is deduplicated so
+ * an adapter can adopt a Claude-compatible path without reading it twice.
+ */
+export function resolveAdapterProjectSettingsPaths(projectDir: string): string[] {
+  const platform = detectPlatform().platform;
+  const adapterSegments = ADAPTER_PROJECT_SETTINGS_SEGMENTS[platform] ?? [];
+  const paths: string[] = [];
+
+  for (const segments of [
+    ...adapterSegments,
+    ...CLAUDE_PROJECT_SETTINGS_SEGMENTS,
+  ]) {
+    const settingsPath = resolve(projectDir, ...segments);
+    if (!paths.includes(settingsPath)) paths.push(settingsPath);
+  }
+
+  return paths;
 }
 
 /**

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -22,8 +22,10 @@ import {
   evaluateCommandDenyOnly,
   parseToolPattern,
   readToolDenyPatterns,
+  readToolPermissionPatterns,
   fileGlobToRegex,
   evaluateFilePath,
+  evaluateProjectContainment,
   extractShellCommands,
 } from "../build/security.js";
 
@@ -992,5 +994,160 @@ describe("cross-adapter deny-policy parity (#451 round-3)", () => {
       allDeny.includes("Bash(claude-only *)"),
       `expected claude deny in union (defense in depth), got ${JSON.stringify(allDeny)}`,
     );
+  });
+});
+
+/**
+ * Pi documents `<project>/.pi/settings.json` as its project settings file.
+ * Security readers must prefer it while retaining the existing Claude project
+ * paths as compatibility fallbacks. Both allow and deny extraction share the
+ * same resolver so the project-boundary escape hatch cannot drift from deny
+ * enforcement.
+ */
+describe("Pi project permission settings", () => {
+  let tmpBase: string;
+  let projectDir: string;
+  let externalFile: string;
+  let missingGlobalPath: string;
+  let piAllowGlob: string;
+  let claudeLocalAllowGlob: string;
+  let claudeSharedAllowGlob: string;
+  let savedPlatform: string | undefined;
+
+  beforeAll(() => {
+    tmpBase = join(tmpdir(), `security-pi-project-test-${Date.now()}`);
+    projectDir = join(tmpBase, "project");
+    const piDir = join(projectDir, ".pi");
+    const claudeDir = join(projectDir, ".claude");
+    const externalDir = join(tmpBase, "ExternalEngine");
+    externalFile = join(externalDir, "CoreTypes.h");
+    missingGlobalPath = join(tmpBase, "missing-global-settings.json");
+    piAllowGlob = join(externalDir, "**");
+    claudeLocalAllowGlob = join(tmpBase, "claude-local", "**");
+    claudeSharedAllowGlob = join(tmpBase, "claude-shared", "**");
+
+    mkdirSync(piDir, { recursive: true });
+    mkdirSync(claudeDir, { recursive: true });
+    mkdirSync(externalDir, { recursive: true });
+    writeFileSync(externalFile, "// external engine fixture\n");
+
+    writeFileSync(
+      join(piDir, "settings.json"),
+      JSON.stringify({
+        permissions: {
+          allow: [
+            `Read(${piAllowGlob})`,
+            "Read(D:/ExternalEngine/**)",
+            "Bash(pi-safe:*)",
+          ],
+          deny: ["Read(**/*.pi-secret)", "Bash(pi-blocked:*)"],
+        },
+      }),
+    );
+    writeFileSync(
+      join(claudeDir, "settings.local.json"),
+      JSON.stringify({
+        permissions: {
+          allow: [`Read(${claudeLocalAllowGlob})`, "Bash(claude-local-safe:*)"],
+          deny: [
+            "Read(**/*.claude-local-secret)",
+            "Bash(claude-local-blocked:*)",
+          ],
+        },
+      }),
+    );
+    writeFileSync(
+      join(claudeDir, "settings.json"),
+      JSON.stringify({
+        permissions: {
+          allow: [`Read(${claudeSharedAllowGlob})`, "Bash(claude-shared-safe:*)"],
+          deny: [
+            "Read(**/*.claude-shared-secret)",
+            "Bash(claude-shared-blocked:*)",
+          ],
+        },
+      }),
+    );
+
+    savedPlatform = process.env.CONTEXT_MODE_PLATFORM;
+    process.env.CONTEXT_MODE_PLATFORM = "pi";
+  });
+
+  afterAll(() => {
+    if (savedPlatform === undefined) delete process.env.CONTEXT_MODE_PLATFORM;
+    else process.env.CONTEXT_MODE_PLATFORM = savedPlatform;
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  test("Pi allow rules precede Claude local and shared compatibility rules", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "pi";
+    const allowGlobs = readToolPermissionPatterns(
+      "Read",
+      "allow",
+      projectDir,
+      missingGlobalPath,
+    );
+
+    assert.deepEqual(allowGlobs, [
+      [piAllowGlob, "D:/ExternalEngine/**"],
+      [claudeLocalAllowGlob],
+      [claudeSharedAllowGlob],
+    ]);
+    assert.deepEqual(
+      evaluateProjectContainment(externalFile, projectDir, allowGlobs),
+      { allowed: true, reason: "allow-rule" },
+    );
+  });
+
+  test("Pi deny rules use the same project settings precedence", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "pi";
+    const denyGlobs = readToolDenyPatterns(
+      "Read",
+      projectDir,
+      missingGlobalPath,
+    );
+
+    assert.deepEqual(denyGlobs, [
+      ["**/*.pi-secret"],
+      ["**/*.claude-local-secret"],
+      ["**/*.claude-shared-secret"],
+    ]);
+  });
+
+  test("Bash policy loading uses the same Pi-first resolver", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "pi";
+    const policies = readBashPolicies(projectDir, missingGlobalPath);
+
+    assert.deepEqual(
+      policies.map((policy) => policy.allow),
+      [
+        ["Bash(pi-safe:*)"],
+        ["Bash(claude-local-safe:*)"],
+        ["Bash(claude-shared-safe:*)"],
+      ],
+    );
+    assert.deepEqual(
+      policies.map((policy) => policy.deny),
+      [
+        ["Bash(pi-blocked:*)"],
+        ["Bash(claude-local-blocked:*)"],
+        ["Bash(claude-shared-blocked:*)"],
+      ],
+    );
+  });
+
+  test("Claude Code keeps local-before-shared behavior and ignores Pi settings", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "claude-code";
+    const allowGlobs = readToolPermissionPatterns(
+      "Read",
+      "allow",
+      projectDir,
+      missingGlobalPath,
+    );
+
+    assert.deepEqual(allowGlobs, [
+      [claudeLocalAllowGlob],
+      [claudeSharedAllowGlob],
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- resolve project permission settings according to the detected adapter
- support Pi project-level permissions in .pi/settings.json
- retain Claude project settings as a compatibility fallback
- add coverage for Pi allow/deny behavior and legacy compatibility

## Testing

- npm run typecheck
- targeted security, project-boundary, Pi adapter, and config tests passed
- full suite: 4702 passed, 46 skipped; one unrelated Windows cache-heal test was flaky due to a stale breadcrumb realpath ENOENT

## Compatibility

Claude Code projects continue to use .claude/settings.local.json and .claude/settings.json. Pi projects can now keep permission rules in .pi/settings.json.
