### PR TITLE
fix(precompact): use platform ctx_search name in resume snapshot

### DIFF
--- a/hooks/codex/precompact.mjs
+++ b/hooks/codex/precompact.mjs
@@ -16,6 +16,9 @@ import {
   CODEX_OPTS,
 } from "../session-helpers.mjs";
 import { createSessionLoaders } from "../session-loaders.mjs";
+import { createToolNamer } from "../core/tool-naming.mjs";
+
+const searchTool = createToolNamer("codex")("ctx_search");
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -43,6 +46,7 @@ try {
     const stats = db.getSessionStats(sessionId);
     const snapshot = buildResumeSnapshot(events, {
       compactCount: (stats?.compact_count ?? 0) + 1,
+      searchTool,
     });
 
     db.upsertResume(sessionId, snapshot, events.length);

--- a/hooks/copilot-cli/precompact.mjs
+++ b/hooks/copilot-cli/precompact.mjs
@@ -3,6 +3,9 @@ import "../suppress-stderr.mjs";
 import "../ensure-deps.mjs";
 
 import { createSessionLoaders } from "../session-loaders.mjs";
+import { createToolNamer } from "../core/tool-naming.mjs";
+
+const searchTool = createToolNamer("copilot-cli")("ctx_search");
 import {
   readStdin,
   parseStdin,
@@ -54,6 +57,7 @@ try {
     const stats = db.getSessionStats(sessionId);
     const snapshot = buildResumeSnapshot(events, {
       compactCount: (stats?.compact_count ?? 0) + 1,
+      searchTool,
     });
 
     db.upsertResume(sessionId, snapshot, events.length);

--- a/hooks/gemini-cli/precompress.mjs
+++ b/hooks/gemini-cli/precompress.mjs
@@ -11,6 +11,9 @@ import "../ensure-deps.mjs";
 
 import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, GEMINI_OPTS } from "../session-helpers.mjs";
 import { createSessionLoaders } from "../session-loaders.mjs";
+import { createToolNamer } from "../core/tool-naming.mjs";
+
+const searchTool = createToolNamer("gemini-cli")("ctx_search");
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -39,6 +42,7 @@ try {
     const stats = db.getSessionStats(sessionId);
     const snapshot = buildResumeSnapshot(events, {
       compactCount: (stats?.compact_count ?? 0) + 1,
+      searchTool,
     });
 
     db.upsertResume(sessionId, snapshot, events.length);

--- a/hooks/jetbrains-copilot/precompact.mjs
+++ b/hooks/jetbrains-copilot/precompact.mjs
@@ -10,6 +10,9 @@ import "../ensure-deps.mjs";
  */
 
 import { createSessionLoaders } from "../session-loaders.mjs";
+import { createToolNamer } from "../core/tool-naming.mjs";
+
+const searchTool = createToolNamer("jetbrains-copilot")("ctx_search");
 import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, JETBRAINS_OPTS } from "../session-helpers.mjs";
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
@@ -39,6 +42,7 @@ try {
     const stats = db.getSessionStats(sessionId);
     const snapshot = buildResumeSnapshot(events, {
       compactCount: (stats?.compact_count ?? 0) + 1,
+      searchTool,
     });
 
     db.upsertResume(sessionId, snapshot, events.length);

--- a/hooks/kimi/precompact.mjs
+++ b/hooks/kimi/precompact.mjs
@@ -16,6 +16,9 @@ import {
   KIMI_OPTS,
 } from "../session-helpers.mjs";
 import { createSessionLoaders } from "../session-loaders.mjs";
+import { createToolNamer } from "../core/tool-naming.mjs";
+
+const searchTool = createToolNamer("kimi")("ctx_search");
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -51,6 +54,7 @@ try {
     const stats = db.getSessionStats(sessionId);
     const snapshot = buildResumeSnapshot(events, {
       compactCount: (stats?.compact_count ?? 0) + 1,
+      searchTool,
     });
 
     db.upsertResume(sessionId, snapshot, events.length);

--- a/hooks/precompact.mjs
+++ b/hooks/precompact.mjs
@@ -21,6 +21,8 @@ await runHook(async () => {
     resolveConfigDir,
   } = await import("./session-helpers.mjs");
   const { createSessionLoaders, attributeAndInsertEvents } = await import("./session-loaders.mjs");
+  const { createToolNamer } = await import("./core/tool-naming.mjs");
+  const searchTool = createToolNamer("claude-code")("ctx_search");
   const { appendFileSync } = await import("node:fs");
   const { join, dirname } = await import("node:path");
   const { fileURLToPath } = await import("node:url");
@@ -48,6 +50,7 @@ await runHook(async () => {
       const stats = db.getSessionStats(sessionId);
       const snapshot = buildResumeSnapshot(events, {
         compactCount: (stats?.compact_count ?? 0) + 1,
+        searchTool,
       });
 
       db.upsertResume(sessionId, snapshot, events.length);

--- a/hooks/vscode-copilot/precompact.mjs
+++ b/hooks/vscode-copilot/precompact.mjs
@@ -10,6 +10,9 @@ import "../ensure-deps.mjs";
  */
 
 import { createSessionLoaders } from "../session-loaders.mjs";
+import { createToolNamer } from "../core/tool-naming.mjs";
+
+const searchTool = createToolNamer("vscode-copilot")("ctx_search");
 import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, VSCODE_OPTS } from "../session-helpers.mjs";
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
@@ -39,6 +42,7 @@ try {
     const stats = db.getSessionStats(sessionId);
     const snapshot = buildResumeSnapshot(events, {
       compactCount: (stats?.compact_count ?? 0) + 1,
+      searchTool,
     });
 
     db.upsertResume(sessionId, snapshot, events.length);

--- a/src/adapters/opencode/plugin.ts
+++ b/src/adapters/opencode/plugin.ts
@@ -630,6 +630,7 @@ async function createContextModePlugin(ctx: PluginContext) {
         const stats = db.getSessionStats(sessionId);
         const snapshot = buildResumeSnapshot(events, {
           compactCount: (stats?.compact_count ?? 0) + 1,
+          searchTool: toolNamer("ctx_search"),
         });
 
         db.upsertResume(sessionId, snapshot, events.length);

--- a/tests/hooks/precompact-search-tool.test.ts
+++ b/tests/hooks/precompact-search-tool.test.ts
@@ -1,0 +1,80 @@
+/**
+ * #1028 — PreCompact resume snapshots must use platform-specific ctx_search
+ * tool names, not the bare default.
+ */
+
+import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createToolNamer, KNOWN_PLATFORMS } from "../../hooks/core/tool-naming.mjs";
+import { buildResumeSnapshot, type StoredEvent } from "../../src/session/snapshot.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+
+const HOOKS: Array<{ path: string; platform: string }> = [
+  { path: "hooks/precompact.mjs", platform: "claude-code" },
+  { path: "hooks/codex/precompact.mjs", platform: "codex" },
+  { path: "hooks/kimi/precompact.mjs", platform: "kimi" },
+  { path: "hooks/vscode-copilot/precompact.mjs", platform: "vscode-copilot" },
+  { path: "hooks/gemini-cli/precompress.mjs", platform: "gemini-cli" },
+  { path: "hooks/jetbrains-copilot/precompact.mjs", platform: "jetbrains-copilot" },
+  { path: "hooks/copilot-cli/precompact.mjs", platform: "copilot-cli" },
+];
+
+const sampleEvents: StoredEvent[] = [
+  {
+    type: "file_edit",
+    category: "file",
+    data: "src/server.ts",
+    priority: 1,
+    created_at: "2026-07-27T00:00:00Z",
+  },
+  {
+    type: "decision",
+    category: "decision",
+    data: "use FTS5 for retrieval",
+    priority: 1,
+    created_at: "2026-07-27T00:00:01Z",
+  },
+];
+
+describe("PreCompact searchTool wiring (#1028)", () => {
+  test("hook sources pass searchTool into buildResumeSnapshot", () => {
+    for (const { path } of HOOKS) {
+      const src = readFileSync(join(ROOT, path), "utf-8");
+      expect(src, path).toMatch(/createToolNamer/);
+      expect(src, path).toMatch(/searchTool/);
+      expect(src, path).toMatch(/buildResumeSnapshot\([\s\S]*searchTool/s);
+    }
+  });
+
+  test("opencode plugin passes platform searchTool into buildResumeSnapshot", () => {
+    const src = readFileSync(
+      join(ROOT, "src/adapters/opencode/plugin.ts"),
+      "utf-8",
+    );
+    expect(src).toMatch(/searchTool:\s*toolNamer\("ctx_search"\)/);
+  });
+
+  test("platform-prefixed snapshot omits bare ctx_search when prefixed", () => {
+    const opencodeTool = createToolNamer("opencode")("ctx_search");
+    expect(opencodeTool).toBe("context-mode_ctx_search");
+
+    const snap = buildResumeSnapshot(sampleEvents, {
+      compactCount: 1,
+      searchTool: opencodeTool,
+    });
+
+    expect(snap).toContain("context-mode_ctx_search(");
+    expect(snap).not.toMatch(/\bctx_search\(/);
+  });
+
+  test("13 of 17 known platforms differ from bare ctx_search", () => {
+    const differ = KNOWN_PLATFORMS.filter(
+      (p) => createToolNamer(p)("ctx_search") !== "ctx_search",
+    );
+    expect(differ.length).toBe(13);
+  });
+});

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -566,6 +566,9 @@ describe("ContextModePlugin", () => {
       expect(snapshot).toContain("session_resume");
       expect(snapshot).toContain("<files");
       expect(snapshot).toContain("index.ts");
+      // #1028: opencode uses prefixed tool name, not bare ctx_search
+      expect(snapshot).toContain("context-mode_ctx_search(");
+      expect(snapshot).not.toMatch(/\bctx_search\(/);
     });
 
     it("can be called multiple times (increments compact count)", async () => {


### PR DESCRIPTION
## Summary
- Wire searchTool from createToolNamer into all PreCompact / PreCompress hooks
- OpenCode adapter passes toolNamer ctx_search when building compaction resume snapshot
- Ensures post-compact retrieval hints match the platform MCP tool name

Fixes #1028

## Test plan
- [x] npx vitest run tests/hooks/precompact-search-tool.test.ts
- [x] npx vitest run tests/opencode-plugin.test.ts