### PR TITLE
fix(snapshot): pass platform tool name into PreCompact resume snapshot (#1028)

### DIFF
--- a/hooks/codex/precompact.mjs
+++ b/hooks/codex/precompact.mjs
@@ -16,6 +16,7 @@ import {
   CODEX_OPTS,
 } from "../session-helpers.mjs";
 import { createSessionLoaders } from "../session-loaders.mjs";
+import { createToolNamer } from "../core/tool-naming.mjs";
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -43,6 +44,7 @@ try {
     const stats = db.getSessionStats(sessionId);
     const snapshot = buildResumeSnapshot(events, {
       compactCount: (stats?.compact_count ?? 0) + 1,
+      searchTool: createToolNamer("codex")("ctx_search"),
     });
 
     db.upsertResume(sessionId, snapshot, events.length);

--- a/hooks/copilot-cli/precompact.mjs
+++ b/hooks/copilot-cli/precompact.mjs
@@ -3,6 +3,7 @@ import "../suppress-stderr.mjs";
 import "../ensure-deps.mjs";
 
 import { createSessionLoaders } from "../session-loaders.mjs";
+import { createToolNamer } from "../core/tool-naming.mjs";
 import {
   readStdin,
   parseStdin,
@@ -54,6 +55,7 @@ try {
     const stats = db.getSessionStats(sessionId);
     const snapshot = buildResumeSnapshot(events, {
       compactCount: (stats?.compact_count ?? 0) + 1,
+      searchTool: createToolNamer("copilot-cli")("ctx_search"),
     });
 
     db.upsertResume(sessionId, snapshot, events.length);

--- a/hooks/gemini-cli/precompress.mjs
+++ b/hooks/gemini-cli/precompress.mjs
@@ -11,6 +11,7 @@ import "../ensure-deps.mjs";
 
 import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, GEMINI_OPTS } from "../session-helpers.mjs";
 import { createSessionLoaders } from "../session-loaders.mjs";
+import { createToolNamer } from "../core/tool-naming.mjs";
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -39,6 +40,7 @@ try {
     const stats = db.getSessionStats(sessionId);
     const snapshot = buildResumeSnapshot(events, {
       compactCount: (stats?.compact_count ?? 0) + 1,
+      searchTool: createToolNamer("gemini-cli")("ctx_search"),
     });
 
     db.upsertResume(sessionId, snapshot, events.length);

--- a/hooks/jetbrains-copilot/precompact.mjs
+++ b/hooks/jetbrains-copilot/precompact.mjs
@@ -10,6 +10,7 @@ import "../ensure-deps.mjs";
  */
 
 import { createSessionLoaders } from "../session-loaders.mjs";
+import { createToolNamer } from "../core/tool-naming.mjs";
 import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, JETBRAINS_OPTS } from "../session-helpers.mjs";
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
@@ -39,6 +40,7 @@ try {
     const stats = db.getSessionStats(sessionId);
     const snapshot = buildResumeSnapshot(events, {
       compactCount: (stats?.compact_count ?? 0) + 1,
+      searchTool: createToolNamer("jetbrains-copilot")("ctx_search"),
     });
 
     db.upsertResume(sessionId, snapshot, events.length);

--- a/hooks/kimi/precompact.mjs
+++ b/hooks/kimi/precompact.mjs
@@ -16,6 +16,7 @@ import {
   KIMI_OPTS,
 } from "../session-helpers.mjs";
 import { createSessionLoaders } from "../session-loaders.mjs";
+import { createToolNamer } from "../core/tool-naming.mjs";
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -51,6 +52,7 @@ try {
     const stats = db.getSessionStats(sessionId);
     const snapshot = buildResumeSnapshot(events, {
       compactCount: (stats?.compact_count ?? 0) + 1,
+      searchTool: createToolNamer("kimi")("ctx_search"),
     });
 
     db.upsertResume(sessionId, snapshot, events.length);

--- a/hooks/precompact.mjs
+++ b/hooks/precompact.mjs
@@ -21,6 +21,7 @@ await runHook(async () => {
     resolveConfigDir,
   } = await import("./session-helpers.mjs");
   const { createSessionLoaders, attributeAndInsertEvents } = await import("./session-loaders.mjs");
+  const { createToolNamer } = await import("./core/tool-naming.mjs");
   const { appendFileSync } = await import("node:fs");
   const { join, dirname } = await import("node:path");
   const { fileURLToPath } = await import("node:url");
@@ -48,6 +49,7 @@ await runHook(async () => {
       const stats = db.getSessionStats(sessionId);
       const snapshot = buildResumeSnapshot(events, {
         compactCount: (stats?.compact_count ?? 0) + 1,
+        searchTool: createToolNamer("claude-code")("ctx_search"),
       });
 
       db.upsertResume(sessionId, snapshot, events.length);

--- a/hooks/vscode-copilot/precompact.mjs
+++ b/hooks/vscode-copilot/precompact.mjs
@@ -10,6 +10,7 @@ import "../ensure-deps.mjs";
  */
 
 import { createSessionLoaders } from "../session-loaders.mjs";
+import { createToolNamer } from "../core/tool-naming.mjs";
 import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, VSCODE_OPTS } from "../session-helpers.mjs";
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
@@ -39,6 +40,7 @@ try {
     const stats = db.getSessionStats(sessionId);
     const snapshot = buildResumeSnapshot(events, {
       compactCount: (stats?.compact_count ?? 0) + 1,
+      searchTool: createToolNamer("vscode-copilot")("ctx_search"),
     });
 
     db.upsertResume(sessionId, snapshot, events.length);

--- a/src/adapters/opencode/plugin.ts
+++ b/src/adapters/opencode/plugin.ts
@@ -630,6 +630,7 @@ async function createContextModePlugin(ctx: PluginContext) {
         const stats = db.getSessionStats(sessionId);
         const snapshot = buildResumeSnapshot(events, {
           compactCount: (stats?.compact_count ?? 0) + 1,
+          searchTool: toolNamer("ctx_search"),
         });
 
         db.upsertResume(sessionId, snapshot, events.length);

--- a/tests/hooks/precompact-snapshot-event.test.ts
+++ b/tests/hooks/precompact-snapshot-event.test.ts
@@ -124,4 +124,68 @@ describe("precompact.mjs — snapshot-built event (D2 PRD Phase 6.1)", () => {
     expect(row.bytes_avoided).toBeGreaterThan(0);
     expect(row.bytes_returned).toBe(0);
   });
+
+  test("resume snapshot uses platform-prefixed tool name (#1028)", () => {
+    // Claude Code platform: ctx_search → mcp__plugin_context-mode_context-mode__ctx_search
+    const { createHash } = require("node:crypto") as typeof import("node:crypto");
+    const projectHash = _hashCanonical(fakeProject.replace(/\\/g, "/"));
+    const dbDir = join(fakeHome, ".claude", "context-mode", "sessions");
+    require("node:fs").mkdirSync(dbDir, { recursive: true });
+    const dbPath = join(dbDir, `${projectHash}.db`);
+
+    {
+      const seedDb = new SessionDB({ dbPath });
+      seedDb.ensureSession(sessionId, fakeProject);
+      seedDb.insertEvent(
+        sessionId,
+        { type: "file_edit", category: "file", data: "/project/src/server.ts", priority: 1 },
+        "PostToolUse",
+      );
+      seedDb.insertEvent(
+        sessionId,
+        { type: "decision", category: "decision", data: "use FTS5 for search", priority: 1 },
+        "PostToolUse",
+      );
+      seedDb.close();
+    }
+
+    const result = spawnSync("node", [PRECOMPACT_PATH], {
+      input: JSON.stringify({ session_id: sessionId, cwd: fakeProject }),
+      encoding: "utf-8",
+      timeout: 30_000,
+      env: { ...process.env, ...env },
+    });
+
+    assert.equal(result.status, 0, `precompact exit non-zero. stderr: ${result.stderr}`);
+
+    // Read the resume snapshot from DB
+    const Database = loadDatabase();
+    const raw = new Database(dbPath, { readonly: true });
+    let snapshot: string;
+    try {
+      const row = raw.prepare(
+        "SELECT snapshot FROM session_resume WHERE session_id = ?",
+      ).get(sessionId) as { snapshot: string } | undefined;
+      snapshot = row?.snapshot ?? "";
+    } finally {
+      raw.close();
+    }
+
+    // precompact.mjs is the claude-code hook — its platform tool name is:
+    // mcp__plugin_context-mode_context-mode__ctx_search
+    const expectedTool = "mcp__plugin_context-mode_context-mode__ctx_search";
+    assert.ok(
+      snapshot.includes(expectedTool),
+      `snapshot should contain platform-prefixed tool name "${expectedTool}" but got: ${snapshot.slice(0, 300)}`,
+    );
+    // The bare form "ctx_search(" should not appear without a platform prefix.
+    // Platform-prefixed forms like "context-mode__ctx_search(" are fine.
+    // Split on the expected prefix and check that all "ctx_search(" occurrences
+    // are preceded by the prefix (i.e. no standalone bare form).
+    const barePattern = snapshot.split(expectedTool).join("").includes("ctx_search(");
+    assert.ok(
+      !barePattern,
+      `snapshot should NOT contain bare "ctx_search(" without platform prefix. Got: ${snapshot.slice(0, 300)}`,
+    );
+  });
 });


### PR DESCRIPTION
## What / Why / How

Fixes #1028.

**What** — Wire `searchTool: createToolNamer(platform)(ctx_search)` into every PreCompact hook and the OpenCode adapter's compaction handler.

**Why** — All PreCompact paths called `buildResumeSnapshot(events, { compactCount })` without `searchTool`, so the snapshot emitted bare `ctx_search(...)` retrieval hints. On 13 of 17 platforms the model's actual tool name is prefixed (e.g. `mcp__plugin_context-mode_context-mode__ctx_search` on Claude Code, `context-mode_ctx_search` on OpenCode). The bare hint doesn't match and the model can't call it after a compact/resume cycle.

**How** — Import `createToolNamer` (already used by sibling SessionStart hooks) and pass the result into `buildResumeSnapshot`. One line per hook + one line in the OpenCode adapter. The plumbing (`BuildSnapshotOpts.searchTool`) already existed and was documented but never wired from the PreCompact path.

## Affected platforms

- [x] Claude Code
- [ ] Cursor
- [x] VS Code Copilot (GitHub Copilot)
- [x] JetBrains Copilot
- [x] Gemini CLI
- [ ] Qwen Code
- [x] OpenCode
- [x] KiloCode
- [x] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

Note: bare-name platforms (cursor, codex, openclaw, pi) already emit the correct name via identity namer — their snapshots are unchanged by this fix.

## Test plan

**TDD (red → green)** — added integration test to `tests/hooks/precompact-snapshot-event.test.ts`:

- Spawns the real `hooks/precompact.mjs` (claude-code) subprocess
- Pre-seeds a SessionDB with file + decision events
- Runs the hook and reads the resume snapshot from the DB
- **Red:** snapshot contained bare `ctx_search(` without platform prefix
- **Green:** snapshot contains `mcp__plugin_context-mode_context-mode__ctx_search(` and no standalone bare `ctx_search(`

All existing tests pass:
- `tests/hooks/precompact-snapshot-event.test.ts`: 2/2
- `tests/session/session-snapshot.test.ts`: 40/40
- `tests/hooks/core-routing.test.ts`: 95/95
- `npm run typecheck`: passes

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes — snapshot/routing/hook tests all green; full-suite has pre-existing Windows-environment failures (verified identical on unmodified `next` baseline)
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md) — n/a
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)