### PR TITLE
fix(analytics): replace time-language with byte-ratio wording (#1023)

### DIFF
--- a/src/session/analytics.ts
+++ b/src/session/analytics.ts
@@ -2216,7 +2216,7 @@ function renderNarrative5Section(args: {
     const convMult   = Math.max(1, Math.round(convTokensWithout / convTokensWith));
     out.push(`  Without context-mode  ${kb(convBytesWithout).padStart(8)}  ${withoutBar}   ${fmtNum(convTokensWithout).padStart(7)} tokens`);
     out.push(`  With context-mode     ${kb(convBytesWith).padStart(8)}  ${withBar}   ${fmtNum(convTokensWith).padStart(7)} tokens`);
-    out.push(`                          ${convPct.toFixed(1)}% kept out of context · your AI ran ${convMult}× longer before /compact fired`);
+    out.push(`                          ${convPct.toFixed(1)}% kept out of context · ${convMult}× more data diverted from context window`);
     out.push("");
   }
 

--- a/tests/analytics/format-report.test.ts
+++ b/tests/analytics/format-report.test.ts
@@ -835,6 +835,33 @@ describe("v1.0.148 Bug G — Section 1 bar uses strict-compression formula", () 
     expect(pct).toBeGreaterThan(99);
     expect(pct).toBeLessThan(100);
   });
+
+  it("byte ratio uses accurate wording, not time-language (#1023)", () => {
+    const { conversation, report } = makeNarrativeContext();
+    const conversationRealBytes = {
+      eventDataBytes: 0,
+      bytesAvoided: 100_000,
+      bytesReturned: 100,
+      snapshotBytes: 0,
+      contentBytes: 0,
+      totalSavedTokens: Math.floor(100_100 / 4),
+    };
+
+    const output = formatReport(report, "1.0.169", null, {
+      conversation: conversation as any,
+      realBytes: { conversation: conversationRealBytes as any },
+    });
+
+    const ratioLine = output
+      .split("\n")
+      .find((l) => l.includes("kept out of context") && l.includes("%"));
+    expect(ratioLine, `bar summary line missing in:\n${output}`).toBeDefined();
+    // Must NOT use time/longevity language for a byte ratio
+    expect(ratioLine!).not.toContain("ran");
+    expect(ratioLine!).not.toContain("longer");
+    // Must still show the multiplier in an accurate form
+    expect(ratioLine!).toMatch(/\d+×/);
+  });
 });
 
 // ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## What / Why / How

Fixes #1023.

**What** — Replace the misleading "your AI ran N× longer before /compact fired" wording with "N× more data diverted from context window".

**Why** — The `convMult` value is `round((bytesAvoided + bytesReturned) / bytesReturned)` — a pure byte ratio. No timestamp, turn count, or proximity-to-compact measurement contributes to it. Presenting a byte ratio with time language ("ran ... longer") makes a causation claim the data doesn't support. With a single redirect avoiding 100KB and returning 100B, the report says "ran 1001× longer" which is meaningless as a time statement.

**How** — One-line string change in `src/session/analytics.ts:2219`. The new wording `"N× more data diverted from context window"` accurately describes what the number measures without implying temporal causation.

## Affected platforms

- [x] All platforms

## Test plan

**TDD (red → green)** — added test to `tests/analytics/format-report.test.ts`:

- Drives a 1001× byte ratio (100KB avoided, 100B returned)
- **Red:** output contained `"ran"` and `"longer"` (time language)
- **Green:** output contains `"1001×"` multiplier without time language

All existing tests pass:
- `tests/analytics/format-report.test.ts`: 38/38
- `npm run typecheck`: passes

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes — analytics tests all green
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md) — n/a
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)
