### PR TITLE
fix(db): stop mutating shared DB files across processes (close-time TRUNCATE checkpoint + default mmap)

### DIFF
--- a/src/db-base.ts
+++ b/src/db-base.ts
@@ -342,12 +342,21 @@ export function loadDatabase(): typeof DatabaseConstructor {
 export function applyWALPragmas(db: DatabaseInstance): void {
   db.pragma("journal_mode = WAL");
   db.pragma("synchronous = NORMAL");
-  // Memory-map the DB file for read-heavy FTS5 search workloads.
-  // Eliminates read() syscalls — the kernel serves pages directly from
-  // the page cache. 256MB is a safe upper bound (SQLite only maps up to
-  // the actual file size). Falls back gracefully on platforms where mmap
-  // is unavailable or restricted.
-  try { db.pragma("mmap_size = 268435456"); } catch { /* unsupported runtime */ }
+  // mmap_size is opt-in (CONTEXT_MODE_MMAP_SIZE=<bytes>), default off.
+  // This helper is shared by ContentStore and SessionDB, both multi-writer
+  // by contract (ADR 0001): sibling server processes rename/delete/recreate
+  // these files on corruption recovery and stale cleanup (renameCorruptDB,
+  // deleteDBFiles), and the DB itself may be truncated by a sibling's
+  // checkpoint. Under mmap, a fault on a replaced or truncated mapping
+  // cannot be handled by SQLite — it surfaces as an uncatchable signal
+  // rather than a catchable error (https://sqlite.org/mmap.html,
+  // disadvantage 1) — and Windows cannot truncate a memory-mapped file at
+  // all (disadvantage 4). Set CONTEXT_MODE_MMAP_SIZE to re-enable the
+  // read() bypass of #267 for single-process, read-heavy workloads.
+  const mmapSize = Number(process.env.CONTEXT_MODE_MMAP_SIZE ?? "0");
+  if (Number.isFinite(mmapSize) && mmapSize > 0) {
+    try { db.pragma(`mmap_size = ${mmapSize}`); } catch { /* unsupported runtime */ }
+  }
   // NOTE: `locking_mode = EXCLUSIVE` is intentionally NOT applied here.
   // ALL DBs built on this helper — ContentStore (FTS5 shared knowledge
   // base) AND SessionDB (per-project events) — are multi-writer-safe by
@@ -392,12 +401,20 @@ export function deleteDBFiles(dbPath: string): void {
 /**
  * Safely close a database connection. Swallows errors so callers can
  * always call this in a finally/cleanup path without try/catch.
+ *
+ * No manual wal_checkpoint(TRUNCATE) is issued. On the multi-writer DBs
+ * this helper serves (ADR 0001), every per-session server close used to
+ * TRUNCATE the shared WAL and reset the wal-index while sibling server
+ * processes held live connections — a cross-process file mutation that
+ * is implicated in permanent SQLITE_IOERR wedges (#880, #992, #905). It
+ * was also redundant: SQLite auto-checkpoints whenever the WAL reaches
+ * 1000 pages, and when the LAST connection closes it runs its own
+ * checkpoint and deletes the -wal/-shm files
+ * (https://sqlite.org/wal.html sections 3.1 and 6). WAL bounding on
+ * hard-exit paths (where the last close never happens) is covered by the
+ * periodic PASSIVE checkpoint timer proposed in #988.
  */
 export function closeDB(db: DatabaseInstance): void {
-  try {
-    // Checkpoint WAL before close to prevent contention on restart (#103)
-    db.pragma("wal_checkpoint(TRUNCATE)");
-  } catch { /* WAL may not be active */ }
   try {
     db.close();
   } catch {

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -5,7 +5,7 @@
  * using real fixtures from Context7 and MCP tools.
  */
 
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import { strict as assert } from "node:assert";
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
 import { join, dirname } from "node:path";
@@ -1727,6 +1727,30 @@ describe("closeDB — WAL checkpoint", () => {
       try { unlinkSync(dbPath + s); } catch {}
     }
   });
+
+  test("closeDB issues no manual wal_checkpoint pragma — sibling connections are never mutated", () => {
+    const pragmas: string[] = [];
+    const closes: number[] = [];
+    const fakeDb = {
+      pragma(q: string) { pragmas.push(q); },
+      close() { closes.push(1); },
+    } as unknown as import("better-sqlite3").Database;
+    closeDB(fakeDb);
+    // The pre-#880/#992 behavior ran `wal_checkpoint(TRUNCATE)` here, which
+    // truncated the shared WAL and reset the wal-index under sibling server
+    // processes' live connections. closeDB must only close.
+    assert.equal(pragmas.length, 0);
+    assert.equal(closes.length, 1);
+  });
+
+  test("closeDB swallows close() errors", () => {
+    const fakeDb = {
+      pragma() { throw new Error("should not be called"); },
+      close() { throw new Error("close failed"); },
+    } as unknown as import("better-sqlite3").Database;
+    // Must not throw — closeDB is called from finally/cleanup paths.
+    closeDB(fakeDb);
+  });
 });
 
 // ── Corrupt DB recovery (#244) ──
@@ -1760,7 +1784,48 @@ describe("ContentStore — corrupt DB recovery", () => {
 // ═══════════════════════════════════════════════════════════
 
 describe("mmap_size pragma", () => {
-  test("mmap_size is set on new ContentStore", () => {
+  const ENV_KEY = "CONTEXT_MODE_MMAP_SIZE";
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+  });
+
+  function recordingDb(): { db: import("../src/db-base.js").DatabaseInstance; pragmas: string[] } {
+    const pragmas: string[] = [];
+    const db = { pragma(q: string) { pragmas.push(q); } } as unknown as import("better-sqlite3").Database;
+    return { db, pragmas };
+  }
+
+  test("mmap_size is NOT applied by default — multi-writer safety (#880, #992, #905)", () => {
+    const { db, pragmas } = recordingDb();
+    applyWALPragmas(db);
+    assert.ok(pragmas.includes("journal_mode = WAL"));
+    assert.ok(pragmas.includes("synchronous = NORMAL"));
+    assert.ok(!pragmas.some((q) => q.startsWith("mmap_size")));
+  });
+
+  test("CONTEXT_MODE_MMAP_SIZE opts back in", () => {
+    process.env[ENV_KEY] = "1048576";
+    const { db, pragmas } = recordingDb();
+    applyWALPragmas(db);
+    assert.ok(pragmas.includes("mmap_size = 1048576"));
+  });
+
+  test("invalid CONTEXT_MODE_MMAP_SIZE is ignored without throwing", () => {
+    process.env[ENV_KEY] = "not-a-number";
+    const { db, pragmas } = recordingDb();
+    applyWALPragmas(db);
+    assert.ok(!pragmas.some((q) => q.startsWith("mmap_size")));
+  });
+
+  test("FTS5 search works with mmap disabled", () => {
     const dbPath = join(tmpdir(), `ctx-mmap-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
     const store = new ContentStore(dbPath);
     store.indexPlainText("Memory-mapped I/O test content for FTS5 search", "mmap-test");


### PR DESCRIPTION
## What / Why / How

Two cross-process file mutations in the shared DB layer violate the multi-writer contract of ADR 0001 and are implicated in the permanent `SQLITE_IOERR` ("disk I/O error") wedges behind #880 / #992 / #905. This PR removes both, relying on SQLite's native WAL handling instead.

**1. `closeDB()` no longer issues `wal_checkpoint(TRUNCATE)`.**

Every per-session server close used to TRUNCATE the shared per-project WAL and reset the wal-index while sibling server processes held live connections. Field timeline (my machine, 4+ concurrent Pi servers in one project cwd): a long-lived server that had been idle for ~11h started failing *every* live op (`ctx_search` / `ctx_execute` / `ctx_fetch_and_index` / `ctx_batch_execute` → `disk I/O error`, reads and writes alike) within minutes of sibling servers starting/stopping, stayed wedged for the life of the process, while the disk was healthy, `quick_check`/`integrity_check` passed on every DB, `ctx_doctor` stayed green, and a fresh process could open and write the same DB fine — exactly the signature of #992. Removing close-time TRUNCATE (plus 2. below) eliminated recurrence across 24h+ of the same multi-session workload.

The manual TRUNCATE was also redundant, per the WAL docs:

> "By default, SQLite will automatically checkpoint whenever a COMMIT occurs that causes the WAL file to be 1000 pages or more in size, or when the last database connection on a database file closes." (wal.html §3.1)
> "When the last connection to a database closes, that connection does one last checkpoint and then deletes the WAL and its associated shared-memory file, to clean up the disk." (wal.html §6)

So the only scenario the manual call covered — no other live connection — is already handled natively by the last-close checkpoint, and WAL bounding on hard-exit paths is what the periodic PASSIVE timer in #988 addresses (PASSIVE never truncates under readers; TRUNCATE-by-default is the unsafe half).

**2. `mmap_size` is now opt-in (`CONTEXT_MODE_MMAP_SIZE=<bytes>`), default off.**

#267 enabled a 256MB mapping for read-heavy FTS5 search. But this helper serves the multi-writer DBs of ADR 0001, where sibling processes rename/delete/recreate these exact files (`renameCorruptDB`, `deleteDBFiles`, stale-content cleanup — the deletion races tracked in #880/#1024). Under mmap, a fault on a replaced or truncated mapping cannot be caught and dealt with by SQLite — it surfaces as a signal rather than a catchable error (mmap.html, disadvantage 1) — and Windows cannot truncate a memory-mapped file at all (disadvantage 4). #267's read() bypass remains available via the env opt-in for single-process, read-heavy setups.

Honest scope note: I could not isolate which of the two mutations poisons a given live handle (both change together in the wild), but each is independently defensible on the grounds above, and both align the code with the "rely on SQLite's native mechanisms" decision ADR 0001 already made for locking.

## Affected platforms

- [x] All platforms (shared `db-base.ts` layer — every platform's ContentStore/SessionDB)

## Test plan

`tests/store.test.ts` (existing domain file, per CONTRIBUTING):

- `closeDB issues no manual wal_checkpoint pragma — sibling connections are never mutated` (fake `DatabaseInstance` spy) — pins the removal
- `closeDB swallows close() errors` — cleanup-path safety preserved
- `mmap_size is NOT applied by default`, `CONTEXT_MODE_MMAP_SIZE opts back in`, `invalid CONTEXT_MODE_MMAP_SIZE is ignored without throwing`
- existing `closeDB checkpoints WAL so no -wal file remains` (real DB) still passes — SQLite's native last-close checkpoint keeps the WAL removed/empty after final close, without the manual pragma

Verification:

- `npm run typecheck` — clean
- `npx vitest run tests/store.test.ts` — 128/128 pass
- `npm test` — 4767 passed / 13 failed; the 13 (`tests/adapters/detect.test.ts`) reproduce identically on unmodified `next` on this machine (env-dependent platform detection), so they are pre-existing, not introduced here
- Bundles left untouched — `.github/workflows/bundle.yml` regenerates them

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes (pre-existing env-dependent failures noted above)
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (behavior documented in code comments; env knob named `CONTEXT_MODE_MMAP_SIZE`)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch
