### PR TITLE
fix(hooks): scan quotes left to right so prose apostrophes cannot expose a command

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -233,11 +233,62 @@ function stripHeredocs(cmd) {
  * Strip ALL quoted content from a shell command so regex only matches command tokens.
  * Removes heredocs, single-quoted strings, and double-quoted strings.
  * This prevents false positives like: gh issue edit --body "text with curl in it"
+ *
+ * Scans left to right and lets whichever quote opens first own everything up to its
+ * partner, the way a shell does. The previous version ran two independent global
+ * replaces -- every '...' pair first, then every "..." pair -- which is only correct
+ * when the two kinds never interleave. An apostrophe inside a double-quoted string
+ * breaks that: in
+ *
+ *   git tag -m "... curl for the header file ... the linter's fixtures ..." && \
+ *     echo "created: $(git tag -l 'modx-tools/v1.27.2')"
+ *
+ * the apostrophe in "linter's" paired with the ' opening 'modx-tools/v1.27.2', so a
+ * span straddling the closing " collapsed to ''. That desynchronised the double-quote
+ * pass, left the middle of the message looking like bare shell, and the command was
+ * redirected as a curl invocation. Apostrophes in prose ("don't", "it's", "linter's")
+ * make commit and tag messages hit this constantly.
  */
 function stripQuotedContent(cmd) {
-  return stripHeredocs(cmd)
-    .replace(/'[^']*'/g, "''")                    // single-quoted strings
-    .replace(/"[^"]*"/g, '""');                   // double-quoted strings
+  const src = stripHeredocs(cmd);
+  let out = "";
+  let i = 0;
+  while (i < src.length) {
+    const ch = src[i];
+
+    // An escape outside quotes consumes its target, so \" and \' cannot open a string.
+    if (ch === "\\" && i + 1 < src.length) {
+      out += ch + src[i + 1];
+      i += 2;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
+      const quote = ch;
+      let j = i + 1;
+      while (j < src.length) {
+        // Backslash escapes apply inside double quotes; inside single quotes a POSIX
+        // shell treats every character literally until the closing quote.
+        if (quote === '"' && src[j] === "\\" && j + 1 < src.length) { j += 2; continue; }
+        if (src[j] === quote) break;
+        j++;
+      }
+      if (j >= src.length) {
+        // Unterminated: this was never a string, just an apostrophe in prose. Emit it
+        // and keep scanning, so a genuine curl later in the command is still seen.
+        out += ch;
+        i++;
+        continue;
+      }
+      out += quote + quote;
+      i = j + 1;
+      continue;
+    }
+
+    out += ch;
+    i++;
+  }
+  return out;
 }
 
 /**

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -137,6 +137,42 @@ describe("routePreToolUse", () => {
       );
     });
 
+    // ─── quote scanning: an apostrophe must not desynchronise the stripper ────────────
+    // stripQuotedContent ran two independent global replaces -- every '...' pair first,
+    // then every "..." pair. That is only correct when the two kinds never interleave.
+    // An apostrophe inside a double-quoted string pairs with the next unrelated ' in a
+    // later argument, and collapsing that span eats both the closing " of the message and
+    // the opening " of the following string. The message's own opening " is then left
+    // unpaired, so its body survives into the gate as if it were bare shell -- and when
+    // the prose happens to mention curl or wget, the command is redirected and never runs.
+    //
+    // Same class as #63, which those two replaces were added to fix; they just do not
+    // survive interleaving. Prose apostrophes ("don't", "it's", "the linter's") make
+    // commit and tag messages hit this routinely.
+
+    it("does not treat a tag message containing an apostrophe and curl as a curl call", () => {
+      // Fails against the two-replace implementation: it leaves
+      //   ... -m "the client -- curl for the header, the linter''v1''%H'
+      // with curl space-preceded and outside any quote.
+      const result = routePreToolUse("Bash", {
+        command:
+          `git tag -a v1 -m "the client -- curl for the header, the linter's fixtures" ` +
+          `&& echo "x $(git tag -l 'v1')" && git show --format='%H'`,
+      });
+      expect(JSON.stringify(result ?? {})).not.toContain("curl/wget redirected");
+    });
+
+    it("still redirects a genuine curl that follows an unterminated apostrophe", () => {
+      // Guards the new scanner rather than the old bug: an apostrophe that never closes
+      // is prose, not a string, so it must not swallow the rest of the line -- otherwise
+      // a real invocation after it would go unseen.
+      const result = routePreToolUse("Bash", {
+        command: "echo it's fine && curl -sS https://example.com",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("modify");
+    });
+
     // ─── curl/wget file-output allow-list (#166) ────────────
 
     it("allows curl -sLo file (silent + file output)", () => {


### PR DESCRIPTION
## What / Why / How

`stripQuotedContent` ran two independent global replaces — every `'...'` pair first, then every `"..."` pair. That is only correct when the two quote kinds never interleave, and an apostrophe inside a double-quoted string breaks it.

```bash
git tag -a v1 -m "the client -- curl for the header, the linter's fixtures" \
  && echo "x $(git tag -l 'v1')" && git show --format='%H'
```

The apostrophe in `linter's` pairs with the `'` opening `'v1'`, and collapsing that span eats **both** the closing `"` of the tag message and the opening `"` of the `echo`. The message's own opening `"` is left unpaired, so the double-quote pass never removes its body:

```
git tag -a v1 -m "the client -- curl for the header, the linter''v1''%H'
```

`curl` is now space-preceded and outside any quote, the gate matches, and the command is redirected instead of run.

This is the same class of false positive as **#63**, which those two replaces were added to fix — they just do not survive interleaving. Prose apostrophes (`don't`, `it's`, `the linter's`) make commit and tag messages hit it routinely; I ran into it writing a release tag whose message happened to mention curl.

**How:** one left-to-right scan that lets whichever quote opens first own everything up to its partner, the way a shell does. Backslash escapes are consumed inside double quotes and outside, so an escaped quote cannot open a string. An unterminated quote is emitted literally rather than swallowing the rest of the line — otherwise `echo it's fine && curl -sS ...` would hide a genuine invocation, trading a false positive for a false negative.

No behaviour change to the allow-list logic in #166; only what the gate is shown.

## Affected platforms

- [x] All platforms

`hooks/core/routing.mjs` is the shared PreToolUse path, so this affects every platform that routes Bash/shell commands through it.

## Test plan

Two tests added alongside the #166 allow-list block:

1. **`does not treat a tag message containing an apostrophe and curl as a curl call`** — the regression guard. Verified red against the two-replace implementation and green with the scan.
2. **`still redirects a genuine curl that follows an unterminated apostrophe`** — guards the new scanner rather than the old bug, so a future "fix" for unterminated quotes cannot start swallowing the rest of the line.

Worth noting: an earlier draft of these tests passed either way. The shortened commands I first wrote had an even quote count and stripped cleanly, so they proved nothing. The command in test 1 is the arrangement that actually reproduces — it needs the trailing `'...'` argument to leave the message's opening `"` unpaired, and `curl` must be space-preceded rather than sitting against the quote.

```
npm test          → 213 files, 4776 passed, 25 skipped, 0 failed
npm run typecheck → clean
```

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md) — no user-facing behaviour documented changes
- [x] No Windows path regressions (forward slashes only) — the change touches no paths
- [x] Targets `next` branch
