### PR TITLE
fix(codex): bound synchronous lifecycle hooks

### DIFF
--- a/.codex-plugin/hooks.json
+++ b/.codex-plugin/hooks.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks/codex/pretooluse.mjs\""
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex/pretooluse.mjs\"",
+            "timeout": 2
           }
         ]
       }
@@ -16,7 +17,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks/codex/posttooluse.mjs\""
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex/posttooluse.mjs\"",
+            "timeout": 3
           }
         ]
       }
@@ -26,7 +28,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks/codex/sessionstart.mjs\""
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex/sessionstart.mjs\"",
+            "timeout": 5
           }
         ]
       }
@@ -36,7 +39,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks/codex/precompact.mjs\""
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex/precompact.mjs\"",
+            "timeout": 5
           }
         ]
       }
@@ -46,7 +50,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks/codex/userpromptsubmit.mjs\""
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex/userpromptsubmit.mjs\"",
+            "timeout": 1
           }
         ]
       }
@@ -56,7 +61,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks/codex/stop.mjs\""
+            "command": "node \"${PLUGIN_ROOT}/hooks/codex/stop.mjs\"",
+            "timeout": 1
           }
         ]
       }

--- a/configs/codex/hooks.json
+++ b/configs/codex/hooks.json
@@ -4,42 +4,42 @@
       {
         "matcher": "local_shell|shell|shell_command|exec_command|Bash|Shell|apply_patch|Edit|Write|grep_files|ctx_execute|ctx_execute_file|ctx_batch_execute|ctx_fetch_and_index|ctx_search|ctx_index|mcp__",
         "hooks": [
-          { "type": "command", "command": "context-mode hook codex pretooluse" }
+          { "type": "command", "command": "context-mode hook codex pretooluse", "timeout": 2 }
         ]
       }
     ],
     "PostToolUse": [
       {
         "hooks": [
-          { "type": "command", "command": "context-mode hook codex posttooluse" }
+          { "type": "command", "command": "context-mode hook codex posttooluse", "timeout": 3 }
         ]
       }
     ],
     "SessionStart": [
       {
         "hooks": [
-          { "type": "command", "command": "context-mode hook codex sessionstart" }
+          { "type": "command", "command": "context-mode hook codex sessionstart", "timeout": 5 }
         ]
       }
     ],
     "PreCompact": [
       {
         "hooks": [
-          { "type": "command", "command": "context-mode hook codex precompact" }
+          { "type": "command", "command": "context-mode hook codex precompact", "timeout": 5 }
         ]
       }
     ],
     "UserPromptSubmit": [
       {
         "hooks": [
-          { "type": "command", "command": "context-mode hook codex userpromptsubmit" }
+          { "type": "command", "command": "context-mode hook codex userpromptsubmit", "timeout": 1 }
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          { "type": "command", "command": "context-mode hook codex stop" }
+          { "type": "command", "command": "context-mode hook codex stop", "timeout": 1 }
         ]
       }
     ]

--- a/hooks/codex/posttooluse.mjs
+++ b/hooks/codex/posttooluse.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import "./platform.mjs";
 import "../suppress-stderr.mjs";
-import "../ensure-deps.mjs";
 /**
  * Codex CLI postToolUse hook — session event capture.
  */

--- a/hooks/codex/precompact.mjs
+++ b/hooks/codex/precompact.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import "./platform.mjs";
 import "../suppress-stderr.mjs";
-import "../ensure-deps.mjs";
 /**
  * Codex CLI PreCompact hook - snapshot generation.
  */

--- a/hooks/codex/sessionstart.mjs
+++ b/hooks/codex/sessionstart.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import "./platform.mjs";
 import "../suppress-stderr.mjs";
-import "../ensure-deps.mjs";
 /**
  * Codex CLI sessionStart hook for context-mode.
  */

--- a/hooks/codex/stop.mjs
+++ b/hooks/codex/stop.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import "./platform.mjs";
 import "../suppress-stderr.mjs";
-import "../ensure-deps.mjs";
 /**
  * Codex CLI Stop hook — record turn-end state for continuity.
  *

--- a/hooks/codex/userpromptsubmit.mjs
+++ b/hooks/codex/userpromptsubmit.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import "./platform.mjs";
 import "../suppress-stderr.mjs";
-import "../ensure-deps.mjs";
 /**
  * Codex CLI UserPromptSubmit hook — capture user prompts for continuity.
  */


### PR DESCRIPTION
## What / Why / How

Codex prompts and turn boundaries can no longer block while a lifecycle hook installs or rebuilds native dependencies. The Codex hook entrypoints now rely on installation-time dependency repair, and both Codex manifests set short event-specific timeouts as a final fail-open boundary.

This is a Codex-only hotfix against `main`. It keeps the plugin manifest and standalone Codex configuration aligned without changing other platforms.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [x] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

- `npm test` — 210 test files passed; 4,717 tests passed and 25 skipped.
- `npm run typecheck` — passed.
- `git diff --check upstream/main...HEAD` — passed.

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (no documentation change needed)
- [x] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (Codex lifecycle hotfix targets `main`)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
