### PR TITLE
Fix VS Code Remote-WSL project root detection (issue #1032)

### DIFF
--- a/src/adapters/vscode-copilot/index.ts
+++ b/src/adapters/vscode-copilot/index.ts
@@ -22,6 +22,7 @@ import { homedir } from "node:os";
 
 import { CopilotBaseAdapter } from "../copilot-base.js";
 import { resolveContextModeDataRoot } from "../base.js";
+import { isVSCodeInstallPath } from "../../util/project-dir.js";
 import type { CopilotHookInput, CopilotHookModule } from "../copilot-base.js";
 
 import type {
@@ -77,10 +78,13 @@ export class VSCodeCopilotAdapter extends CopilotBaseAdapter {
     //      from this cascade — every direct VS Code Copilot session silently
     //      lost its workspace folder. PR #689 5-agent EM audit (Phase A
     //      claim verification) confirmed the gap; this is the minimal fix.
+    //      Skipped when it points at VS Code's own install directory: that
+    //      launch cwd is poisoned for remote workspaces.
     //   3. process.cwd() — last resort.
+    const vscodeCwd = process.env.VSCODE_CWD;
     return (
       process.env.CLAUDE_PROJECT_DIR
-      || process.env.VSCODE_CWD
+      || (vscodeCwd && !isVSCodeInstallPath(vscodeCwd) ? vscodeCwd : undefined)
       || process.cwd()
     );
   }

--- a/src/util/project-dir.ts
+++ b/src/util/project-dir.ts
@@ -68,6 +68,23 @@ export function isPluginInstallPath(p: string): boolean {
 }
 
 /**
+ * Detect whether a path is VS Code's own application install directory
+ * rather than a real workspace folder.
+ *
+ * VS Code exports its launch cwd as VSCODE_CWD to spawned children. When the
+ * UI is launched from a shortcut and the workspace is remote, that cwd can
+ * be the local VS Code installation directory rather than the remote project.
+ */
+export function isVSCodeInstallPath(p: string): boolean {
+  if (!p) return false;
+  return (
+    /[/\\]Microsoft VS Code(?: - Insiders)?(?:[/\\]|$)/i.test(p) ||
+    /[/\\]Visual Studio Code(?: - Insiders)?(?:\.app)?(?:[/\\]|$)/i.test(p) ||
+    /[/\\](?:usr[/\\]share|opt)[/\\]code(?:-insiders)?(?:[/\\]|$)/i.test(p)
+  );
+}
+
+/**
  * Read the per-session project dir from Claude Code's transcript files.
  *
  * Claude Code writes session transcripts under

--- a/tests/adapters/vscode-copilot.test.ts
+++ b/tests/adapters/vscode-copilot.test.ts
@@ -99,6 +99,15 @@ describe("VSCodeCopilotAdapter", () => {
       expect(event.projectDir).toBe("/vscode/workspace");
     });
 
+    it("skips VSCODE_CWD when it points at the VS Code install path", () => {
+      delete process.env.CLAUDE_PROJECT_DIR;
+      process.env.VSCODE_CWD = "C:\\Users\\{userName}\\AppData\\Local\\Programs\\Microsoft VS Code";
+      const event = adapter.parsePreToolUseInput({
+        tool_name: "readFile",
+      });
+      expect(event.projectDir).toBe(process.cwd());
+    });
+
     it("CLAUDE_PROJECT_DIR still wins over VSCODE_CWD when both are set (cascade order)", () => {
       // Cascade order is locked: CLAUDE_PROJECT_DIR remains the top priority
       // for users running VS Code under Claude Code's CLI; VSCODE_CWD is the

--- a/tests/server-stdin-eof-exit.test.ts
+++ b/tests/server-stdin-eof-exit.test.ts
@@ -194,7 +194,11 @@ setTimeout(() => {
     });
 
     try {
-      const result = await waitForClose(child, 2_000);
+      // The standalone bundle can take several seconds to initialize under
+      // WSL, especially when native dependencies are cold. The fatal handler
+      // still exits promptly after registration; allow startup time before
+      // classifying the child as surviving the exception storm.
+      const result = await waitForClose(child, 10_000);
       if (!result.closed) {
         child.kill("SIGTERM");
         await waitForClose(child, 1_000);

--- a/tests/util/project-dir.test.ts
+++ b/tests/util/project-dir.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   isPluginInstallPath,
+  isVSCodeInstallPath,
   resolveProjectDir,
   resolveProjectDirFromTranscript,
 } from "../../src/util/project-dir.js";
@@ -94,6 +95,30 @@ describe("isPluginInstallPath", () => {
   it("returns false for empty / null-ish inputs", () => {
     expect(isPluginInstallPath("")).toBe(false);
     expect(isPluginInstallPath("/")).toBe(false);
+  });
+});
+
+describe("isVSCodeInstallPath", () => {
+  it("matches Windows stable and Insiders install paths", () => {
+    expect(isVSCodeInstallPath("C:\\Users\\{userName}\\AppData\\Local\\Programs\\Microsoft VS Code")).toBe(true);
+    expect(isVSCodeInstallPath("C:\\Users\\{userName}\\AppData\\Local\\Programs\\Microsoft VS Code - Insiders")).toBe(true);
+  });
+
+  it("matches macOS app bundles", () => {
+    expect(isVSCodeInstallPath("/Applications/Visual Studio Code.app/Contents/Resources/app")).toBe(true);
+    expect(isVSCodeInstallPath("/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app")).toBe(true);
+  });
+
+  it("matches Linux stable and Insiders install paths", () => {
+    expect(isVSCodeInstallPath("/usr/share/code")).toBe(true);
+    expect(isVSCodeInstallPath("/usr/share/code-insiders")).toBe(true);
+    expect(isVSCodeInstallPath("/opt/code")).toBe(true);
+    expect(isVSCodeInstallPath("/opt/code-insiders")).toBe(true);
+  });
+
+  it("does not match an ordinary project containing code as a substring", () => {
+    expect(isVSCodeInstallPath("/home/{userName}/source/code-project")).toBe(false);
+    expect(isVSCodeInstallPath("C:\\Users\\{userName}\\workspace\\vscode-tools")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What / Why / How

Fixes #1032.

When VS Code is launched from a shortcut on Windows and opens a remote WSL workspace, `VSCODE_CWD` can point to the local VS Code installation directory rather than the remote workspace. The VS Code Copilot adapter previously trusted that value and anchored project-boundary checks to the install directory, rejecting legitimate remote file reads.

This change:

- Adds `isVSCodeInstallPath()` with cross-platform separator support for stable/Insiders Windows, macOS, and Linux install locations.
- Keeps `CLAUDE_PROJECT_DIR` as the highest-priority value.
- Skips an install-directory `VSCODE_CWD` and falls through to `process.cwd()`.
- Adds unit coverage for install-path detection and the adapter cascade.
- Hardens the existing standalone fatal-exit test timeout for slow WSL startup.

All paths and user names in the issue and tests are anonymized.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [x] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

- Focused Vitest: utility, VS Code adapter, and lifecycle tests — **67 passed**.
- `npm run typecheck` — passed.
- Build, bundle assertions, and asymmetric-drift assertions — passed.
- Full `npm test` — **4,703 passed, 44 skipped**.

The lifecycle test-only timeout change addresses slow standalone bundle startup under WSL; no production lifecycle behavior was changed.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch