### PR TITLE
fix: derive context-mode registry key

### DIFF
--- a/scripts/heal-installed-plugins.mjs
+++ b/scripts/heal-installed-plugins.mjs
@@ -20,6 +20,14 @@
 import { existsSync, readFileSync, writeFileSync, readdirSync, unlinkSync, statSync } from "node:fs";
 import { resolve, sep } from "node:path";
 
+export function resolveContextModePluginKey(plugins) {
+  if (!plugins || typeof plugins !== "object" || Array.isArray(plugins)) {
+    return "context-mode@context-mode";
+  }
+  return Object.keys(plugins).find((key) => key.startsWith("context-mode@"))
+    ?? "context-mode@context-mode";
+}
+
 /**
  * @typedef {Object} HealResult
  * @property {string[]} healed - one of: "entry-version", "enabled-plugins"
@@ -525,10 +533,10 @@ export function healClaudeJsonMcpArgs({ dotClaudeJsonPath, pluginCacheParent, ne
 
 /**
  * Remove every `.mcp.json` from per-version directories under
- * `<pluginCacheRoot>/<owner>/<plugin>/<X.Y.Z>/`.
+ * `<pluginCacheRoot>/<marketplace>/<plugin>/<X.Y.Z>/`.
  *
  * @param {{ pluginCacheRoot: string, pluginKey: string }} opts
- *   pluginKey is the "<owner>@<plugin>" form (e.g. "context-mode@context-mode").
+ *   pluginKey is the "<plugin>@<marketplace>" registry form.
  * @returns {SweepResult}
  */
 export function sweepStaleMcpJson({ pluginCacheRoot, pluginKey }) {
@@ -544,9 +552,9 @@ export function sweepStaleMcpJson({ pluginCacheRoot, pluginKey }) {
     return { removed, skipped: "no-cache-root" };
   }
 
-  // pluginKey shape: "<owner>@<plugin>"
-  const [ownerSegment, pluginSegment] = pluginKey.split("@");
-  if (!ownerSegment || !pluginSegment) {
+  // Registry key shape: "<plugin>@<marketplace>"; cache path reverses it.
+  const [pluginSegment, marketplaceSegment] = pluginKey.split("@");
+  if (!pluginSegment || !marketplaceSegment) {
     return { removed, skipped: "bad-plugin-key" };
   }
 
@@ -554,29 +562,29 @@ export function sweepStaleMcpJson({ pluginCacheRoot, pluginKey }) {
   // even if pluginKey contains `..` segments. Per Mert's standing Windows
   // safety rule, resolve normalizes both `/` and `\` so the guard fires
   // on either separator.
-  const ownerDir = resolve(resolvedCacheRoot, ownerSegment, pluginSegment);
+  const pluginDir = resolve(resolvedCacheRoot, marketplaceSegment, pluginSegment);
   const cacheRootWithSep = resolvedCacheRoot + sep;
-  if (!ownerDir.startsWith(cacheRootWithSep)) {
+  if (!pluginDir.startsWith(cacheRootWithSep)) {
     return { removed, skipped: "outside-cache-root" };
   }
 
-  if (!existsSync(ownerDir)) {
+  if (!existsSync(pluginDir)) {
     return { removed, skipped: "no-plugin-dir" };
   }
 
   /** @type {string[]} */
   let versionEntries = [];
   try {
-    versionEntries = readdirSync(ownerDir);
+    versionEntries = readdirSync(pluginDir);
   } catch {
     return { removed, skipped: "readdir-failed" };
   }
 
   for (const versionEntry of versionEntries) {
-    const versionDir = resolve(ownerDir, versionEntry);
+    const versionDir = resolve(pluginDir, versionEntry);
     // Per-version guard: only enter directories whose resolved path stays
     // under the owner dir. Belt-and-braces against weird FS entries.
-    if (!versionDir.startsWith(ownerDir + sep)) continue;
+    if (!versionDir.startsWith(pluginDir + sep)) continue;
     try {
       const stat = statSync(versionDir);
       if (!stat.isDirectory()) continue;

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -14,7 +14,7 @@ import { dirname, resolve, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { healBetterSqlite3Binding } from "./heal-better-sqlite3.mjs";
-import { healInstalledPlugins, healSettingsEnabledPlugins, healPluginJsonMcpServers, sweepStaleMcpJson } from "./heal-installed-plugins.mjs";
+import { healInstalledPlugins, healSettingsEnabledPlugins, healPluginJsonMcpServers, resolveContextModePluginKey, sweepStaleMcpJson } from "./heal-installed-plugins.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(__dirname, "..");
@@ -116,13 +116,19 @@ function isSafeWindowsPath(p) {
 // sync. Only runs in real `npm install -g` to avoid surprising
 // contributors. Best effort, never blocks install. (#46915 follow-up.)
 if (isGlobalInstall()) {
+  const registryPath = resolve(homedir(), ".claude", "plugins", "installed_plugins.json");
+  const pluginCacheRoot = resolve(homedir(), ".claude", "plugins", "cache");
+  let pluginKey = "context-mode@context-mode";
   try {
-    const registryPath = resolve(homedir(), ".claude", "plugins", "installed_plugins.json");
-    const pluginCacheRoot = resolve(homedir(), ".claude", "plugins", "cache");
+    const ip = JSON.parse(readFileSync(registryPath, "utf-8"));
+    pluginKey = resolveContextModePluginKey(ip.plugins);
+  } catch { /* best effort */ }
+
+  try {
     const result = healInstalledPlugins({
       registryPath,
       pluginCacheRoot,
-      pluginKey: "context-mode@context-mode",
+      pluginKey,
     });
     if (result.skipped === "no-registry") {
       // Standalone npm user (no Claude Code) — silent success.
@@ -147,7 +153,7 @@ if (isGlobalInstall()) {
     const settingsPath = resolve(homedir(), ".claude", "settings.json");
     const r = healSettingsEnabledPlugins({
       settingsPath,
-      pluginKey: "context-mode@context-mode",
+      pluginKey,
     });
     if (r.healed && r.healed.length > 0) {
       process.stderr.write(`context-mode: healed settings.json (${r.healed.join(", ")})\n`);
@@ -161,11 +167,9 @@ if (isGlobalInstall()) {
   // already-broken users self-recover the next time `npm install -g context-mode`
   // runs. Best effort, never blocks install.
   try {
-    const ipPath = resolve(homedir(), ".claude", "plugins", "installed_plugins.json");
-    const cacheRoot = resolve(homedir(), ".claude", "plugins", "cache");
-    if (existsSync(ipPath)) {
-      const ip = JSON.parse(readFileSync(ipPath, "utf-8"));
-      const entries = (ip && ip.plugins && ip.plugins["context-mode@context-mode"]) || [];
+    if (existsSync(registryPath)) {
+      const ip = JSON.parse(readFileSync(registryPath, "utf-8"));
+      const entries = (ip && ip.plugins && ip.plugins[pluginKey]) || [];
       let healedAny = false;
       if (Array.isArray(entries)) {
         for (const entry of entries) {
@@ -174,8 +178,8 @@ if (isGlobalInstall()) {
           try {
             const r = healPluginJsonMcpServers({
               pluginRoot: installPath,
-              pluginCacheRoot: cacheRoot,
-              pluginKey: "context-mode@context-mode",
+              pluginCacheRoot,
+              pluginKey,
             });
             if (r && Array.isArray(r.healed) && r.healed.length > 0) {
               healedAny = true;
@@ -190,8 +194,8 @@ if (isGlobalInstall()) {
       // future auto-updates from working cleanly. Single sweep per install.
       try {
         const sweepResult = sweepStaleMcpJson({
-          pluginCacheRoot: cacheRoot,
-          pluginKey: "context-mode@context-mode",
+          pluginCacheRoot,
+          pluginKey,
         });
         if (sweepResult && Array.isArray(sweepResult.removed) && sweepResult.removed.length > 0) {
           process.stderr.write(`context-mode: swept ${sweepResult.removed.length} stale .mcp.json file(s) (Issue #609)\n`);
@@ -213,7 +217,7 @@ try {
     const ip = JSON.parse(readFileSync(ipPath, "utf-8"));
     const cacheRoot = resolve(homedir(), ".claude", "plugins", "cache");
     for (const [key, entries] of Object.entries(ip.plugins || {})) {
-      if (key !== "context-mode@context-mode") continue;
+      if (!key.startsWith("context-mode@")) continue;
       for (const entry of entries) {
         const rp = entry.installPath;
         if (!rp || existsSync(rp)) continue;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,7 +46,7 @@ import { discoverSiblingMcpPids, killSiblingMcpServers } from "./util/sibling-mc
 // v1.0.119 — Issue #523 Layer 5 heal: post-bump assertion on .claude-plugin/plugin.json
 // mcpServers args. Single source of truth shared with start.mjs HEAL block + postinstall.
 // @ts-expect-error — JS module, no TS declarations
-import { healPluginJsonMcpServers, sweepStaleMcpJson } from "../scripts/heal-installed-plugins.mjs";
+import { healPluginJsonMcpServers, resolveContextModePluginKey, sweepStaleMcpJson } from "../scripts/heal-installed-plugins.mjs";
 // @ts-expect-error — JS module, no TS declarations
 import { detectWindowsVsYear } from "../scripts/heal-better-sqlite3.mjs";
 // Private 16-LOC copy of browserOpenArgv. Canonical version lives in src/server.ts;
@@ -1541,6 +1541,7 @@ async function upgrade(opts?: { platform?: string }) {
       // Fix registry — adapter-aware
       adapter.updatePluginRegistry(pluginRoot, newVersion);
       p.log.info(color.dim("  Registry synced to " + pluginRoot));
+      let pluginKey = "context-mode@context-mode";
 
       // v1.0.114 hotfix — post-write assertion: re-read installed_plugins.json
       // and verify installPath/.claude-plugin/plugin.json's version matches
@@ -1550,7 +1551,8 @@ async function upgrade(opts?: { platform?: string }) {
         const ipPath = resolve(resolveClaudeConfigDir(), "plugins", "installed_plugins.json");
         if (existsSync(ipPath)) {
           const ip = JSON.parse(readFileSync(ipPath, "utf-8"));
-          const entries = ip?.plugins?.["context-mode@context-mode"];
+          pluginKey = resolveContextModePluginKey(ip?.plugins);
+          const entries = ip?.plugins?.[pluginKey];
           if (Array.isArray(entries)) {
             for (const entry of entries) {
               const ip2 = entry?.installPath;
@@ -1586,7 +1588,6 @@ async function upgrade(opts?: { platform?: string }) {
       // truth shared with start.mjs HEAL block + postinstall.
       try {
         const pluginCacheRoot = resolve(resolveClaudeConfigDir(), "plugins", "cache");
-        const pluginKey = "context-mode@context-mode";
         const firstPass = healPluginJsonMcpServers({ pluginRoot, pluginCacheRoot, pluginKey });
         if (firstPass && firstPass.error) {
           throw new Error(firstPass.error);
@@ -1616,7 +1617,6 @@ async function upgrade(opts?: { platform?: string }) {
       // block + postinstall.
       try {
         const pluginCacheRoot = resolve(resolveClaudeConfigDir(), "plugins", "cache");
-        const pluginKey = "context-mode@context-mode";
         const firstSweep = sweepStaleMcpJson({ pluginCacheRoot, pluginKey });
         if (firstSweep && firstSweep.removed && firstSweep.removed.length > 0) {
           p.log.info(color.dim(`  Swept ${firstSweep.removed.length} stale .mcp.json file(s) from cache`));
@@ -1798,7 +1798,7 @@ async function upgrade(opts?: { platform?: string }) {
           // The lexical resolve+startsWith check rejects ".."-escapes and
           // absolute paths outside cacheRoot, but path.resolve doesn't
           // dereference symlinks. A same-uid actor who can plant a symlink
-          // AT <cacheRoot>/<owner>/<plugin>/<version> targeting an attacker
+          // AT <cacheRoot>/<marketplace>/<plugin>/<version> targeting an attacker
           // dir gets past the lexical guard, then cpSync follows the link at
           // FS-write time. Re-check via realpathSync so a planted symlink
           // anchor fails the gate.
@@ -1808,7 +1808,8 @@ async function upgrade(opts?: { platform?: string }) {
           catch { cacheRootCanon = cacheRoot; }
           const cacheRootWithSep = cacheRootCanon + sep;
           const registry = JSON.parse(readFileSync(registryPath, "utf-8"));
-          const entries = registry?.plugins?.["context-mode@context-mode"];
+          const pluginKey = resolveContextModePluginKey(registry?.plugins);
+          const entries = registry?.plugins?.[pluginKey];
           if (Array.isArray(entries)) {
             for (const entry of entries) {
               const installPath = entry?.installPath;
@@ -1999,7 +2000,7 @@ function statuslineForward(): void {
       // on the user's behalf.
       //
       // path.resolve is purely lexical, so a same-uid actor who can plant
-      // a symlink at <cacheRoot>/<owner>/<plugin>/<version> targeting an
+      // a symlink at <cacheRoot>/<marketplace>/<plugin>/<version> targeting an
       // attacker dir would pass the lexical gate. Re-check via
       // realpathSync so the dynamic-import target's actual on-disk
       // location also stays under cacheRoot.
@@ -2009,7 +2010,8 @@ function statuslineForward(): void {
       catch { cacheRootCanon = cacheRoot; }
       const cacheRootWithSep = cacheRootCanon + sep;
       const registry = JSON.parse(readFileSync(registryPath, "utf-8"));
-      const entries = registry?.plugins?.["context-mode@context-mode"];
+      const pluginKey = resolveContextModePluginKey(registry?.plugins);
+      const entries = registry?.plugins?.[pluginKey];
       if (Array.isArray(entries)) {
         for (const entry of entries) {
           const installPath = entry?.installPath;

--- a/src/server.ts
+++ b/src/server.ts
@@ -865,7 +865,7 @@ function healCacheMidSession(): void {
     // Plugin root: build/ for tsc, plugin root for bundle
     const pluginRoot = getPackageRoot();
     for (const [key, entries] of Object.entries((ip.plugins ?? {}) as Record<string, Array<{ installPath?: string }>>)) {
-      if (key !== "context-mode@context-mode") continue;
+      if (!key.startsWith("context-mode@")) continue;
       for (const entry of entries) {
         const rp = entry.installPath;
         if (!rp || existsSync(rp)) continue;

--- a/start.mjs
+++ b/start.mjs
@@ -187,7 +187,7 @@ if (cacheMatch) {
 
         const ip = JSON.parse(readFileSync(ipPath, "utf-8"));
         for (const [key, entries] of Object.entries(ip.plugins || {})) {
-          if (key !== "context-mode@context-mode") continue;
+          if (!key.startsWith("context-mode@")) continue;
           for (const entry of entries) {
             entry.installPath = newestDir;
             entry.version = newest;
@@ -203,7 +203,7 @@ if (cacheMatch) {
     if (existsSync(ipPath)) {
       const ip = JSON.parse(readFileSync(ipPath, "utf-8"));
       for (const [key, entries] of Object.entries(ip.plugins || {})) {
-        if (key !== "context-mode@context-mode") continue;
+        if (!key.startsWith("context-mode@")) continue;
         for (const entry of entries) {
           const rp = entry.installPath;
           if (!rp || existsSync(rp) || rp === __dirname) continue;
@@ -238,13 +238,17 @@ if (cacheMatch) {
 // truth) so users who fix themselves via `npm install -g context-mode`
 // follow the exact same code path. Best-effort, never blocks MCP boot.
 try {
-  const { healInstalledPlugins, healSettingsEnabledPlugins, healPluginJsonMcpServers, sweepStaleMcpJson } =
+  const { healInstalledPlugins, healSettingsEnabledPlugins, healPluginJsonMcpServers, resolveContextModePluginKey, sweepStaleMcpJson } =
     await import("./scripts/heal-installed-plugins.mjs");
-  const pluginKey = "context-mode@context-mode";
   const claudeConfigDir = resolveClaudeConfigDir();
   const registryPath = resolve(claudeConfigDir, "plugins", "installed_plugins.json");
   const pluginCacheRoot = resolve(claudeConfigDir, "plugins", "cache");
   const settingsPath = resolve(claudeConfigDir, "settings.json");
+  let pluginKey = "context-mode@context-mode";
+  try {
+    const ip = JSON.parse(readFileSync(registryPath, "utf-8"));
+    pluginKey = resolveContextModePluginKey(ip.plugins);
+  } catch { /* best effort */ }
   try { healInstalledPlugins({ registryPath, pluginCacheRoot, pluginKey }); }
   catch { /* best effort */ }
   // v1.0.116: Claude Code's plugin loader reads settings.json.enabledPlugins
@@ -335,7 +339,7 @@ try{
   const cacheRoot=resolve(cfgDir(),"plugins","cache");
   const ip=JSON.parse(readFileSync(f,"utf-8"));
   for(const[k,es]of Object.entries(ip.plugins||{})){
-    if(k!=="context-mode@context-mode")continue;
+    if(!k.startsWith("context-mode@"))continue;
     for(const e of es){
       const p=e.installPath;
       if(!p)continue;

--- a/tests/hooks/cache-heal-self-heal.test.ts
+++ b/tests/hooks/cache-heal-self-heal.test.ts
@@ -554,7 +554,7 @@ describe("sweepStaleMcpJson", () => {
     versionDirs: string[];
   } {
     const dir = makeTmp("ctx-sweep-");
-    // Match the real cache layout: <cacheRoot>/<owner>/<plugin>/<version>/
+    // Match the real cache layout: <cacheRoot>/<marketplace>/<plugin>/<version>/
     const pluginCacheRoot = join(dir, "cache");
     const pluginKey = "context-mode@context-mode";
     const ownerDir = join(pluginCacheRoot, "context-mode", "context-mode");
@@ -602,6 +602,24 @@ describe("sweepStaleMcpJson", () => {
     for (const removedPath of result.removed) {
       expect(removedPath).toContain(".mcp.json");
     }
+  });
+
+  test("maps plugin@marketplace keys to marketplace/plugin cache paths", () => {
+    const dir = makeTmp("ctx-sweep-marketplace-");
+    const pluginCacheRoot = join(dir, "cache");
+    const versionDir = makeDir(
+      join(pluginCacheRoot, "claude-context-mode", "context-mode", "1.0.169"),
+    );
+    const mcpJsonPath = join(versionDir, ".mcp.json");
+    writeFileSync(mcpJsonPath, "{}", "utf-8");
+
+    const result = sweepStaleMcpJson({
+      pluginCacheRoot,
+      pluginKey: "context-mode@claude-context-mode",
+    });
+
+    expect(result.removed).toEqual([mcpJsonPath]);
+    expect(existsSync(mcpJsonPath)).toBe(false);
   });
 
   test("no-op when no .mcp.json files exist in any version dir", () => {

--- a/tests/scripts/asymmetric-drift-assert.test.ts
+++ b/tests/scripts/asymmetric-drift-assert.test.ts
@@ -478,6 +478,7 @@ describe("Issue #531 — asymmetric-drift invariant", () => {
           "export function healSettingsEnabledPlugins() { return { healed: [] }; }",
           "export function healPluginJsonMcpServers() { return { healed: [] }; }",
           "export function healMcpJsonArgs() { return { healed: [] }; }",
+          "export function resolveContextModePluginKey() { return 'context-mode@context-mode'; }",
           // Issue #609 — sweepStaleMcpJson replaced per-entry healMcpJsonArgs.
           // Stubbed alongside healMcpJsonArgs for backwards compatibility with
           // any in-flight callers that still import it.

--- a/tests/util/heal-installed-plugins.test.ts
+++ b/tests/util/heal-installed-plugins.test.ts
@@ -29,6 +29,8 @@ import { join, resolve } from "node:path";
 import {
   healInstalledPlugins,
   // @ts-expect-error — JS module, no TS declarations
+  resolveContextModePluginKey,
+  // @ts-expect-error — JS module, no TS declarations
   healSettingsEnabledPlugins,
   // @ts-expect-error — JS module, no TS declarations
   healPluginJsonMcpServers,
@@ -120,6 +122,19 @@ function readRegistry(p: string): Record<string, unknown> {
 }
 
 const KEY = "context-mode@context-mode";
+
+describe("resolveContextModePluginKey", () => {
+  it("finds context-mode under a custom marketplace name", () => {
+    expect(resolveContextModePluginKey({
+      "other@marketplace": [],
+      "context-mode@claude-context-mode": [],
+    })).toBe("context-mode@claude-context-mode");
+  });
+
+  it("falls back to the legacy key when the registry is missing", () => {
+    expect(resolveContextModePluginKey(undefined)).toBe(KEY);
+  });
+});
 
 // ─────────────────────────────────────────────────────────────────────────
 // Slice 1 — HEAL 3: per-plugin entry.version syncs from cache plugin.json

--- a/tests/util/postinstall-heal.test.ts
+++ b/tests/util/postinstall-heal.test.ts
@@ -91,6 +91,7 @@ interface FakeHome {
   home: string;
   registryPath: string;
   cacheDir: string;
+  pluginKey: string;
 }
 
 /**
@@ -101,10 +102,13 @@ function buildFakeHome(opts: {
   entryVersion: string;
   cacheVersion: string;
   enabledPlugins?: unknown;
+  marketplace?: string;
 }): FakeHome {
   const home = makeTmp("ctx-postinstall-home-");
   const pluginsRoot = resolve(home, ".claude", "plugins");
-  const cacheDir = resolve(pluginsRoot, "cache", "context-mode", "context-mode", opts.cacheVersion);
+  const marketplace = opts.marketplace ?? "context-mode";
+  const pluginKey = `context-mode@${marketplace}`;
+  const cacheDir = resolve(pluginsRoot, "cache", marketplace, "context-mode", opts.cacheVersion);
   mkdirSync(resolve(cacheDir, ".claude-plugin"), { recursive: true });
   writeFileSync(
     resolve(cacheDir, ".claude-plugin", "plugin.json"),
@@ -113,7 +117,7 @@ function buildFakeHome(opts: {
   const registry: Record<string, unknown> = {
     version: 2,
     plugins: {
-      [KEY]: [
+      [pluginKey]: [
         {
           scope: "user",
           installPath: cacheDir,
@@ -127,7 +131,7 @@ function buildFakeHome(opts: {
   if (opts.enabledPlugins !== undefined) registry.enabledPlugins = opts.enabledPlugins;
   const registryPath = resolve(pluginsRoot, "installed_plugins.json");
   writeFileSync(registryPath, JSON.stringify(registry, null, 2) + "\n");
-  return { home, registryPath, cacheDir };
+  return { home, registryPath, cacheDir, pluginKey };
 }
 
 /**
@@ -215,6 +219,25 @@ describe("postinstall — global install with poisoned registry", () => {
     expect(healLines.length).toBe(1);
     // No emoji / ANSI noise — line should be plain ASCII summary.
     expect(healLines[0]).toMatch(/^context-mode:/);
+  });
+
+  it("repairs a registry installed from a custom marketplace", { timeout: 90_000 }, () => {
+    const fake = buildFakeHome({
+      entryVersion: "1.0.99",
+      cacheVersion: "1.0.169",
+      enabledPlugins: {},
+      marketplace: "claude-context-mode",
+    });
+
+    const r = runPostinstall({ home: fake.home, global: true });
+    expect(r.status === 0 || r.status === null).toBe(true);
+
+    const after = readRegistry(fake.registryPath) as {
+      plugins: Record<string, Array<{ version: string }>>;
+      enabledPlugins: Record<string, unknown>;
+    };
+    expect(after.plugins[fake.pluginKey][0].version).toBe("1.0.169");
+    expect(after.enabledPlugins[fake.pluginKey]).toBe(true);
   });
 });
 

--- a/tests/util/start-mjs-self-heal.test.ts
+++ b/tests/util/start-mjs-self-heal.test.ts
@@ -136,6 +136,23 @@ describe("start.mjs — Issue #609 sweep stale .mcp.json", () => {
   });
 });
 
+describe("start.mjs — Issue #1078 marketplace-derived registry key", () => {
+  test("all cache-heal gates match the plugin segment, not a marketplace literal", () => {
+    expect(startSrc).not.toContain('key !== "context-mode@context-mode"');
+    expect(startSrc).not.toContain('k!=="context-mode@context-mode"');
+    expect(
+      (startSrc.match(/\.startsWith\("context-mode@"\)/g) ?? []).length,
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  test("HEAL 3+4 derives pluginKey from installed_plugins.json", () => {
+    const heal34Idx = startSrc.indexOf("HEAL 3");
+    const layer4Idx = startSrc.indexOf("Self-heal Layer 4");
+    const block = startSrc.slice(heal34Idx, layer4Idx);
+    expect(block).toContain("resolveContextModePluginKey(ip.plugins)");
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────────
 // Issue #577 — start.mjs cache-heal layer MUST honor CLAUDE_CONFIG_DIR.
 //


### PR DESCRIPTION
## What / Why / How

Fixes #1078.

Claude Code keys installed plugins as `<plugin>@<marketplace>`, but cache healing assumed the marketplace was also named `context-mode`. Installs registered as `context-mode@claude-context-mode` therefore skipped every startup, postinstall, mid-session, and upgrade heal.

This change resolves the live registry key by the `context-mode@` plugin segment, uses it at each registry caller, and corrects stale `.mcp.json` cache traversal to map `<plugin>@<marketplace>` onto `<marketplace>/<plugin>/<version>`. The generated SessionStart hook uses the same marketplace-independent gate.

## Affected platforms

- [x] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

- Red: new custom-marketplace cases failed in startup gating, cache-path mapping, key resolution, and global postinstall recovery.
- Green: focused suite passes (4 files, 97 tests).
- Full suite passes (213 files, 4,780 passed, 25 skipped).
- `npm run typecheck` passes.
- `npm run build` passes, including bundle and asymmetric-drift assertions.
- `npm run lint --if-present` passes (no lint script is defined).

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (no user-facing docs change needed)
- [x] No Windows path regressions (uses existing `node:path` joins/resolves)
- [x] Targets `next` branch (unless hotfix)
