### PR TITLE
fix: preserve compound shell syntax in batch execution

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1466,7 +1466,7 @@ export function buildBatchNodeOptionsPrefix(shellPath: string, preloadPath: stri
     return `set "NODE_OPTIONS=${option.replace(/"/g, '""')}" && `;
   }
 
-  return `NODE_OPTIONS=${quotePosixSingle(option)} `;
+  return `export NODE_OPTIONS=${quotePosixSingle(option)}; `;
 }
 
 /**

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -3353,9 +3353,20 @@ describe("runBatchCommands edge cases", () => {
     expect(seen[0]).toBe('NODE_OPTIONS="--require /tmp/x" echo hi');
   });
 
-  test("buildBatchNodeOptionsPrefix formats POSIX shell assignment", () => {
+  test("buildBatchNodeOptionsPrefix formats POSIX shell export", () => {
     const prefix = buildBatchNodeOptionsPrefix("bash", "/tmp/cm fs'preload.js");
-    expect(prefix).toBe("NODE_OPTIONS='--require /tmp/cm fs'\\''preload.js' ");
+    expect(prefix).toBe("export NODE_OPTIONS='--require /tmp/cm fs'\\''preload.js'; ");
+  });
+
+  test("POSIX node options prefix permits compound shell commands", () => {
+    const prefix = buildBatchNodeOptionsPrefix("bash", "/tmp/cm-fs-preload.js");
+    const result = spawnSync("bash", ["-c", `${prefix}for value in one two; do printf '%s\\n' "$value"; done`], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("one\ntwo\n");
   });
 
   test("buildBatchNodeOptionsPrefix formats PowerShell assignment", () => {


### PR DESCRIPTION
## Summary
- export `NODE_OPTIONS` as a POSIX shell statement before batch commands
- preserve compound commands such as `for`, `if`, functions, and groups
- add a real-shell regression test for a `for` loop

## Root cause
A leading environment assignment can prefix only a simple command. Concatenating it before a shell reserved word produced invalid syntax (`NODE_OPTIONS=... for ...`).

## Verification
- `bunx vitest run tests/core/server.test.ts -t "buildBatchNodeOptionsPrefix|POSIX node options prefix"`
- `bun run typecheck`