### PR TITLE
fix(detect): wait for MCP initialize before platform detect

### DIFF
--- a/src/adapters/detect.ts
+++ b/src/adapters/detect.ts
@@ -498,22 +498,6 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
     };
   }
 
-  if (existsSync(resolve(home, ".claude"))) {
-    return {
-      platform: "claude-code",
-      confidence: "medium",
-      reason: "~/.claude/ directory exists",
-    };
-  }
-
-  if (existsSync(resolve(home, ".gemini"))) {
-    return {
-      platform: "gemini-cli",
-      confidence: "medium",
-      reason: "~/.gemini/ directory exists",
-    };
-  }
-
   if (existsSync(resolve(home, ".codex"))) {
     return {
       platform: "codex",
@@ -577,6 +561,22 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
       platform: "openclaw",
       confidence: "medium",
       reason: "~/.openclaw/ directory exists",
+    };
+  }
+
+  if (existsSync(resolve(home, ".claude"))) {
+    return {
+      platform: "claude-code",
+      confidence: "medium",
+      reason: "~/.claude/ directory exists",
+    };
+  }
+
+  if (existsSync(resolve(home, ".gemini"))) {
+    return {
+      platform: "gemini-cli",
+      confidence: "medium",
+      reason: "~/.gemini/ directory exists",
     };
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5354,6 +5354,24 @@ async function main() {
   // Lifecycle guard: detect parent death + stdin close to prevent orphaned processes (#103)
   startLifecycleGuard({ onShutdown: () => gracefulShutdown() });
 
+  // Detect platform adapter after MCP initialize. server.connect()
+  // returns before the handshake, so getClientVersion() is empty on
+  // that path. Wait for oninitialized so omp-coding-agent clientInfo
+  // wins over ~/.claude config-dir fallback.
+  server.server.oninitialized = () => {
+    void (async () => {
+      try {
+        const { detectPlatform, getAdapter } = await import("./adapters/detect.js");
+        const clientInfo = server.server.getClientVersion();
+        const signal = detectPlatform(clientInfo ?? undefined);
+        _detectedAdapter = await getAdapter(signal.platform);
+        if (clientInfo) {
+          console.error(`MCP client: ${clientInfo.name} v${clientInfo.version} → ${signal.platform}`);
+        }
+      } catch { /* best effort — _detectedAdapter stays null, falls back to .claude */ }
+    })();
+  };
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
@@ -5376,17 +5394,6 @@ async function main() {
     try { writeFileSync(mcpSentinel, String(process.pid)); } catch { /* best effort */ }
   }, 30_000);
   sentinelRefresh.unref();
-
-  // Detect platform adapter — stored for platform-aware session paths
-  try {
-    const { detectPlatform, getAdapter } = await import("./adapters/detect.js");
-    const clientInfo = server.server.getClientVersion();
-    const signal = detectPlatform(clientInfo ?? undefined);
-    _detectedAdapter = await getAdapter(signal.platform);
-    if (clientInfo) {
-      console.error(`MCP client: ${clientInfo.name} v${clientInfo.version} → ${signal.platform}`);
-    }
-  } catch { /* best effort — _detectedAdapter stays null, falls back to .claude */ }
 
   // Restore tool-call counters from SessionDB BEFORE the heartbeat fires
   // so the very first persistStats() carries the prior PID's totals into

--- a/tests/adapters/detect-after-initialize.test.ts
+++ b/tests/adapters/detect-after-initialize.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Detection after MCP initialize handshake.
+ *
+ * server.connect() returns before initialize completes, so
+ * getClientVersion() is empty on that path. Detect MUST wait for
+ * server.server.oninitialized so omp-coding-agent clientInfo wins
+ * over ~/.claude config-dir fallback.
+ *
+ * Source-text inspection (same pattern as ctx-upgrade-platform-threading.test.ts).
+ */
+import { describe, test, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..", "..");
+const serverSrc = readFileSync(resolve(ROOT, "src", "server.ts"), "utf-8");
+
+const mainIdx = serverSrc.indexOf("async function main()");
+const mainBody = serverSrc.slice(mainIdx);
+
+describe("main() defers adapter detect until initialize handshake", () => {
+  test("does not call getClientVersion immediately after connect", () => {
+    const connectIdx = mainBody.indexOf("await server.connect(transport)");
+    expect(connectIdx).toBeGreaterThan(-1);
+    const afterConnect = mainBody.slice(connectIdx, connectIdx + 2500);
+    expect(afterConnect).not.toMatch(/getClientVersion\(\)/);
+  });
+
+  test("detects from oninitialized after handshake", () => {
+    expect(mainBody).toMatch(/server\.server\.oninitialized\s*=/);
+    expect(mainBody).toMatch(/oninitialized[\s\S]{0,800}getClientVersion\(\)/);
+    expect(mainBody).toMatch(/oninitialized[\s\S]{0,1200}detectPlatform\(/);
+  });
+});

--- a/tests/adapters/detect-config-dir.test.ts
+++ b/tests/adapters/detect-config-dir.test.ts
@@ -243,6 +243,20 @@ describe("detectPlatform — config directory branches", () => {
     expect(signal.platform).toBe(expected);
     expect(signal.confidence).toBe("medium");
   });
+
+  // Dedicated CLI agents (.omp/.pi/.kiro) MUST outrank generic ~/.claude,
+  // same #542/#774 pattern as Cursor. A machine with both ~/.claude and
+  // ~/.omp otherwise mis-detects OMP MCP as Claude Code.
+  it("agent dir ~/.omp beats ~/.claude when both exist", () => {
+    existsSyncMock.mockImplementation(
+      ((p: unknown) =>
+        p === resolve(home, ".omp") ||
+        p === resolve(home, ".claude")) as typeof fs.existsSync,
+    );
+    const signal = detectPlatform();
+    expect(signal.platform).toBe("omp");
+    expect(signal.confidence).toBe("medium");
+  });
 });
 
 describe("detectPlatform — env var priority chain", () => {


### PR DESCRIPTION
## What / Why / How

OMP MCP was mis-detected as Claude Code. `server.connect()` returns before initialize, so `getClientVersion()` is empty and `~/.claude` beat `~/.omp` in the config-dir fallback.

Detect on `server.server.oninitialized` so omp-coding-agent `clientInfo` wins. Probe dedicated CLI agent dirs (`.kiro` / `.omp` / `.pi` / `.qwen` / `.kimi` / `.openclaw` / `.codex`) before `~/.claude`, same #542/#774 pattern as Cursor.

Detect-only. No adapter / plugin rewrite.

## Affected platforms

- [x] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [x] Codex CLI
- [x] OpenClaw (Pi Agent)
- [x] Pi
- [x] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

Also: OMP, Qwen, Kimi (CLI agent dirs now outrank `~/.claude`).

## Test plan

- `tests/adapters/detect-config-dir.test.ts`: `~/.omp` beats `~/.claude`
- `tests/adapters/detect-after-initialize.test.ts`: detect waits for `oninitialized`
- `bunx vitest run tests/adapters/detect-config-dir.test.ts tests/adapters/detect-after-initialize.test.ts` — 48 passed

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] Targeted tests pass
- [x] `npx tsc -b --noEmit` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)