### PR TITLE
fix: update Kiro hooks config to 1.0 v1 schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,7 +920,39 @@ Restart `agy`.
    }
    ```
 
-3. Create `.kiro/hooks/context-mode.json`:
+3. Create `.kiro/hooks/context-mode.json`.
+
+   **Kiro 1.0 (current)** — top-level `version: "v1"`, `hooks` as an array, each entry needs `name` + PascalCase `trigger` + `action: { type, command }`:
+
+   ```json
+   {
+     "version": "v1",
+     "hooks": [
+       {
+         "name": "context-mode-pretooluse",
+         "description": "Context-mode context-window protection (pre tool use)",
+         "trigger": "PreToolUse",
+         "matcher": "execute_bash|fs_read|@context-mode/ctx_execute|@context-mode/ctx_execute_file|@context-mode/ctx_batch_execute|@(?!context-mode/)",
+         "action": {
+           "type": "command",
+           "command": "context-mode hook kiro pretooluse"
+         }
+       },
+       {
+         "name": "context-mode-posttooluse",
+         "description": "Context-mode context-window protection (post tool use)",
+         "trigger": "PostToolUse",
+         "matcher": "*",
+         "action": {
+           "type": "command",
+           "command": "context-mode hook kiro posttooluse"
+         }
+       }
+     ]
+   }
+   ```
+
+   **Kiro 0.x (legacy)** — the old `.kiro.hook` style with `hooks` as an object and camelCase `preToolUse`/`postToolUse`. Kiro 1.0 silently ignores this format, so the Agent Hooks panel shows nothing. Use only if you are still on a 0.x build:
 
    ```json
    {

--- a/configs/kiro/agent.json
+++ b/configs/kiro/agent.json
@@ -1,18 +1,25 @@
 {
-  "name": "context-mode",
-  "description": "Context-mode hooks for context window protection",
-  "hooks": {
-    "preToolUse": [
-      {
-        "matcher": "execute_bash|fs_read|@context-mode/ctx_execute|@context-mode/ctx_execute_file|@context-mode/ctx_batch_execute|@(?!context-mode/)",
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "context-mode-pretooluse",
+      "description": "Context-mode context-window protection (pre tool use)",
+      "trigger": "PreToolUse",
+      "matcher": "execute_bash|fs_read|@context-mode/ctx_execute|@context-mode/ctx_execute_file|@context-mode/ctx_batch_execute|@(?!context-mode/)",
+      "action": {
+        "type": "command",
         "command": "context-mode hook kiro pretooluse"
       }
-    ],
-    "postToolUse": [
-      {
-        "matcher": "*",
+    },
+    {
+      "name": "context-mode-posttooluse",
+      "description": "Context-mode context-window protection (post tool use)",
+      "trigger": "PostToolUse",
+      "matcher": "*",
+      "action": {
+        "type": "command",
         "command": "context-mode hook kiro posttooluse"
       }
-    ]
-  }
+    }
+  ]
 }


### PR DESCRIPTION
## What / Why / How

Kiro 1.0 requires top-level version "v1", hooks as an array, and
PascalCase trigger + action:{type,command} per entry. The old 0.x
object/camelCase format was silently ignored, leaving the Agent Hooks
panel empty. Update README example to the v1 schema (keeping the 0.x
format labeled as legacy) and convert bundled configs/kiro/agent.json.

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [x] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

<!-- What tests were added or modified? -->

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
