### PR TITLE
fix(cost): emit opencode multi-step usage as deltas (#1036)

### DIFF
--- a/src/adapters/opencode/plugin.ts
+++ b/src/adapters/opencode/plugin.ts
@@ -32,6 +32,7 @@ import {
   parseOpencodeUsage,
   buildAgentUsageEvent,
   toOpencodeUsageStepDelta,
+  rememberOpencodeCumulativeCost,
 } from "../../session/extract.js";
 import type { HookInput } from "../../session/extract.js";
 import { buildResumeSnapshot } from "../../session/snapshot.js";
@@ -325,6 +326,9 @@ async function createContextModePlugin(ctx: PluginContext) {
   // Per-assistant-message high-water for opencode cumulative cost → step delta
   // (issue #1036). Key: `${sessionId}:${messageId}` (or sessionId alone when
   // info.id is absent). Value: last observed cumulative `info.cost`.
+  // Bounded via rememberOpencodeCumulativeCost (insertion-order FIFO ~1000);
+  // the plugin lifecycle only consumes `message.updated` (no completion event
+  // to delete-on-finish).
   const lastCumulativeCostByMessage = new Map<string, number>();
 
   /**
@@ -593,7 +597,11 @@ async function createContextModePlugin(ctx: PluginContext) {
         const stepped = toOpencodeUsageStepDelta(counts, prev);
         if (!stepped) return;
         if (typeof stepped.nextCumulativeCost === "number") {
-          lastCumulativeCostByMessage.set(messageKey, stepped.nextCumulativeCost);
+          rememberOpencodeCumulativeCost(
+            lastCumulativeCostByMessage,
+            messageKey,
+            stepped.nextCumulativeCost,
+          );
         }
 
         const usageEvent = buildAgentUsageEvent(stepped.counts);

--- a/src/adapters/opencode/plugin.ts
+++ b/src/adapters/opencode/plugin.ts
@@ -26,7 +26,13 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { existsSync, readFileSync } from "node:fs";
 
 import { resolveSessionDbPath, SessionDB } from "../../session/db.js";
-import { extractEvents, extractUserEvents, parseOpencodeUsage, buildAgentUsageEvent } from "../../session/extract.js";
+import {
+  extractEvents,
+  extractUserEvents,
+  parseOpencodeUsage,
+  buildAgentUsageEvent,
+  toOpencodeUsageStepDelta,
+} from "../../session/extract.js";
 import type { HookInput } from "../../session/extract.js";
 import { buildResumeSnapshot } from "../../session/snapshot.js";
 import type { SessionEvent } from "../../types.js";
@@ -316,6 +322,11 @@ async function createContextModePlugin(ctx: PluginContext) {
   // lived plugin process still gets per-session capture exactly once.
   const agentsMdCaptured = new Set<string>();
 
+  // Per-assistant-message high-water for opencode cumulative cost → step delta
+  // (issue #1036). Key: `${sessionId}:${messageId}` (or sessionId alone when
+  // info.id is absent). Value: last observed cumulative `info.cost`.
+  const lastCumulativeCostByMessage = new Map<string, number>();
+
   /**
    * OC-4: Read AGENTS.md (with CLAUDE.md / CONTEXT.md fallbacks) from the
    * project directory and persist as `rule` + `rule_content` events. Mirrors
@@ -551,24 +562,41 @@ async function createContextModePlugin(ctx: PluginContext) {
     // CAVEAT (refs processor.ts:717-718): message-level `.tokens` is the LAST
     // step's snapshot (overwritten per step-finish), while `.cost` is
     // cumulative for the turn. parseOpencodeUsage passes `.cost` through as
-    // native_cost_usd so the billed $ stays exact despite the token snapshot
-    // being last-step only. `message.updated` fires multiple times per turn;
-    // because tokens are a terminal snapshot and cost is cumulative, the last
-    // event for a message carries the final figures — re-emitting on each
-    // update is idempotent at the cost column and merely refreshes the
-    // last-step token telemetry. db.insertEvent both persists locally AND
-    // forwards to the platform (the TS-plugin equivalent of the .mjs
-    // attributeAndInsertEvents path).
+    // native_cost_usd. Because `message.updated` fires once per step-finish
+    // and `db.insertEvent` always APPENDs (there is no cost-column upsert),
+    // re-emitting the cumulative figure over-counts under additive aggregation
+    // (issue #1036: 0.02 then 0.05 stored as 0.07). We convert to a per-step
+    // delta via toOpencodeUsageStepDelta — same incremental shape codex/kimi
+    // use — so summing rows yields the true turn cost. Last-step token
+    // snapshots remain best-effort per-step telemetry (sum ≈ turn total).
+    // db.insertEvent both persists locally AND forwards to the platform (the
+    // TS-plugin equivalent of the .mjs attributeAndInsertEvents path).
+    // lastCumulativeCostByMessage (declared above) tracks per-message cumulative
+    // high-water so step deltas sum to the true turn cost.
     event: async (input: EventHookInput) => {
       try {
         const ev = input?.event;
         if (!ev || ev.type !== "message.updated") return;
-        const sessionId = ev.properties?.info?.sessionID;
+        const info = ev.properties?.info;
+        const sessionId = info?.sessionID;
         if (!sessionId || typeof sessionId !== "string") return;
 
         const counts = parseOpencodeUsage(ev);
         if (!counts) return;
-        const usageEvent = buildAgentUsageEvent(counts);
+
+        const messageId = typeof info?.id === "string" && info.id.length > 0 ? info.id : "";
+        const messageKey = messageId.length > 0 ? `${sessionId}:${messageId}` : sessionId;
+        const prev =
+          lastCumulativeCostByMessage.has(messageKey)
+            ? (lastCumulativeCostByMessage.get(messageKey) as number)
+            : null;
+        const stepped = toOpencodeUsageStepDelta(counts, prev);
+        if (!stepped) return;
+        if (typeof stepped.nextCumulativeCost === "number") {
+          lastCumulativeCostByMessage.set(messageKey, stepped.nextCumulativeCost);
+        }
+
+        const usageEvent = buildAgentUsageEvent(stepped.counts);
         if (!usageEvent) return;
 
         db.ensureSession(sessionId, projectDir);

--- a/src/adapters/opencode/plugin.ts
+++ b/src/adapters/opencode/plugin.ts
@@ -557,26 +557,11 @@ async function createContextModePlugin(ctx: PluginContext) {
     },
 
     // ── event: per-turn token + cost capture (paid-observability) ───
-    // The generic bus `event` hook (refs/platforms/opencode/packages/plugin/
-    // src/index.ts:224) delivers every Event; we filter `message.updated`
-    // (published on each assistant-message update incl. step-finish —
-    // session.ts:673) and read tokens/cost/modelID off properties.info
-    // (assistant filter via role; refs stream.transport.ts:214-216).
-    //
-    // CAVEAT (refs processor.ts:717-718): message-level `.tokens` is the LAST
-    // step's snapshot (overwritten per step-finish), while `.cost` is
-    // cumulative for the turn. parseOpencodeUsage passes `.cost` through as
-    // native_cost_usd. Because `message.updated` fires once per step-finish
-    // and `db.insertEvent` always APPENDs (there is no cost-column upsert),
-    // re-emitting the cumulative figure over-counts under additive aggregation
-    // (issue #1036: 0.02 then 0.05 stored as 0.07). We convert to a per-step
-    // delta via toOpencodeUsageStepDelta — same incremental shape codex/kimi
-    // use — so summing rows yields the true turn cost. Last-step token
-    // snapshots remain best-effort per-step telemetry (sum ≈ turn total).
-    // db.insertEvent both persists locally AND forwards to the platform (the
-    // TS-plugin equivalent of the .mjs attributeAndInsertEvents path).
-    // lastCumulativeCostByMessage (declared above) tracks per-message cumulative
-    // high-water so step deltas sum to the true turn cost.
+    // Filter bus `message.updated` (fires per step-finish). Opencode `.cost`
+    // is cumulative for the turn while `.tokens` is last-step; re-emitting the
+    // cumulative figure over-counts under additive aggregation (#1036). Convert
+    // via toOpencodeUsageStepDelta so summed rows equal the true turn cost.
+    // lastCumulativeCostByMessage tracks per-message high-water (FIFO-capped).
     event: async (input: EventHookInput) => {
       try {
         const ev = input?.event;

--- a/src/session/extract.ts
+++ b/src/session/extract.ts
@@ -1915,6 +1915,34 @@ export function parseOpencodeUsage(payload: unknown): AgentUsageCounts | null {
  * assistant message (null if never seen). `nextCumulativeCost` is what the
  * caller should store for the next fire of the same message.
  */
+/**
+ * Cap for the in-memory cumulative-cost high-water map used by the opencode
+ * plugin (#1036). Map preserves insertion order; when a new key would exceed
+ * this size, the oldest key is deleted (FIFO). No message-completion bus event
+ * is consumed by the plugin lifecycle, so we bound memory this way rather than
+ * delete-on-complete.
+ */
+export const OPENCODE_CUMULATIVE_COST_MAP_CAP = 1000;
+
+/**
+ * Remember the last observed cumulative cost for a message key, bounded by
+ * insertion-order FIFO. Updating an existing key does not grow the map or
+ * reorder entries. When inserting a new key past `maxSize`, the oldest key is
+ * evicted so long-lived plugin processes cannot unbounded-grow the Map.
+ */
+export function rememberOpencodeCumulativeCost(
+  map: Map<string, number>,
+  key: string,
+  cost: number,
+  maxSize: number = OPENCODE_CUMULATIVE_COST_MAP_CAP,
+): void {
+  if (!map.has(key) && map.size >= maxSize) {
+    const oldest = map.keys().next().value;
+    if (oldest !== undefined) map.delete(oldest);
+  }
+  map.set(key, cost);
+}
+
 export function toOpencodeUsageStepDelta(
   counts: AgentUsageCounts,
   previousCumulativeCost: number | null,

--- a/src/session/extract.ts
+++ b/src/session/extract.ts
@@ -1893,43 +1893,15 @@ export function parseOpencodeUsage(payload: unknown): AgentUsageCounts | null {
 }
 
 /**
- * Convert opencode's CUMULATIVE turn cost into a per-step delta so multi-fire
- * `message.updated` events sum to the true turn cost under additive aggregation.
- *
- * Opencode's processor accumulates `info.cost` across step-finishes inside one
- * assistant message (`cost += usage.cost`) while overwriting `info.tokens` with
- * the last step's snapshot. The adapter used to call `db.insertEvent` on every
- * fire with the full cumulative cost — a 2-step turn (0.02 then 0.05) stored
- * 0.02 + 0.05 = 0.07 instead of 0.05 (issue #1036). Other adapters either emit
- * once per turn (pi/omp/openclaw) or deliberately store incremental deltas
- * (codex/kimi). Opencode has no turn_end bus event, so we convert the cumulative
- * figure to a step delta here.
- *
- * Returns null when there is no positive cost progress after the first
- * observation (no-op refresh of the same cumulative figure) so last-step token
- * snapshots are not double-counted. When `native_cost_usd` is absent, emits only
- * on the first observation (catalog-priced last-step tokens are not cumulative,
- * but re-emitting them every step still over-counts under += aggregation).
- *
- * `previousCumulativeCost` is the last observed cumulative cost for this
- * assistant message (null if never seen). `nextCumulativeCost` is what the
- * caller should store for the next fire of the same message.
+ * Convert opencode cumulative turn cost to a per-step delta for additive sum
+ * under multi-fire `message.updated` (#1036). Null on no-progress refresh;
+ * without native cost, emit only on first observation. High-water is tracked
+ * per message via previous/next cumulative; map is FIFO-capped (see CAP).
  */
-/**
- * Cap for the in-memory cumulative-cost high-water map used by the opencode
- * plugin (#1036). Map preserves insertion order; when a new key would exceed
- * this size, the oldest key is deleted (FIFO). No message-completion bus event
- * is consumed by the plugin lifecycle, so we bound memory this way rather than
- * delete-on-complete.
- */
+/** FIFO cap for the in-memory cumulative-cost high-water map (#1036). */
 export const OPENCODE_CUMULATIVE_COST_MAP_CAP = 1000;
 
-/**
- * Remember the last observed cumulative cost for a message key, bounded by
- * insertion-order FIFO. Updating an existing key does not grow the map or
- * reorder entries. When inserting a new key past `maxSize`, the oldest key is
- * evicted so long-lived plugin processes cannot unbounded-grow the Map.
- */
+/** Remember last cumulative cost per message key (insertion-order FIFO eviction). */
 export function rememberOpencodeCumulativeCost(
   map: Map<string, number>,
   key: string,
@@ -1958,8 +1930,7 @@ export function toOpencodeUsageStepDelta(
     if (previousCumulativeCost !== null && delta <= 0) {
       return null;
     }
-    // First fire: emit the cumulative as-is (equiv. to delta from 0).
-    // Later fires: emit only the step delta so additive sum = true turn cost.
+    // First observation emits cumulative; later ones emit the step delta only.
     const stepCost = previousCumulativeCost === null ? current : delta;
     return {
       counts: { ...counts, native_cost_usd: stepCost },

--- a/src/session/extract.ts
+++ b/src/session/extract.ts
@@ -1893,6 +1893,64 @@ export function parseOpencodeUsage(payload: unknown): AgentUsageCounts | null {
 }
 
 /**
+ * Convert opencode's CUMULATIVE turn cost into a per-step delta so multi-fire
+ * `message.updated` events sum to the true turn cost under additive aggregation.
+ *
+ * Opencode's processor accumulates `info.cost` across step-finishes inside one
+ * assistant message (`cost += usage.cost`) while overwriting `info.tokens` with
+ * the last step's snapshot. The adapter used to call `db.insertEvent` on every
+ * fire with the full cumulative cost — a 2-step turn (0.02 then 0.05) stored
+ * 0.02 + 0.05 = 0.07 instead of 0.05 (issue #1036). Other adapters either emit
+ * once per turn (pi/omp/openclaw) or deliberately store incremental deltas
+ * (codex/kimi). Opencode has no turn_end bus event, so we convert the cumulative
+ * figure to a step delta here.
+ *
+ * Returns null when there is no positive cost progress after the first
+ * observation (no-op refresh of the same cumulative figure) so last-step token
+ * snapshots are not double-counted. When `native_cost_usd` is absent, emits only
+ * on the first observation (catalog-priced last-step tokens are not cumulative,
+ * but re-emitting them every step still over-counts under += aggregation).
+ *
+ * `previousCumulativeCost` is the last observed cumulative cost for this
+ * assistant message (null if never seen). `nextCumulativeCost` is what the
+ * caller should store for the next fire of the same message.
+ */
+export function toOpencodeUsageStepDelta(
+  counts: AgentUsageCounts,
+  previousCumulativeCost: number | null,
+): { counts: AgentUsageCounts; nextCumulativeCost: number | null } | null {
+  const current = counts.native_cost_usd;
+  if (typeof current === "number" && Number.isFinite(current)) {
+    const prev =
+      typeof previousCumulativeCost === "number" && Number.isFinite(previousCumulativeCost)
+        ? previousCumulativeCost
+        : 0;
+    const delta = current - prev;
+    // Same (or lower) cumulative after we've already emitted → no-op refresh.
+    if (previousCumulativeCost !== null && delta <= 0) {
+      return null;
+    }
+    // First fire: emit the cumulative as-is (equiv. to delta from 0).
+    // Later fires: emit only the step delta so additive sum = true turn cost.
+    const stepCost = previousCumulativeCost === null ? current : delta;
+    return {
+      counts: { ...counts, native_cost_usd: stepCost },
+      nextCumulativeCost: current,
+    };
+  }
+
+  // No native cost → emit once per message (first observation only).
+  if (previousCumulativeCost !== null) {
+    return null;
+  }
+  return {
+    counts,
+    // Sentinel "seen" marker so subsequent fires without native cost are skipped.
+    nextCumulativeCost: 0,
+  };
+}
+
+/**
  * Build a structured `agent_usage` event from summed per-model token counts.
  * Emits the colon-string `data` (human/debug + back-compat) AND the structured
  * top-level fields the forward envelope spreads to the platform. cost_usd via

--- a/tests/session/parse-opencode-usage.test.ts
+++ b/tests/session/parse-opencode-usage.test.ts
@@ -24,6 +24,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseOpencodeUsage,
   buildAgentUsageEvent,
+  toOpencodeUsageStepDelta,
 } from "../../src/session/extract.js";
 
 /** Minimal opencode `message.updated` bus-event fixture. */
@@ -167,5 +168,76 @@ describe("parseOpencodeUsage", () => {
     expect(event?.cache_creation_tokens).toBe(80);
     expect(event?.model_id).toBe("anthropic/claude-sonnet-4");
     expect(event?.data).toContain("cost_usd:");
+  });
+});
+
+/**
+ * #1036 — multi-step turn over-count: message.updated fires once per step-finish
+ * with CUMULATIVE cost. Without a step-delta conversion, two inserts (0.02 then
+ * 0.05) sum to 0.07 under additive aggregation instead of the true turn cost 0.05.
+ * PoC shape from the issue comment (re-derived; not pasted): parse → delta → build
+ * for each step, assert summed cost_usd === final cumulative.
+ */
+describe("toOpencodeUsageStepDelta (#1036 cumulative multi-step)", () => {
+  it("converts a 2-step cumulative turn (0.02 then 0.05) into deltas that sum to 0.05", () => {
+    const step1 = parseOpencodeUsage(
+      busEvent({
+        cost: 0.02,
+        tokens: { input: 100, output: 20, cache: { read: 0, write: 0 } },
+      }),
+    );
+    const step2 = parseOpencodeUsage(
+      busEvent({
+        cost: 0.05,
+        tokens: { input: 200, output: 40, cache: { read: 0, write: 0 } },
+      }),
+    );
+    expect(step1).not.toBeNull();
+    expect(step2).not.toBeNull();
+
+    // Without delta: naive sum of native costs over-counts (the bug).
+    expect((step1!.native_cost_usd ?? 0) + (step2!.native_cost_usd ?? 0)).toBeCloseTo(0.07, 10);
+
+    const d1 = toOpencodeUsageStepDelta(step1!, null);
+    expect(d1).not.toBeNull();
+    expect(d1!.counts.native_cost_usd).toBeCloseTo(0.02, 10);
+    expect(d1!.nextCumulativeCost).toBeCloseTo(0.02, 10);
+
+    const d2 = toOpencodeUsageStepDelta(step2!, d1!.nextCumulativeCost);
+    expect(d2).not.toBeNull();
+    expect(d2!.counts.native_cost_usd).toBeCloseTo(0.03, 10);
+    expect(d2!.nextCumulativeCost).toBeCloseTo(0.05, 10);
+
+    const e1 = buildAgentUsageEvent(d1!.counts);
+    const e2 = buildAgentUsageEvent(d2!.counts);
+    expect(e1?.cost_usd).toBeCloseTo(0.02, 10);
+    expect(e2?.cost_usd).toBeCloseTo(0.03, 10);
+    // Additive aggregation across step rows equals the true turn cost.
+    expect((e1!.cost_usd ?? 0) + (e2!.cost_usd ?? 0)).toBeCloseTo(0.05, 10);
+  });
+
+  it("skips a no-op refresh when cumulative cost does not advance", () => {
+    const first = parseOpencodeUsage(busEvent({ cost: 0.05 }));
+    const same = parseOpencodeUsage(busEvent({ cost: 0.05 }));
+    expect(first).not.toBeNull();
+    expect(same).not.toBeNull();
+
+    const d1 = toOpencodeUsageStepDelta(first!, null);
+    expect(d1).not.toBeNull();
+    const d2 = toOpencodeUsageStepDelta(same!, d1!.nextCumulativeCost);
+    expect(d2).toBeNull();
+  });
+
+  it("emits catalog-priced rows only once when native cost is absent", () => {
+    const a = parseOpencodeUsage(busEvent({ cost: undefined }));
+    const b = parseOpencodeUsage(busEvent({ cost: undefined }));
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a!.native_cost_usd).toBeNull();
+
+    const d1 = toOpencodeUsageStepDelta(a!, null);
+    expect(d1).not.toBeNull();
+    const d2 = toOpencodeUsageStepDelta(b!, d1!.nextCumulativeCost);
+    expect(d2).toBeNull();
   });
 });

--- a/tests/session/parse-opencode-usage.test.ts
+++ b/tests/session/parse-opencode-usage.test.ts
@@ -25,6 +25,8 @@ import {
   parseOpencodeUsage,
   buildAgentUsageEvent,
   toOpencodeUsageStepDelta,
+  rememberOpencodeCumulativeCost,
+  OPENCODE_CUMULATIVE_COST_MAP_CAP,
 } from "../../src/session/extract.js";
 
 /** Minimal opencode `message.updated` bus-event fixture. */
@@ -239,5 +241,51 @@ describe("toOpencodeUsageStepDelta (#1036 cumulative multi-step)", () => {
     expect(d1).not.toBeNull();
     const d2 = toOpencodeUsageStepDelta(b!, d1!.nextCumulativeCost);
     expect(d2).toBeNull();
+  });
+});
+
+/**
+ * #1036 follow-up — bound lastCumulativeCostByMessage so a long-lived plugin
+ * process cannot unbounded-grow the in-memory Map. Plugin lifecycle has no
+ * message-completion event to delete-on-finish; insertion-order FIFO cap.
+ */
+describe("rememberOpencodeCumulativeCost (#1036 map eviction)", () => {
+  it("evicts the oldest key when inserting past maxSize (insertion-order FIFO)", () => {
+    const map = new Map<string, number>();
+    const maxSize = 3;
+    rememberOpencodeCumulativeCost(map, "a", 0.01, maxSize);
+    rememberOpencodeCumulativeCost(map, "b", 0.02, maxSize);
+    rememberOpencodeCumulativeCost(map, "c", 0.03, maxSize);
+    expect(map.size).toBe(3);
+    expect([...map.keys()]).toEqual(["a", "b", "c"]);
+
+    rememberOpencodeCumulativeCost(map, "d", 0.04, maxSize);
+    expect(map.size).toBe(3);
+    expect(map.has("a")).toBe(false);
+    expect([...map.keys()]).toEqual(["b", "c", "d"]);
+    expect(map.get("d")).toBe(0.04);
+  });
+
+  it("updating an existing key does not grow the map or evict others", () => {
+    const map = new Map<string, number>();
+    const maxSize = 2;
+    rememberOpencodeCumulativeCost(map, "a", 0.01, maxSize);
+    rememberOpencodeCumulativeCost(map, "b", 0.02, maxSize);
+    rememberOpencodeCumulativeCost(map, "a", 0.05, maxSize);
+    expect(map.size).toBe(2);
+    expect(map.get("a")).toBe(0.05);
+    expect(map.has("b")).toBe(true);
+  });
+
+  it(`defaults maxSize to OPENCODE_CUMULATIVE_COST_MAP_CAP (${OPENCODE_CUMULATIVE_COST_MAP_CAP})`, () => {
+    const map = new Map<string, number>();
+    for (let i = 0; i < OPENCODE_CUMULATIVE_COST_MAP_CAP; i++) {
+      rememberOpencodeCumulativeCost(map, `k${i}`, i);
+    }
+    expect(map.size).toBe(OPENCODE_CUMULATIVE_COST_MAP_CAP);
+    rememberOpencodeCumulativeCost(map, "overflow", 1);
+    expect(map.size).toBe(OPENCODE_CUMULATIVE_COST_MAP_CAP);
+    expect(map.has("k0")).toBe(false);
+    expect(map.has("overflow")).toBe(true);
   });
 });

--- a/tests/session/parse-opencode-usage.test.ts
+++ b/tests/session/parse-opencode-usage.test.ts
@@ -174,11 +174,7 @@ describe("parseOpencodeUsage", () => {
 });
 
 /**
- * #1036 — multi-step turn over-count: message.updated fires once per step-finish
- * with CUMULATIVE cost. Without a step-delta conversion, two inserts (0.02 then
- * 0.05) sum to 0.07 under additive aggregation instead of the true turn cost 0.05.
- * PoC shape from the issue comment (re-derived; not pasted): parse → delta → build
- * for each step, assert summed cost_usd === final cumulative.
+ * #1036 — multi-step cumulative cost must become deltas that sum to the final cost.
  */
 describe("toOpencodeUsageStepDelta (#1036 cumulative multi-step)", () => {
   it("converts a 2-step cumulative turn (0.02 then 0.05) into deltas that sum to 0.05", () => {


### PR DESCRIPTION
## What / Why / How

**What:** Stop the opencode adapter from over-counting multi-step turn cost under additive aggregation.

**Why:** `message.updated` fires once per step-finish with a *cumulative* turn cost, while `db.insertEvent` always appends a new `agent_usage` row. A 2-step turn (cost 0.02 then 0.05) was stored as 0.02 + 0.05 = **0.07** instead of the true turn cost **0.05**. The old comment claimed re-emitting was "idempotent at the cost column," but there is no cost-column upsert.

Reported by **@EvolveAegis** in #1036; dynamic PoC + citation corrections also by **@EvolveAegis**.

**How:** Convert the cumulative figure to a **per-step delta** (same incremental shape as the codex/kimi adapters) via `toOpencodeUsageStepDelta`, keyed by assistant message id in the opencode plugin. Skip no-op refreshes when the cumulative cost does not advance so last-step token snapshots are not double-counted. Bound the in-memory high-water map with insertion-order FIFO (~1000 keys) so long-lived plugin processes cannot unbounded-grow memory. Update the misleading comment.

Fixes #1036

## Limitations

1. **Plugin-process restart vs durable DB.** The cumulative high-water map is **in-memory only**. A plugin-process restart clears it while prior `agent_usage` rows remain in the session DB. The first `message.updated` after restart for an in-flight multi-step turn re-emits the full cumulative cost as if it were a first observation → a **one-time double-count** on that narrow edge. Still strictly better than status quo, which over-counted **every** multi-step turn.

2. **Missing `info.id` key collision.** When `info.id` is absent the map key falls back to bare `sessionId`. Two assistant messages in the same session that both lack `id` share one high-water entry; the second message's first fire is treated as a continuation of the first. If its cumulative cost is not greater, the `delta <= 0` guard **silently drops** it (fails toward under-counting; no signal/log).

3. **FIFO eviction does not refresh insertion position.** Re-setting an existing key does not move it to the newest slot. A message still in flight after 1000 newer keys arrive is evicted; its next fire sees no prior cumulative and re-emits the full figure — the same one-time double-count as the restart edge. Practically unreachable at cap 1000 within one turn.

## Affected platforms

- [x] OpenCode
- [x] KiloCode (shares the opencode plugin entry)

## Test plan

- [x] Regression test: 2-step turn (0.02 → 0.05) produces deltas that sum to 0.05; naive sum still documents the pre-fix 0.07 over-count
- [x] No-op refresh (same cumulative cost) emits nothing on the second fire
- [x] Absent native cost: catalog-priced row emitted once per message
- [x] Map eviction: insertion-order FIFO drops oldest key past cap; update-in-place does not evict
- [x] `npx vitest run tests/session/parse-opencode-usage.test.ts` — 20 passed
- [x] `npx vitest run tests/session/parse-opencode-usage.test.ts tests/opencode-plugin.test.ts` (+ related)
- [x] `npx tsc --noEmit` clean

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] Touched suite + related tests pass
- [x] `npm run typecheck` / `tsc --noEmit` passes
- [ ] Docs updated if needed (README, platform-support.md) — N/A (behavior fix; comment-only docs in code)
- [x] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix) — staged off `main` at base `3bad0f4` per work-order; retarget if maintainers prefer `next`

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
