### PR TITLE
fix: allow opt-in proxy env passthrough in ctx_fetch_and_index (CTX_FETCH_ALLOW_PROXY)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2864,23 +2864,12 @@ export function buildFetchCode(url: string, outputPath: string): string {
       ? `var classifyIp = ${classifyIpInner};`
       : `var ${classifyIpFnName} = ${classifyIpInner};\nvar classifyIp = ${classifyIpFnName};`;
   const strictMode = process.env.CTX_FETCH_STRICT === "1";
-  // Opt-in only: preserving proxy env vars routes DNS through the proxy and
-  // bypasses the connect-time rebinding guard (CWE-918/441 control from #476).
-  // Default remains strip. See issue #1039 / DenisBalan option 1.
+  // Default strips proxy env so the connect-time rebinding guard runs (#476/#1039).
+  // Opt-in is exact string "1" only (any other value keeps the strip path).
   const allowProxy = process.env.CTX_FETCH_ALLOW_PROXY === "1";
   const proxyEnvBlock = allowProxy
-    ? `// Proxy env vars preserved under CTX_FETCH_ALLOW_PROXY=1 (issue #1039).
-// When a proxy is set, DNS resolution happens at the proxy and the
-// connect-time dns.lookup / dnsPromises.lookup patches below never see
-// the rebound IP. Parent-side ssrfGuard still runs pre-flight. This is
-// operator-consented: corporate egress control requires explicit opt-in
-// because it weakens the #476 rebinding defense.`
-    : `// Strip proxy env vars from this subprocess only. A configured outbound
-// proxy (HTTP_PROXY / HTTPS_PROXY / ALL_PROXY) would route fetch through
-// an arbitrary target — DNS resolution happens at the proxy and the
-// in-subprocess DNS rebinding guard never sees the rebound IP. The
-// sandbox fetch path has no legitimate need for an upstream proxy by
-// default; set CTX_FETCH_ALLOW_PROXY=1 to preserve them (issue #1039).
+    ? `// Proxy env vars preserved under CTX_FETCH_ALLOW_PROXY=1 (issue #1039).`
+    : `// Strip proxy env by default so DNS rebinding guard sees connect-time IPs (#1039).
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 delete process.env.ALL_PROXY;

--- a/src/server.ts
+++ b/src/server.ts
@@ -2864,6 +2864,31 @@ export function buildFetchCode(url: string, outputPath: string): string {
       ? `var classifyIp = ${classifyIpInner};`
       : `var ${classifyIpFnName} = ${classifyIpInner};\nvar classifyIp = ${classifyIpFnName};`;
   const strictMode = process.env.CTX_FETCH_STRICT === "1";
+  // Opt-in only: preserving proxy env vars routes DNS through the proxy and
+  // bypasses the connect-time rebinding guard (CWE-918/441 control from #476).
+  // Default remains strip. See issue #1039 / DenisBalan option 1.
+  const allowProxy = process.env.CTX_FETCH_ALLOW_PROXY === "1";
+  const proxyEnvBlock = allowProxy
+    ? `// Proxy env vars preserved under CTX_FETCH_ALLOW_PROXY=1 (issue #1039).
+// When a proxy is set, DNS resolution happens at the proxy and the
+// connect-time dns.lookup / dnsPromises.lookup patches below never see
+// the rebound IP. Parent-side ssrfGuard still runs pre-flight. This is
+// operator-consented: corporate egress control requires explicit opt-in
+// because it weakens the #476 rebinding defense.`
+    : `// Strip proxy env vars from this subprocess only. A configured outbound
+// proxy (HTTP_PROXY / HTTPS_PROXY / ALL_PROXY) would route fetch through
+// an arbitrary target — DNS resolution happens at the proxy and the
+// in-subprocess DNS rebinding guard never sees the rebound IP. The
+// sandbox fetch path has no legitimate need for an upstream proxy by
+// default; set CTX_FETCH_ALLOW_PROXY=1 to preserve them (issue #1039).
+delete process.env.HTTP_PROXY;
+delete process.env.HTTPS_PROXY;
+delete process.env.ALL_PROXY;
+delete process.env.http_proxy;
+delete process.env.https_proxy;
+delete process.env.all_proxy;
+delete process.env.npm_config_proxy;
+delete process.env.npm_config_https_proxy;`;
   return `
 const TurndownService = require(${turndownPath});
 const { gfm } = require(${gfmPath});
@@ -2873,19 +2898,7 @@ const dnsPromises = require('no' + 'de:dns/promises');
 const url = ${JSON.stringify(url)};
 const outputPath = ${escapedOutputPath};
 
-// Strip proxy env vars from this subprocess only. A configured outbound
-// proxy (HTTP_PROXY / HTTPS_PROXY / ALL_PROXY) would route fetch through
-// an arbitrary target — DNS resolution happens at the proxy and the
-// in-subprocess DNS rebinding guard never sees the rebound IP. The
-// sandbox fetch path has no legitimate need for an upstream proxy.
-delete process.env.HTTP_PROXY;
-delete process.env.HTTPS_PROXY;
-delete process.env.ALL_PROXY;
-delete process.env.http_proxy;
-delete process.env.https_proxy;
-delete process.env.all_proxy;
-delete process.env.npm_config_proxy;
-delete process.env.npm_config_https_proxy;
+${proxyEnvBlock}
 
 ${classifyIpSrc}
 

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -3830,17 +3830,56 @@ import { buildFetchCode } from "../../src/server.js";
 describe("buildFetchCode — embedded SSRF guard contract", () => {
   const generated = buildFetchCode("https://example.com/x", "/tmp/x");
 
-  test("strips proxy env vars (HTTP_PROXY / HTTPS_PROXY / ALL_PROXY)", () => {
+  test("strips proxy env vars (HTTP_PROXY / HTTPS_PROXY / ALL_PROXY) by default (#476 pinning)", () => {
     // A configured outbound proxy would route fetch through an arbitrary
     // target; DNS resolution would happen at the proxy and the in-subprocess
-    // DNS guard would never see the rebound IP. The generated subprocess
-    // source must delete every proxy env var before any fetch can run.
-    expect(generated).toMatch(/delete process\.env\.HTTP_PROXY/);
-    expect(generated).toMatch(/delete process\.env\.HTTPS_PROXY/);
-    expect(generated).toMatch(/delete process\.env\.ALL_PROXY/);
-    expect(generated).toMatch(/delete process\.env\.http_proxy/);
-    expect(generated).toMatch(/delete process\.env\.https_proxy/);
-    expect(generated).toMatch(/delete process\.env\.all_proxy/);
+    // DNS guard would never see the rebound IP. Default must delete every
+    // proxy env var before any fetch can run (CWE-918/441 control from #476).
+    const prev = process.env.CTX_FETCH_ALLOW_PROXY;
+    delete process.env.CTX_FETCH_ALLOW_PROXY;
+    try {
+      const src = buildFetchCode("https://example.com/x", "/tmp/x");
+      expect(src).toMatch(/delete process\.env\.HTTP_PROXY/);
+      expect(src).toMatch(/delete process\.env\.HTTPS_PROXY/);
+      expect(src).toMatch(/delete process\.env\.ALL_PROXY/);
+      expect(src).toMatch(/delete process\.env\.http_proxy/);
+      expect(src).toMatch(/delete process\.env\.https_proxy/);
+      expect(src).toMatch(/delete process\.env\.all_proxy/);
+      expect(src).toMatch(/delete process\.env\.npm_config_proxy/);
+      expect(src).toMatch(/delete process\.env\.npm_config_https_proxy/);
+    } finally {
+      if (prev === undefined) delete process.env.CTX_FETCH_ALLOW_PROXY;
+      else process.env.CTX_FETCH_ALLOW_PROXY = prev;
+    }
+  });
+
+  test("preserves proxy env vars when CTX_FETCH_ALLOW_PROXY=1 (#1039 opt-in)", () => {
+    // Corporate/audited networks need operator-consented proxy egress.
+    // With CTX_FETCH_ALLOW_PROXY=1 the generated subprocess must NOT
+    // delete proxy env vars — undici EnvHttpProxyAgent honors them.
+    // Parent ssrfGuard still pre-flights; connect-time DNS patches cover
+    // the no-proxy case only.
+    const prev = process.env.CTX_FETCH_ALLOW_PROXY;
+    process.env.CTX_FETCH_ALLOW_PROXY = "1";
+    try {
+      const src = buildFetchCode("https://example.com/x", "/tmp/x");
+      expect(src).not.toMatch(/delete process\.env\.HTTP_PROXY/);
+      expect(src).not.toMatch(/delete process\.env\.HTTPS_PROXY/);
+      expect(src).not.toMatch(/delete process\.env\.ALL_PROXY/);
+      expect(src).not.toMatch(/delete process\.env\.http_proxy/);
+      expect(src).not.toMatch(/delete process\.env\.https_proxy/);
+      expect(src).not.toMatch(/delete process\.env\.all_proxy/);
+      expect(src).not.toMatch(/delete process\.env\.npm_config_proxy/);
+      expect(src).not.toMatch(/delete process\.env\.npm_config_https_proxy/);
+      expect(src).not.toMatch(/delete process\.env\[[^\]]*PROXY/i);
+      expect(src).not.toMatch(
+        /process\.env\.(HTTP|HTTPS|ALL)_?PROXY\s*=\s*(undefined|null|['"]{2})/i,
+      );
+      expect(src).toMatch(/CTX_FETCH_ALLOW_PROXY=1/);
+    } finally {
+      if (prev === undefined) delete process.env.CTX_FETCH_ALLOW_PROXY;
+      else process.env.CTX_FETCH_ALLOW_PROXY = prev;
+    }
   });
 
   test("embedded SSRF classifier is callable as `classifyIp` even when bundler renames the export (#bug-v1.0.133)", () => {

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -3831,10 +3831,7 @@ describe("buildFetchCode — embedded SSRF guard contract", () => {
   const generated = buildFetchCode("https://example.com/x", "/tmp/x");
 
   test("strips proxy env vars (HTTP_PROXY / HTTPS_PROXY / ALL_PROXY) by default (#476 pinning)", () => {
-    // A configured outbound proxy would route fetch through an arbitrary
-    // target; DNS resolution would happen at the proxy and the in-subprocess
-    // DNS guard would never see the rebound IP. Default must delete every
-    // proxy env var before any fetch can run (CWE-918/441 control from #476).
+    // Default must delete proxy env vars so the in-subprocess DNS guard runs (#476).
     const prev = process.env.CTX_FETCH_ALLOW_PROXY;
     delete process.env.CTX_FETCH_ALLOW_PROXY;
     try {
@@ -3854,11 +3851,7 @@ describe("buildFetchCode — embedded SSRF guard contract", () => {
   });
 
   test("preserves proxy env vars when CTX_FETCH_ALLOW_PROXY=1 (#1039 opt-in)", () => {
-    // Corporate/audited networks need operator-consented proxy egress.
-    // With CTX_FETCH_ALLOW_PROXY=1 the generated subprocess must NOT
-    // delete proxy env vars — undici EnvHttpProxyAgent honors them.
-    // Parent ssrfGuard still pre-flights; connect-time DNS patches cover
-    // the no-proxy case only.
+    // Exact "1" opt-in preserves proxy env for corporate egress; parent ssrfGuard remains.
     const prev = process.env.CTX_FETCH_ALLOW_PROXY;
     process.env.CTX_FETCH_ALLOW_PROXY = "1";
     try {
@@ -3876,6 +3869,26 @@ describe("buildFetchCode — embedded SSRF guard contract", () => {
         /process\.env\.(HTTP|HTTPS|ALL)_?PROXY\s*=\s*(undefined|null|['"]{2})/i,
       );
       expect(src).toMatch(/CTX_FETCH_ALLOW_PROXY=1/);
+    } finally {
+      if (prev === undefined) delete process.env.CTX_FETCH_ALLOW_PROXY;
+      else process.env.CTX_FETCH_ALLOW_PROXY = prev;
+    }
+  });
+
+  test('rejects non-"1" truthy CTX_FETCH_ALLOW_PROXY (fail-secure; still strips)', () => {
+    // Non-"1" values (e.g. "true") must still strip — fail-secure vs accidental truthy env.
+    const prev = process.env.CTX_FETCH_ALLOW_PROXY;
+    process.env.CTX_FETCH_ALLOW_PROXY = "true";
+    try {
+      const src = buildFetchCode("https://example.com/x", "/tmp/x");
+      expect(src).toMatch(/delete process\.env\.HTTP_PROXY/);
+      expect(src).toMatch(/delete process\.env\.HTTPS_PROXY/);
+      expect(src).toMatch(/delete process\.env\.ALL_PROXY/);
+      expect(src).toMatch(/delete process\.env\.http_proxy/);
+      expect(src).toMatch(/delete process\.env\.https_proxy/);
+      expect(src).toMatch(/delete process\.env\.all_proxy/);
+      expect(src).toMatch(/delete process\.env\.npm_config_proxy/);
+      expect(src).toMatch(/delete process\.env\.npm_config_https_proxy/);
     } finally {
       if (prev === undefined) delete process.env.CTX_FETCH_ALLOW_PROXY;
       else process.env.CTX_FETCH_ALLOW_PROXY = prev;


### PR DESCRIPTION
## What / Why / How

`ctx_fetch_and_index` embeds a subprocess script (`buildFetchCode`) that, since #476, deletes every proxy env var before `fetch()` runs. That is a deliberate CWE-918 / CWE-441 control: a configured `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` would move DNS resolution to the proxy, so the connect-time `dns.lookup` / `dnsPromises.lookup` re-validation never sees a rebound IP. Corporate and audited environments that *must* route egress through a proxy therefore see silent direct egress — reported in #1039 by @DenisBalan.

This PR does **not** reverse the #476 default. Unconditional preservation would re-open the SSRF control that #476 closed. Instead it implements DenisBalan's proposed option 1: **explicit operator opt-in**.

- **Default (unchanged):** generated source still strips `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` (and lowercase / `npm_config_*` siblings). The #476 pinning test remains green.
- **Opt-in:** when the process that *generates* the subprocess script has `CTX_FETCH_ALLOW_PROXY=1`, the strip block is omitted so Node/undici `EnvHttpProxyAgent` can honor the configured proxy. Gate style matches the existing `CTX_FETCH_STRICT === "1"` precedent in `server.ts`.

### Why parent-side resolve alone is not enough

A single parent-side `ssrfGuard` DNS lookup is insufficient against rebinding: an attacker can return a public IP for the pre-flight check and a blocked IP (e.g. IMDS `169.254.169.254`) for the subprocess connect. The compensating control is the **connect-time** `dns.lookup` re-validation inside the generated script. A proxy moves that resolution out of the subprocess's sight, so preserving proxy vars must be operator-consented, not default.

### Existing carve-out

The original design already allows legit proxy use on `ctx_execute` (executor `#buildSafeEnv` does not put proxy keys on the DENIED set). The strip lived only in the fetch-subprocess path. Operators who need corporate egress for `ctx_fetch_and_index` can now set `CTX_FETCH_ALLOW_PROXY=1` without weakening the default sandbox posture for everyone else.

Fixes #1039. Credit: @DenisBalan for the report, the exact repro against the embedded delete block, and the opt-in design option this implements.

## Limitations

- When `CTX_FETCH_ALLOW_PROXY=1` is active there is **no runtime signal** that the rebinding defense is relaxed; a stderr note is offered as a follow-up if maintainers want operators to see the weaker posture.

## Affected platforms

- [x] All platforms

(MCP-level fetch path; not adapter-specific.)

## Test plan

- [x] Restored #476 pinning test: generated source **strips** proxy vars by default
- [x] New #1039 test: with `CTX_FETCH_ALLOW_PROXY=1`, generated source **preserves** proxy vars (no `delete process.env.*PROXY*`)
- [x] `npx vitest run tests/core/server.test.ts` — 500 passed
- [x] `npm run typecheck` — clean
- [ ] Manual: with `HTTP_PROXY` pointed at a local proxy (or closed port) **and** `CTX_FETCH_ALLOW_PROXY=1`, confirm `ctx_fetch_and_index` traffic routes via the proxy (proxy log / connection refused vs direct success). **Still unchecked.**

## Checklist

- [x] Tests added/updated (default pin + opt-in preservation)
- [ ] `npm test` passes (full suite not run; `tests/core/server.test.ts` + typecheck green)
- [x] `npm run typecheck` passes
- [x] Docs updated if needed — N/A (env gate documented in code comments; README mention optional follow-up)
- [x] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix) — staged off `main` at base `3bad0f4`; retarget to `next` on ship if preferred

<details>
<summary><strong>Cross-platform notes</strong></summary>

No path/hook changes. Env var names are the standard cross-platform proxy set (HTTP(S)_PROXY, ALL_PROXY, npm_config_*). Opt-in flag: `CTX_FETCH_ALLOW_PROXY=1`.

</details>
