### PR TITLE
docs(skill): surface workspace-boundary fallback

### DIFF
--- a/skills/context-mode/SKILL.md
+++ b/skills/context-mode/SKILL.md
@@ -14,6 +14,8 @@ description: |
   "find TODOs", "count lines", "codebase statistics", "security audit",
   "outdated packages", "dependency tree", "cloud resources", "CI/CD output".
   Also triggers on ANY MCP tool output that may exceed 20 lines.
+  For intentional reads outside the project root, use authorized host read with
+  offset/limit; do not widen permissions merely to bypass confinement.
   Subagent routing is handled automatically via PreToolUse hook.
 ---
 
@@ -38,6 +40,8 @@ Bash whitelist (safe to run directly):
 **Everything else → `ctx_execute` or `ctx_execute_file`.** Any command that reads, queries, fetches, lists, logs, tests, builds, diffs, inspects, or calls an external service. This includes ALL CLIs (gh, aws, kubectl, docker, terraform, wrangler, fly, heroku, gcloud, etc.) — there are thousands and we cannot list them all.
 
 **When uncertain, use context-mode.** Every KB of unnecessary context reduces the quality and speed of the entire session.
+
+**Workspace-boundary fallback:** `ctx_execute_file` is confined to the current project root. If an intentional file read outside that root is needed and the host `read` tool is authorized, use `read` with `offset`/`limit`; do not change permissions or use shell `cat` merely to bypass the boundary.
 
 ## Decision Tree
 


### PR DESCRIPTION
# Proposed upstream change

Title: docs(skill): surface workspace-boundary fallback

Commit message: docs(skill): surface workspace-boundary fallback

## Summary

- Surface the existing workspace-boundary exception in the context-mode skill description so tool selection can avoid a known failed call.
- Add the same fallback to the mandatory-rule body on current upstream `main`, which does not contain it.
- Keep the fallback narrow: authorized bounded host reads only, without permission widening or shell `cat` bypasses.

## Why

`ctx_execute_file` is intentionally confined to the current project root. During a Pi maintenance review, attempting to process explicitly supplied installed skill files outside that root caused avoidable failed calls before the authorized host `read` fallback was used.

The installed context-mode v1.0.169 snapshot in that environment already contained the body fallback, but the always-visible skill description did not. Fresh upstream `main` at commit `aafb69cb91a233cf4d7752633445fd3e982a6797` contains neither form. This patch makes the upstream skill internally consistent and exposes the exception at activation time.

## Validation

- Skill name and frontmatter structure preserved.
- No em dash introduced in frontmatter.
- Frontmatter fallback appears exactly once.
- Body fallback appears exactly once.
- `git diff --check` passes.
- Documentation-only change; no runtime code behavior changes.

## Review base

- Upstream commit: `aafb69cb91a233cf4d7752633445fd3e982a6797`
- Upstream file preimage SHA-256: `ce26cb01de7a116eab256f916620935f029e850771f3fb6cb7d40a3ce8d1f7ff`
- Prepared file SHA-256: `27664d21566823c24ab648509eea646535d2e7b34c577df7c92fec7497ef0897`
- Patch SHA-256: `194522eae16979a1345854e6129faf77e803dbb081439499f0c0285feca8e039`
- Patch: `/tmp/session-improvements-prepared/P2/P2-upstream.patch`
