### PR TITLE
fix(opencode): route webfetch through the WebFetch redirect (#1052)

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -532,6 +532,7 @@ const TOOL_ALIASES = {
   "view": "Read",
   "grep": "Grep",
   "fetch": "WebFetch",
+  "webfetch": "WebFetch",
   "agent": "Agent",
   // Codex CLI
   "shell": "Bash",

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -490,6 +490,22 @@ describe("routePreToolUse", () => {
       expect(subagent.status).toBe(0);
       expect(subagent.stdout).toBe("");
     });
+
+    it("treats opencode webfetch as WebFetch and blocks it (#1052)", () => {
+      const url = "https://example.com";
+      const result = routePreToolUse(
+        "webfetch",
+        { url },
+        undefined,
+        "opencode",
+        "opencode-webfetch",
+      );
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("deny");
+      expect(result!.reason).toContain("WebFetch redirected");
+      expect(result!.reason).toContain("fetch_and_index");
+      expect(result!.reason).toContain("ctx_search");
+    });
   });
 
   // ─── MCP readiness: all redirects degrade gracefully (#230) ───


### PR DESCRIPTION
## What / Why / How

Fixes #1052.

**What** — Add the missing OpenCode `webfetch` alias to `TOOL_ALIASES` in `hooks/core/routing.mjs`:

```js
"fetch": "WebFetch",
"webfetch": "WebFetch",   // +1 line — opencode registers its fetch tool as `webfetch`
"agent": "Agent",
```

**Why** — OpenCode registers its fetch tool as `webfetch` (`Tool.define("webfetch")`), but `TOOL_ALIASES` only mapped `"fetch"`. The alias lookup missed, `canonical` stayed `webfetch`, and the `if (canonical === "WebFetch")` redirect branch never matched — so the tool executed as a plain allow with **zero routing interception** (the page bytes enter the conversation, no `ctx_fetch_and_index` / `ctx_search` redirect).

**How** — One-line alias addition, same shape as the neighbouring `"fetch": "WebFetch"` entry. Hook-only change: `hooks/core/routing.mjs` is plain JS loaded fresh on each invocation, no rebuild needed (per CONTRIBUTING "What needs rebuild?").

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [x] **OpenCode**
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

**TDD (red → green)** — added one test to the existing `tests/hooks/core-routing.test.ts` (WebFetch domain, per CONTRIBUTING "Do NOT create new test files"):

- **Red:** `routePreToolUse("webfetch", { url }, …, "opencode", …)` → `null` (no interception) — test failed as expected
- **Green:** after the alias, the same call → `{ action: "deny", reason: "WebFetch redirected … ctx_fetch_and_index … ctx_search" }`
- `tests/hooks/core-routing.test.ts`: **96/96 pass**
- `npm run typecheck`: **passes**

**Real-path verification** (no OpenCode CLI on this machine, so done via the compiled plugin's actual hook surface): loaded the compiled `build/adapters/opencode/plugin.js` and invoked its real `tool.execute.before` hook with a `webfetch` payload:

- with the alias: **throws** the redirect error (`context-mode: WebFetch redirected. Call context-mode_ctx_fetch_and_index(url: …)`) → OpenCode blocks the call
- without the alias (stashed): **passes through** — reproduces the bug exactly

`tool.execute.before`'s deny path in this plugin is `throw Error`, which OpenCode catches and turns into a denied tool call — so the throw observed is the same interception a live OpenCode session would hit.

**Honest note on `npm test`:** the full suite on this Windows box reports pre-existing environment failures unrelated to this change — `EPERM` on symlink creation (Windows needs admin to create symlinks) in `tests/core/cli.test.ts`, missing Python runtime + POSIX-shell expectations in `tests/executor.test.ts`, and temp-dir cleanup `EPERM` in session-path tests. I verified this by stashing my change and running the suite on the untouched `next` baseline: the same failures appear (49–57 failed depending on run). The routing suite itself (`tests/hooks/core-routing.test.ts`) passes 96/96 with the change.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes — routing suite 96/96; full-suite failures are pre-existing Windows-environment failures (verified identical on unmodified `next` baseline; see Test plan)
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md) — n/a, one-line alias
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)
