### PR TITLE
fix(stats): net returned bytes in reduction_pct denominator (#1025)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1029,10 +1029,13 @@ function persistStats(): void {
       (a, b) => a + b,
       0,
     );
-    const keptOut =
+    const rawKeptOut =
       sessionStats.bytesIndexed +
       sessionStats.bytesSandboxed +
       sessionStats.cacheBytesSaved;
+    // Indexed content returned as query snippets was counted in both keptOut
+    // and totalReturned, inflating total_processed and tokens_saved (#1025).
+    const keptOut = Math.max(0, rawKeptOut - totalReturned);
     const totalProcessed = keptOut + totalReturned;
     const reductionPct =
       totalProcessed > 0

--- a/tests/session/stats-reduction-pct.test.ts
+++ b/tests/session/stats-reduction-pct.test.ts
@@ -1,0 +1,54 @@
+/**
+ * #1025 — persistStats must not double-count returned snippet bytes in
+ * total_processed / reduction_pct / tokens_saved.
+ */
+
+import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverSrc = readFileSync(resolve(__dirname, "../../src/server.ts"), "utf-8");
+
+function computePersistStats(rawKeptOut: number, totalReturned: number) {
+  const keptOut = Math.max(0, rawKeptOut - totalReturned);
+  const totalProcessed = keptOut + totalReturned;
+  const reductionPct =
+    totalProcessed > 0
+      ? Math.round((1 - totalReturned / totalProcessed) * 100)
+      : 0;
+  const tokensSaved = Math.round(keptOut / 4);
+  return { keptOut, totalProcessed, reductionPct, tokensSaved };
+}
+
+describe("persistStats reduction_pct (#1025)", () => {
+  test("server.ts nets returned bytes out of rawKeptOut before totaling", () => {
+    expect(serverSrc).toMatch(/rawKeptOut/);
+    expect(serverSrc).toMatch(/Math\.max\(0,\s*rawKeptOut\s*-\s*totalReturned\)/);
+  });
+
+  test("indexed stdout with returned snippet uses universe as total_processed", () => {
+    const universe = 10_001;
+    const returned = 3_000;
+    const { keptOut, totalProcessed, reductionPct, tokensSaved } = computePersistStats(
+      universe,
+      returned,
+    );
+
+    expect(totalProcessed).toBe(universe);
+    expect(keptOut).toBe(universe - returned);
+    expect(reductionPct).toBe(Math.round((1 - returned / universe) * 100));
+    expect(tokensSaved).toBe(Math.round((universe - returned) / 4));
+  });
+
+  test("naive sum would inflate total_processed (regression guard)", () => {
+    const universe = 10_001;
+    const returned = 3_000;
+    const naiveTotal = universe + returned;
+    const { totalProcessed } = computePersistStats(universe, returned);
+
+    expect(naiveTotal).toBeGreaterThan(totalProcessed);
+    expect(naiveTotal - totalProcessed).toBe(returned);
+  });
+});


### PR DESCRIPTION
## Summary
- Net returned snippet bytes out of `keptOut` before computing `total_processed`, `reduction_pct`, and `tokens_saved`
- Prevents double-counting when indexed stdout is partially returned via `ctx_batch_execute`, `ctx_search`, or `ctx_fetch_and_index`
- Adds regression tests for the persistStats formula

Fixes #1025

## Test plan
- [x] `npx vitest run tests/session/stats-reduction-pct.test.ts`
- [x] Verified indexed 10,001-byte stdout + 3,000-byte returned snippet yields `total_processed = 10,001` (not 13,001)