### PR TITLE
mcp: name execution timeout in milliseconds

### DIFF
--- a/skills/context-mode/references/anti-patterns.md
+++ b/skills/context-mode/references/anti-patterns.md
@@ -198,7 +198,7 @@ BAD — will timeout on API calls:
     const resp = await fetch('https://api.slow-service.com/data');
     console.log(await resp.json());
   language: javascript
-  timeout_ms: 5000  ← API may take 10+ seconds
+  timeoutMs: 5000  ← API may take 10+ seconds
 
 GOOD — generous timeout for network:
   Tool: execute
@@ -206,11 +206,11 @@ GOOD — generous timeout for network:
     const resp = await fetch('https://api.slow-service.com/data');
     console.log(JSON.stringify(await resp.json(), null, 2));
   language: javascript
-  timeout_ms: 30000  ← 30 seconds for network calls
+  timeoutMs: 30000  ← 30 seconds for network calls
 ```
 
-**Recommended timeouts:**
-| Operation | timeout_ms |
+**Recommended timeouts (`timeoutMs` is milliseconds):**
+| Operation | timeoutMs |
 |-----------|-----------|
 | File reading/parsing | 5000 - 10000 |
 | Local computation | 10000 |
@@ -219,7 +219,7 @@ GOOD — generous timeout for network:
 | npm install / build | 120000 |
 | Full test suite | 120000 - 300000 |
 
-**Rule:** Always consider what your script does and set `timeout_ms` accordingly. Network calls and builds need significantly more time than file operations.
+**Rule:** Always consider what your script does and set `timeoutMs` accordingly. Network calls and builds need significantly more time than file operations.
 
 ---
 

--- a/skills/context-mode/references/patterns-javascript.md
+++ b/skills/context-mode/references/patterns-javascript.md
@@ -78,7 +78,7 @@ allIssues
   .forEach(i => console.log(`  #${i.number} (${i.created_at.slice(0,10)}): ${i.title}`));
 ```
 > summary_prompt: "Summarize issue distribution by label, highlight stale issues, suggest priorities"
-> timeout_ms: 30000
+> timeoutMs: 30000
 
 ---
 
@@ -295,4 +295,4 @@ try {
 }
 ```
 > summary_prompt: "Report test pass/fail counts, list each failing test with its error message"
-> timeout_ms: 60000
+> timeoutMs: 60000

--- a/skills/context-mode/references/patterns-shell.md
+++ b/skills/context-mode/references/patterns-shell.md
@@ -36,7 +36,7 @@ wc -l < /tmp/build-output.txt | xargs -I{} echo "{} total lines of output"
 rm -f /tmp/build-output.txt
 ```
 > summary_prompt: "Report build success/failure, list all errors with file paths, and count warnings"
-> timeout_ms: 120000
+> timeoutMs: 120000
 
 ### TypeScript compilation check
 
@@ -67,7 +67,7 @@ fi
 rm -f /tmp/tsc-output.txt
 ```
 > summary_prompt: "Report type error count, most common error codes, and most affected files"
-> timeout_ms: 60000
+> timeoutMs: 60000
 
 ---
 
@@ -97,7 +97,7 @@ grep -i 'slow' /tmp/test-output.txt | head -10
 rm -f /tmp/test-output.txt
 ```
 > summary_prompt: "Report pass/fail ratio, list all failing test names with suite, note any slow tests"
-> timeout_ms: 120000
+> timeoutMs: 120000
 
 ### Pytest summary
 
@@ -119,7 +119,7 @@ grep -E '(FAILED|ERROR)' /tmp/pytest-output.txt | head -30
 rm -f /tmp/pytest-output.txt
 ```
 > summary_prompt: "Report test results, list all failures with file and test name"
-> timeout_ms: 120000
+> timeoutMs: 120000
 
 ---
 

--- a/src/adapters/openclaw/mcp-tools.ts
+++ b/src/adapters/openclaw/mcp-tools.ts
@@ -92,7 +92,7 @@ export const OPENCLAW_TOOL_DEFS: readonly OpenClawToolDef[] = [
       properties: {
         language: { type: "string", description: "Runtime language" },
         code: { type: "string", description: "Source code to execute" },
-        timeout: { type: "number", description: "Max execution time in ms" },
+        timeoutMs: { type: "number", description: "Max execution time in milliseconds" },
       },
       required: ["language", "code"],
       additionalProperties: true,

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -210,6 +210,7 @@ function killTree(proc: ReturnType<typeof spawn>): void {
 interface ExecuteOptions {
   language: Language;
   code: string;
+  /** Wall-clock deadline in milliseconds. Undefined means no server-side timer. */
   timeout?: number;
   /** Keep process running after timeout instead of killing it. */
   background?: boolean;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1420,7 +1420,7 @@ export interface BatchRunResult {
 
 export interface BatchRunOptions {
   /**
-   * Total budget (concurrency=1, shared) or per-command (concurrency>1).
+   * Milliseconds. Total budget (concurrency=1, shared) or per-command (concurrency>1).
    * When `undefined`, no server-side timer fires — the MCP host's RPC
    * timeout governs (Issue #406).
    */
@@ -1478,17 +1478,47 @@ function truncateCommandForEcho(command: string): string {
  * blocking script hangs forever — the host never kills it and the user must
  * interrupt. Every other host enforces its own RPC timeout, so we keep the
  * no-server-timer behavior there (Issue #406 — long builds need an unbounded
- * run). A caller can still pass an explicit `timeout` to override on any host.
+ * run). A caller can still pass an explicit `timeoutMs` to override on any host.
  */
 export const AGY_DEFAULT_EXEC_TIMEOUT_MS = 120_000;
-export function resolveExecTimeout(timeout: number | undefined): number | undefined {
-  if (timeout !== undefined) return timeout;
+export function resolveExecTimeout(timeoutMs: number | undefined): number | undefined {
+  if (timeoutMs !== undefined) return timeoutMs;
   // Only agy gets a default — every other host enforces its own RPC timeout, so
   // keep the unbounded behavior there. Detected via the env the agy bundle pins
   // (CONTEXT_MODE_PLATFORM=antigravity-cli). Tunable via CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS.
   if (detectPlatform().platform !== "antigravity-cli") return undefined;
   const override = Number(process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS);
   return Number.isFinite(override) && override > 0 ? override : AGY_DEFAULT_EXEC_TIMEOUT_MS;
+}
+
+interface LegacyTimeoutArguments {
+  readonly timeoutMs?: number;
+  readonly timeout?: unknown;
+}
+
+/**
+ * Issue #1081 — `timeout` was renamed to `timeoutMs`. Zod strips unknown keys,
+ * so a caller still sending `timeout` would get no deadline at all: a caller
+ * that meant two minutes gets an unbounded run instead. The three sandbox tools
+ * declare `.passthrough()` so the legacy key survives parsing and reaches this
+ * guard, which fails the call. The value is never read as a deadline, so
+ * `timeout` is not an alias.
+ */
+export function checkLegacyTimeoutArg(
+  args: LegacyTimeoutArguments,
+  toolName: string,
+): ToolResult | null {
+  if (!Object.hasOwn(args, "timeout")) return null;
+  return trackResponse(toolName, {
+    content: [{
+      type: "text" as const,
+      text:
+        `Input validation error: Invalid arguments for tool ${toolName}: ` +
+        "`timeout` was renamed to `timeoutMs` and is no longer accepted. " +
+        "Resend with `timeoutMs` in milliseconds — timeoutMs: 120000 is two minutes.",
+    }],
+    isError: true,
+  });
 }
 
 /**
@@ -1701,10 +1731,10 @@ EXAMPLE: ctx_execute(language: "javascript", code: "const out = require('child_p
         .describe(
           "Source code to execute. Use console.log (JS/TS), print (Python/Ruby/Perl/R), echo (Shell), echo (PHP), fmt.Println (Go), IO.puts (Elixir), or Console.WriteLine (C#) to output a summary to context.",
         ),
-      timeout: z
+      timeoutMs: z
         .coerce.number()
         .optional()
-        .describe("Max execution time in ms. When omitted, no server-side timer fires — the MCP host's RPC timeout governs (which is the right layer for this policy). Pass an explicit value for long-running builds (Gradle/Maven/SBT)."),
+        .describe("Max execution time in MILLISECONDS — timeoutMs: 120000 is two minutes, timeoutMs: 120 is 0.12 seconds. When omitted, no server-side timer fires — the MCP host's RPC timeout governs (which is the right layer for this policy). Pass an explicit value for long-running builds (Gradle/Maven/SBT)."),
       // background: wrapped in coerceBoolean preprocessor so the literal
       // strings "true"/"false" arriving from OpenCode's native plugin
       // bridge (and several LLM providers' tool-call JSON) parse as the
@@ -1714,7 +1744,7 @@ EXAMPLE: ctx_execute(language: "javascript", code: "const out = require('child_p
         .preprocess(coerceBoolean, z.boolean())
         .optional()
         .default(false)
-        .describe("Keep process running after timeout (for servers/daemons). Returns partial output without killing the process. IMPORTANT: Do NOT add setTimeout/self-close timers in background scripts — the process must stay alive until the timeout detaches it. For server+fetch patterns, prefer putting both server and fetch in ONE ctx_execute call instead of using background."),
+        .describe("Keep process running once the timeoutMs deadline passes (for servers/daemons). Returns partial output without killing the process. IMPORTANT: Do NOT add setTimeout/self-close timers in background scripts — the process must stay alive until timeoutMs detaches it. For server+fetch patterns, prefer putting both server and fetch in ONE ctx_execute call instead of using background."),
       cwd: z
         .string()
         .optional()
@@ -1728,9 +1758,17 @@ EXAMPLE: ctx_execute(language: "javascript", code: "const out = require('child_p
           "Use ctx_search(queries: [...]) to retrieve specific sections. Example: 'failing tests', 'HTTP 500 errors'." +
           "\n\nTIP: Use specific technical terms, not just concepts. Check 'Searchable terms' in the response for available vocabulary.",
         ),
-    }),
+    // .passthrough(): #1081 keeps the legacy `timeout` key visible to the
+    // handler so it can be rejected instead of silently stripped. The emitted
+    // tools/list schema is unchanged — installStrictClientSchemaCompat() drops
+    // `additionalProperties` before it reaches the wire.
+    }).passthrough(),
   },
-  async ({ language, code, timeout, background, cwd, intent }) => {
+  async (args) => {
+    const legacyTimeout = checkLegacyTimeoutArg(args, "ctx_execute");
+    if (legacyTimeout) return legacyTimeout;
+    const { language, code, timeoutMs, background, cwd, intent } = args;
+
     // Security: deny-only firewall
     if (language === "shell") {
       const denied = checkDenyPolicy(code, "execute");
@@ -1808,7 +1846,7 @@ ${code}
 __cm_main().catch(e=>{console.error(e);process.exitCode=1});${background ? '\nsetInterval(()=>{},2147483647);' : ''}
 })(typeof require!=='undefined'?require:null);`;
       }
-      const effTimeout = resolveExecTimeout(timeout);
+      const effTimeout = resolveExecTimeout(timeoutMs);
       const result = await executor.execute({ language, code: instrumentedCode, timeout: effTimeout, background, cwd });
 
       // Echo the executed source code before stdout so users can audit
@@ -2088,10 +2126,10 @@ EXAMPLE: ctx_execute_file(path: "data.csv", language: "javascript", code: "const
         .describe(
           "Code to process FILE_CONTENT (file_content in Elixir). Print summary via console.log/print/echo/IO.puts/Console.WriteLine.",
         ),
-      timeout: z
+      timeoutMs: z
         .coerce.number()
         .optional()
-        .describe("Max execution time in ms. When omitted, no server-side timer fires — the MCP host's RPC timeout governs."),
+        .describe("Max execution time in MILLISECONDS — timeoutMs: 120000 is two minutes, timeoutMs: 120 is 0.12 seconds. When omitted, no server-side timer fires — the MCP host's RPC timeout governs."),
       intent: z
         .string()
         .optional()
@@ -2099,9 +2137,13 @@ EXAMPLE: ctx_execute_file(path: "data.csv", language: "javascript", code: "const
           "What you're looking for in the output. When provided and output is large (>5KB), " +
           "returns only matching sections via BM25 search instead of truncated output.",
         ),
-    }),
+    }).passthrough(), // #1081 — see ctx_execute
   },
-  async ({ path, language, code, timeout, intent }) => {
+  async (args) => {
+    const legacyTimeout = checkLegacyTimeoutArg(args, "ctx_execute_file");
+    if (legacyTimeout) return legacyTimeout;
+    const { path, language, code, timeoutMs, intent } = args;
+
     // Security (#852): confine the processed file to the project root so
     // ctx_execute_file cannot be used to escape the host's sandbox/permission
     // controls. Runs before the deny-glob check — boundary first, then policy.
@@ -2122,7 +2164,7 @@ EXAMPLE: ctx_execute_file(path: "data.csv", language: "javascript", code: "const
     }
 
     try {
-      const effTimeout = resolveExecTimeout(timeout);
+      const effTimeout = resolveExecTimeout(timeoutMs);
       const result = await executor.executeFile({
         path,
         language,
@@ -4211,10 +4253,10 @@ EXAMPLE: ctx_batch_execute(
           "Each returns top 5 matching sections with full content. " +
           "This is your ONLY chance — put ALL your questions here. No follow-up calls needed.",
         )),
-      timeout: z
+      timeoutMs: z
         .coerce.number()
         .optional()
-        .describe("Max execution time in ms. When omitted, no server-side timer fires — the MCP host's RPC timeout governs. With concurrency=1, the value (when set) is a shared budget across commands; with concurrency>1, it is applied per-command."),
+        .describe("Max execution time in MILLISECONDS — timeoutMs: 120000 is two minutes, timeoutMs: 120 is 0.12 seconds. When omitted, no server-side timer fires — the MCP host's RPC timeout governs. With concurrency=1, the value (when set) is a shared budget across commands; with concurrency>1, it is applied per-command."),
       concurrency: z
         .coerce.number()
         .int()
@@ -4245,9 +4287,13 @@ EXAMPLE: ctx_batch_execute(
           "— useful when you want the batch commands to enrich context and " +
           "the queries to also surface related prior knowledge in one round trip.",
         ),
-    }),
+    }).passthrough(), // #1081 — see ctx_execute
   },
-  async ({ commands, queries, timeout, concurrency, cwd, query_scope }) => {
+  async (args) => {
+    const legacyTimeout = checkLegacyTimeoutArg(args, "ctx_batch_execute");
+    if (legacyTimeout) return legacyTimeout;
+    const { commands, queries, timeoutMs, concurrency, cwd, query_scope } = args;
+
     // Security: check each command against deny patterns
     for (const cmd of commands) {
       const denied = checkDenyPolicy(cmd.command, "batch_execute");
@@ -4262,7 +4308,7 @@ EXAMPLE: ctx_batch_execute(
 
       // Full stdout is preserved per-command and indexed into FTS5 (Issue #61, #197).
       // Concurrency>1 switches to a worker pool with per-command timeouts.
-      const effTimeout = resolveExecTimeout(timeout);
+      const effTimeout = resolveExecTimeout(timeoutMs);
       const { outputs: perCommandOutputs, timedOut } = await runBatchCommands(
         commands,
         {

--- a/tests/adapters/zod3tov4.test.ts
+++ b/tests/adapters/zod3tov4.test.ts
@@ -166,7 +166,7 @@ describe("zod3ShapeToV4", () => {
     const z3Shape = {
       language: z.enum(["javascript", "typescript", "python", "shell"]),
       code: z.string().describe("Source code"),
-      timeout: z.number().optional(),
+      timeoutMs: z.number().optional(),
       background: z.boolean().default(false),
       intent: z.string().optional().describe("Search intent"),
     };

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -20,6 +20,7 @@ import {
   mkdirSync,
   rmSync,
   readFileSync,
+  realpathSync,
   existsSync,
 } from "node:fs";
 import { join, dirname, resolve } from "node:path";
@@ -6715,4 +6716,165 @@ describe("ctx_* MCP tool annotations (#846)", () => {
       expect(find(name)!.config.annotations!.readOnlyHint).toBe(false);
     }
   });
+});
+
+// ─── Issue #1081: the execution deadline field states its unit ──────────────
+// "Server & tools" domain → this file owns tool registration per CONTRIBUTING.md.
+// `ctx_execute`, `ctx_execute_file`, and `ctx_batch_execute` used to expose a
+// numeric `timeout` whose unit (milliseconds) appeared nowhere in the public
+// schema, so `timeout: 120` for a two-minute job bought a 120ms deadline. The
+// field is now `timeoutMs` with no alias. These cases drive the real server
+// over stdio (start.mjs loads server.bundle.mjs, so the shipped bundle is what
+// answers) because the deadline is a timer in a spawned process killing a
+// grandchild sandbox: nothing in this file's event loop owns that clock, so
+// fake timers cannot substitute. A 4-second script against a 120ms deadline is
+// a gap only a seconds-vs-milliseconds misreading can close.
+describe("issue #1081 — execution deadline field states its unit", () => {
+  const EXEC_TOOLS = ["ctx_execute", "ctx_execute_file", "ctx_batch_execute"] as const;
+
+  interface TimeoutRpcResponse {
+    id?: number;
+    error?: { message: string };
+    result?: {
+      isError?: boolean;
+      content?: Array<{ text?: string }>;
+      tools?: Array<{
+        name: string;
+        inputSchema?: { properties?: Record<string, { description?: string }> };
+      }>;
+    };
+  }
+  type ToolArguments = Record<string, unknown>;
+  type ListedTools = NonNullable<NonNullable<TimeoutRpcResponse["result"]>["tools"]>;
+
+  let projectDir: string;
+  let fixtureFile: string;
+  let proc: ChildProcess;
+  let tools: ListedTools = [];
+
+  function rpc(
+    id: number,
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<TimeoutRpcResponse | undefined> {
+    return new Promise((settle) => {
+      let buffer = "";
+      const done = (value: TimeoutRpcResponse | undefined) => {
+        proc.stdout!.off("data", onData);
+        clearTimeout(timer);
+        settle(value);
+      };
+      const onData = (chunk: Buffer) => {
+        buffer += chunk.toString();
+        let idx: number;
+        while ((idx = buffer.indexOf("\n")) >= 0) {
+          const line = buffer.slice(0, idx).trim();
+          buffer = buffer.slice(idx + 1);
+          if (!line) continue;
+          try {
+            const parsed = JSON.parse(line) as TimeoutRpcResponse;
+            if (parsed.id === id) return done(parsed);
+          } catch { /* interleaved log line */ }
+        }
+      };
+      const timer = setTimeout(() => done(undefined), 25_000);
+      proc.stdout!.on("data", onData);
+      proc.stdin!.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    });
+  }
+
+  const callTool = (id: number, name: string, args: ToolArguments) =>
+    rpc(id, "tools/call", { name, arguments: args });
+  const textOf = (r: TimeoutRpcResponse | undefined) => r?.result?.content?.[0]?.text ?? "";
+
+  /**
+   * A marker split across a concatenation so the joined form appears only in
+   * the child's stdout, never in the source echo the response prepends. Lets
+   * an assertion tell "the script produced output" from "the response quoted
+   * the script".
+   */
+  const splitMarker = (name: string) => ({
+    code: "'" + name + "' + '_1081'",
+    joined: name + "_1081",
+  });
+
+  beforeAll(async () => {
+    // realpath: macOS hands out /var/... symlinks for tmpdir and the #852
+    // project-boundary check compares resolved paths.
+    projectDir = realpathSync(mkdtempSync(join(tmpdir(), "timeout-ms-1081-")));
+    fixtureFile = join(projectDir, "sample-1081.txt");
+    writeFileSync(fixtureFile, "alpha\nbeta\ngamma\n");
+    proc = spawn("node", [mcpEntry], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        CONTEXT_MODE_DISABLE_VERSION_CHECK: "1",
+        CLAUDE_PROJECT_DIR: projectDir,
+      },
+    });
+    await rpc(1, "initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "timeout-ms-1081-test", version: "1.0" },
+    });
+    proc.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+    tools = (await rpc(2, "tools/list", {}))?.result?.tools ?? [];
+  }, 60_000);
+
+  afterAll(() => {
+    try { proc.kill("SIGTERM"); } catch { /* best effort */ }
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  test("tools/list exposes timeoutMs with its unit, and no timeout alias", () => {
+    expect(tools.length).toBeGreaterThan(0);
+    for (const name of EXEC_TOOLS) {
+      const tool = tools.find((t) => t.name === name);
+      expect(tool, `${name} missing from tools/list`).toBeDefined();
+      const props = tool!.inputSchema?.properties ?? {};
+      expect(Object.keys(props), `${name} must advertise timeoutMs`).toContain("timeoutMs");
+      expect(Object.keys(props), `${name} must not advertise a timeout alias`).not.toContain("timeout");
+      expect(
+        props.timeoutMs?.description ?? "",
+        `${name}.timeoutMs description must name the unit`,
+      ).toMatch(/millisecond/i);
+    }
+  });
+
+  test("timeoutMs 120 is 120 milliseconds, not 120 seconds", async () => {
+    const marker = splitMarker("EXEC_SLOW");
+    const started = Date.now();
+    const resp = await callTool(10, "ctx_execute", {
+      language: "javascript",
+      code: `setTimeout(() => console.log(${marker.code}), 4000);`,
+      timeoutMs: 120,
+    });
+    const elapsed = Date.now() - started;
+    expect(resp?.error).toBeUndefined();
+    expect(resp?.result?.isError).toBe(true);
+    expect(textOf(resp)).toContain("Execution timed out after 120ms");
+    // 120 seconds would have let the 4s script print and exit cleanly.
+    expect(textOf(resp)).not.toContain(marker.joined);
+    expect(elapsed).toBeLessThan(4000);
+  }, 30_000);
+
+  test("the legacy timeout key is rejected on all three tools, never aliased", async () => {
+    const marker = splitMarker("EXEC_LEGACY");
+    const cases: Array<[string, ToolArguments]> = [
+      ["ctx_execute", { language: "javascript", code: `console.log(${marker.code});`, timeout: 120 }],
+      ["ctx_execute_file", { path: fixtureFile, language: "javascript", code: `console.log(${marker.code});`, timeout: 120 }],
+      ["ctx_batch_execute", { commands: [{ label: "echo", command: `node -e "console.log(${marker.code})"` }], queries: ["one"], timeout: 120 }],
+    ];
+    let id = 20;
+    for (const [name, args] of cases) {
+      const resp = await callTool(id++, name, args);
+      const text = textOf(resp);
+      expect(resp?.result?.isError, `${name} must reject the legacy key`).toBe(true);
+      expect(text).toContain("`timeout` was renamed to `timeoutMs`");
+      expect(text).toContain("timeoutMs: 120000 is two minutes");
+      // Rejected before execution: the code never ran, so there is no alias
+      // and no silent unbounded fallback for a caller who meant two minutes.
+      expect(text).not.toContain(marker.joined);
+    }
+  }, 45_000);
 });


### PR DESCRIPTION
Closes #1081

Renames the public execution deadline to timeoutMs for ctx_execute, ctx_execute_file, and ctx_batch_execute. The retired timeout field returns a bounded migration error instead of silently changing or dropping the deadline. Skill references are regenerated. The generated bundles are left out, since the bundle workflow rebuilds and commits them on push.

Tests: 6 live-server timeout tests, 646 focused tests after cleanup, 4727 full-suite passes with 21 skips, typecheck, build assertions, changed-line anti-slop scan.