### PR TITLE
fix(security): expand // and ~/ anchors in permission patterns (#1075)

### DIFF
--- a/src/security.ts
+++ b/src/security.ts
@@ -1,5 +1,6 @@
 import { readFileSync, realpathSync } from "node:fs";
-import { relative, resolve, sep } from "node:path";
+import { homedir } from "node:os";
+import { join, relative, resolve, sep } from "node:path";
 
 import { resolveAdapterGlobalSettingsPaths } from "./util/claude-config.js";
 
@@ -592,6 +593,29 @@ export function evaluateCommandDenyOnly(
 // ==============================================================================
 
 /**
+ * Expand the two path anchors Claude Code documents for permission patterns
+ * (issue #1075). A pattern body reaches the matcher exactly as the user typed
+ * it inside `Read(...)`, so these two forms never matched anything:
+ *
+ *   - `//abs/path` — an absolute path from the filesystem root
+ *   - `~/rel/path` — a path relative to the user's home directory
+ *
+ * Only the bare `/path` form matched, and that is the one form Claude Code
+ * does *not* resolve against the filesystem root. The consequences ran both
+ * ways: a `deny` rule written with either anchor silently failed open, and an
+ * `allow` rule written with either anchor failed to unblock the path it named.
+ *
+ * The expansion is additive — the raw glob stays in the returned list — so no
+ * rule that matched before stops matching now.
+ */
+export function expandGlobAnchors(glob: string): string[] {
+  if (glob.startsWith("//")) return [glob, glob.slice(1)];
+  if (glob === "~") return [glob, homedir()];
+  if (glob.startsWith("~/")) return [glob, join(homedir(), glob.slice(2))];
+  return [glob];
+}
+
+/**
  * Check if a file path should be denied based on deny globs.
  *
  * Normalizes backslashes to forward slashes before matching so that
@@ -639,14 +663,18 @@ export function evaluateFilePath(
 
   for (const globs of denyGlobs) {
     for (const glob of globs) {
-      // Normalize the glob's path separators the same way candidates were
+      // Expand `//` and `~/` anchors (issue #1075) before matching, then
+      // normalize the glob's path separators the same way candidates were
       // normalized — otherwise a Windows absolute deny rule like
       // `Read(C:\Users\...\secret.env)` parses with literal backslashes that
       // never match a forward-slash candidate.
-      const regex = fileGlobToRegex(toForward(glob), caseInsensitive);
-      for (const candidate of candidates) {
-        if (regex.test(candidate)) {
-          return { denied: true, matchedPattern: glob };
+      for (const variant of expandGlobAnchors(glob)) {
+        const regex = fileGlobToRegex(toForward(variant), caseInsensitive);
+        for (const candidate of candidates) {
+          if (regex.test(candidate)) {
+            // Report the pattern as the user wrote it, not the expansion.
+            return { denied: true, matchedPattern: glob };
+          }
         }
       }
     }

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -24,6 +24,8 @@ import {
   readToolDenyPatterns,
   fileGlobToRegex,
   evaluateFilePath,
+  evaluateProjectContainment,
+  expandGlobAnchors,
   extractShellCommands,
 } from "../build/security.js";
 
@@ -992,5 +994,86 @@ describe("cross-adapter deny-policy parity (#451 round-3)", () => {
       allDeny.includes("Bash(claude-only *)"),
       `expected claude deny in union (defense in depth), got ${JSON.stringify(allDeny)}`,
     );
+  });
+});
+
+// ==============================================================================
+// Issue #1075 — `//` and `~/` permission-pattern anchors
+// ==============================================================================
+
+describe("permission pattern anchors (#1075)", () => {
+  const home = homedir().replace(/\\/g, "/");
+
+  test("expandGlobAnchors: // resolves to the filesystem root", () => {
+    assert.deepEqual(expandGlobAnchors("//etc/passwd"), [
+      "//etc/passwd",
+      "/etc/passwd",
+    ]);
+  });
+
+  test("expandGlobAnchors: ~/ resolves to the home directory", () => {
+    const [raw, expanded] = expandGlobAnchors("~/.ssh/id_rsa");
+    assert.equal(raw, "~/.ssh/id_rsa");
+    assert.equal(expanded.replace(/\\/g, "/"), `${home}/.ssh/id_rsa`);
+  });
+
+  test("expandGlobAnchors: unanchored globs are returned untouched", () => {
+    assert.deepEqual(expandGlobAnchors("**/.env"), ["**/.env"]);
+    assert.deepEqual(expandGlobAnchors("/src/**"), ["/src/**"]);
+  });
+
+  test("deny: `//` rule blocks the absolute path it names", () => {
+    // Before the fix this failed open: the regex was built from the literal
+    // "//etc/passwd", which no candidate path can equal.
+    const result = evaluateFilePath("/etc/passwd", [["//etc/passwd"]], false);
+    assert.equal(result.denied, true);
+    assert.equal(result.matchedPattern, "//etc/passwd");
+  });
+
+  test("deny: `~/` rule blocks the home-relative path it names", () => {
+    const result = evaluateFilePath(`${home}/.ssh/id_rsa`, [["~/.ssh/**"]], false);
+    assert.equal(result.denied, true);
+    assert.equal(result.matchedPattern, "~/.ssh/**");
+  });
+
+  test("deny: an anchored rule still does not match unrelated paths", () => {
+    assert.equal(
+      evaluateFilePath("/etc/hosts", [["//etc/passwd"]], false).denied,
+      false,
+    );
+    assert.equal(
+      evaluateFilePath(`${home}/notes/todo.md`, [["~/.ssh/**"]], false).denied,
+      false,
+    );
+  });
+
+  test("allow: `~/` rule lets an out-of-project read through the #852 guard", () => {
+    const projectRoot = resolve(tmpdir(), "ctx-anchor-project");
+    const target = `${home}/logs/app.log`;
+    // Without the allow rule the containment guard rejects an outside path.
+    assert.equal(
+      evaluateProjectContainment(target, projectRoot, [], false).allowed,
+      false,
+    );
+    const allowed = evaluateProjectContainment(
+      target,
+      projectRoot,
+      [["~/logs/**"]],
+      false,
+    );
+    assert.equal(allowed.allowed, true);
+    assert.equal(allowed.reason, "allow-rule");
+  });
+
+  test("allow: `//` rule lets an out-of-project read through the #852 guard", () => {
+    const projectRoot = resolve(tmpdir(), "ctx-anchor-project");
+    const allowed = evaluateProjectContainment(
+      "/var/log/system.log",
+      projectRoot,
+      [["//var/log/**"]],
+      false,
+    );
+    assert.equal(allowed.allowed, true);
+    assert.equal(allowed.reason, "allow-rule");
   });
 });


### PR DESCRIPTION
Fixes #1075.

## The bug

`parseToolPattern` returns the text inside `Read(...)` verbatim, and
`evaluateFilePath` feeds it straight to `fileGlobToRegex`. Nothing in
`src/security.ts` touches `~` or a leading `//`, so the two anchors Claude Code
documents as absolute never matched anything:

| pattern form | meaning | matched before |
|---|---|---|
| `//abs/path` | absolute from the filesystem root | no |
| `~/rel/path` | relative to the home directory | no |
| `/path` | relative to the settings file's directory | yes |

The only form that worked is the one form Claude Code does *not* resolve
against the filesystem root.

`evaluateFilePath` is the single matcher behind both gates (the deny gate, and
the `permissions.allow` consultation in `evaluateProjectContainment`), so one
omission broke them in opposite directions:

- **deny fails open.** `Read(~/.ssh/**)` compiles to a regex over the literal
  string `~/.ssh/**`. Candidates are raw / lexically-resolved / realpath'd
  paths — none can equal that — so the rule never fires and the path the user
  explicitly denied is read.
- **allow fails closed.** `Read(//var/log/**)` never matches either, so the
  #852 containment guard still reports `outside` and `ctx_execute_file`
  refuses a path the user explicitly allowed.

## The fix

One helper, applied at the one place both gates route through:

```ts
export function expandGlobAnchors(glob: string): string[] {
  if (glob.startsWith("//")) return [glob, glob.slice(1)];
  if (glob === "~") return [glob, homedir()];
  if (glob.startsWith("~/")) return [glob, join(homedir(), glob.slice(2))];
  return [glob];
}
```

The expansion is **additive** — the raw glob stays in the match set — so no
rule that matched before stops matching, which also keeps the Windows
literal-backslash behaviour and the UNC-ish `//server/share` reading intact.
`matchedPattern` still reports the pattern as the user wrote it, not the
expansion, so deny messages stay recognisable.

I kept it inside `evaluateFilePath` rather than at `parseToolPattern` /
`readToolPermissionPatterns` on purpose: `evaluateFilePath` also takes globs
from callers that never went through the settings reader, and normalizing at
parse time would leave those paths unfixed.

## Tests

Seven cases in `tests/security.test.ts` under `permission pattern anchors
(#1075)` — the helper itself, deny for both anchors, allow-through-#852 for
both anchors, and a negative control asserting an anchored rule still does not
match unrelated paths.

Verified locally (Node v24.13.0, vitest 4.1.5):

- **before the fix**, 7 of the 8 new assertions fail — e.g.
  `deny: '//' rule blocks the absolute path it names` gets `denied: false`.
  The one that passes is the negative control, as it should.
- **after the fix**, `npx tsc` is clean and the full suite is
  `4731 passed | 18 skipped`.

One pre-existing failure is unrelated to this change and reproduces on a clean
checkout of `main`:

```
FAIL tests/hooks/cache-heal-self-heal.test.ts > Issues #814/#807 …
  > a stale breadcrumb pointing at a removed intermediate version is re-pointed at the live root
ENOENT: … /plugins/cache/context-mode/context-mode/1.0.050
```

Bundles are not committed here — per CONTRIBUTING they are CI-built, and
`hooks/security.bundle.mjs` is gitignored.
