### PR TITLE
feat(pi): live command preview and result tail in the Pi TUI

### DIFF
--- a/src/adapters/pi/mcp-bridge.ts
+++ b/src/adapters/pi/mcp-bridge.ts
@@ -321,18 +321,172 @@ interface PiRenderContext {
   lastComponent?: unknown;
 }
 
-function createContextModeCallRenderer(toolName: string) {
-  return (_args: unknown, theme: PiRenderTheme, context: PiRenderContext) => {
+/** Max preview lines shown for code/content arguments in the call renderer. */
+const CALL_PREVIEW_MAX_LINES = 8;
+/** Max visible width per preview line (Pi's TUI does not wrap tool rows). */
+const CALL_PREVIEW_MAX_LINE_WIDTH = 110;
+
+function truncatePreviewLine(line: string): string {
+  return line.length <= CALL_PREVIEW_MAX_LINE_WIDTH
+    ? line
+    : line.slice(0, CALL_PREVIEW_MAX_LINE_WIDTH - 1) + "\u2026";
+}
+
+function pushCodePreviewLines(lines: string[], code: string): void {
+  const sourceLines = code.split(/\r?\n/);
+  for (const raw of sourceLines.slice(0, CALL_PREVIEW_MAX_LINES)) {
+    lines.push(truncatePreviewLine(raw.replace(/\s+$/, "")));
+  }
+  if (sourceLines.length > CALL_PREVIEW_MAX_LINES) {
+    lines.push(`\u2026 ${sourceLines.length - CALL_PREVIEW_MAX_LINES} more lines`);
+  }
+}
+
+/**
+ * Per-tool preview of a ctx_* tool call's arguments, rendered UNDER the
+ * tool title by the Pi TUI while the tool is streaming/running.
+ *
+ * Pi re-runs the call renderer on every partial-argument update, so this
+ * shows the code/command being executed in real time — matching how Pi's
+ * built-in tools (bash, read, edit) render their arguments. Returns an
+ * empty list when there is nothing meaningful to show. Safe on partial
+ * args (mid-stream JSON) and non-object args.
+ */
+export function formatCtxCallPreview(toolName: string, args: unknown): string[] {
+  const a: Record<string, unknown> =
+    args && typeof args === "object" && !Array.isArray(args)
+      ? (args as Record<string, unknown>)
+      : {};
+  const lines: string[] = [];
+  switch (toolName) {
+    case "ctx_execute": {
+      if (typeof a.language === "string" && a.language) {
+        lines.push(`language: ${a.language}`);
+      }
+      if (typeof a.code === "string" && a.code.length > 0) {
+        pushCodePreviewLines(lines, a.code);
+      }
+      break;
+    }
+    case "ctx_execute_file": {
+      if (typeof a.path === "string" && a.path) {
+        lines.push(`file: ${a.path}`);
+      }
+      if (typeof a.code === "string" && a.code.length > 0) {
+        pushCodePreviewLines(lines, a.code);
+      }
+      break;
+    }
+    case "ctx_batch_execute": {
+      if (Array.isArray(a.commands)) {
+        const commands = a.commands as Array<{
+          label?: unknown;
+          command?: unknown;
+        } | null | undefined>;
+        for (const entry of commands.slice(0, 10)) {
+          if (!entry || typeof entry.command !== "string" || !entry.command) {
+            continue;
+          }
+          const label =
+            typeof entry.label === "string" && entry.label ? `[${entry.label}] ` : "";
+          const first = entry.command.split(/\r?\n/)[0];
+          lines.push(label + truncatePreviewLine(first));
+        }
+        if (commands.length > 10) {
+          lines.push(`\u2026 ${commands.length - 10} more commands`);
+        }
+      }
+      break;
+    }
+    case "ctx_search": {
+      if (Array.isArray(a.queries) && a.queries.length > 0) {
+        const q = (a.queries as unknown[])
+          .filter((x): x is string => typeof x === "string")
+          .join(" | ");
+        if (q) lines.push(truncatePreviewLine(`queries: ${q}`));
+      }
+      break;
+    }
+    case "ctx_fetch_and_index": {
+      const urls = Array.isArray(a.requests) && a.requests.length > 0
+        ? (a.requests as Array<{ url?: unknown } | null | undefined>)
+            .map((r) => (r && typeof r.url === "string" ? r.url : ""))
+            .filter(Boolean)
+        : typeof a.url === "string" && a.url
+          ? [a.url]
+          : [];
+      for (const u of urls.slice(0, 6)) {
+        lines.push(truncatePreviewLine(u));
+      }
+      if (urls.length > 6) {
+        lines.push(`\u2026 ${urls.length - 6} more urls`);
+      }
+      break;
+    }
+    case "ctx_index": {
+      if (typeof a.path === "string" && a.path) {
+        lines.push(`path: ${a.path}`);
+      }
+      if (typeof a.source === "string" && a.source) {
+        lines.push(`source: ${a.source}`);
+      }
+      if (typeof a.content === "string" && a.content.length > 0) {
+        pushCodePreviewLines(lines, a.content);
+      }
+      break;
+    }
+    default: {
+      // Generic fallback so no ctx_* tool call is ever a mystery.
+      try {
+        const json = JSON.stringify(a);
+        if (json && json !== "{}") {
+          lines.push(truncatePreviewLine(json.replace(/\s+/g, " ")));
+        }
+      } catch {
+        // Partial args while streaming — nothing safe to show yet.
+      }
+    }
+  }
+  return lines;
+}
+
+export function createContextModeCallRenderer(toolName: string) {
+  return (args: unknown, theme: PiRenderTheme, context: PiRenderContext) => {
     const text =
       context.lastComponent instanceof PiTextComponent
         ? context.lastComponent
         : new PiTextComponent();
-    text.setText(theme.fg("toolTitle", theme.bold(toolName)));
+    let out = theme.fg("toolTitle", theme.bold(toolName));
+    for (const line of formatCtxCallPreview(toolName, args)) {
+      out += `\n  ${theme.fg("toolOutput", line)}`;
+    }
+    text.setText(out);
     return text;
   };
 }
 
-function createContextModeResultRenderer(toolName: string) {
+/** Max lines shown in the collapsed result row (matches Pi's bash tool). */
+const RESULT_PREVIEW_LINES = 5;
+
+/**
+ * Collapsed preview of a finished ctx_* tool result: the last few output
+ * lines, like Pi's built-in bash tool shows the tail of command output.
+ * The full output stays available via the expand keybinding (ctrl+o).
+ * Exported for unit tests.
+ */
+export function formatCtxResultPreview(toolName: string, output: string): string {
+  const nonEmpty = output.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  if (nonEmpty.length === 0) return `${toolName} completed`;
+  const shown = nonEmpty.slice(-RESULT_PREVIEW_LINES);
+  const skipped = nonEmpty.length - shown.length;
+  const body = shown.join("\n");
+  if (skipped > 0) {
+    return `... (${skipped} earlier line${skipped === 1 ? "" : "s"}, ctrl+o to expand)\n${body}`;
+  }
+  return body;
+}
+
+export function createContextModeResultRenderer(toolName: string) {
   return (
     result: MCPCallResult,
     { expanded, isPartial }: { expanded: boolean; isPartial: boolean },
@@ -355,15 +509,7 @@ function createContextModeResultRenderer(toolName: string) {
       text.setText(theme.fg("toolOutput", output));
       return text;
     }
-    const firstLine = output
-      .split(/\r?\n/)
-      .find((line) => line.trim().length > 0)
-      ?.trim();
-    const status =
-      firstLine && firstLine.length <= 180
-        ? firstLine
-        : `${toolName} completed`;
-    text.setText(theme.fg("toolOutput", status));
+    text.setText(theme.fg("toolOutput", formatCtxResultPreview(toolName, output)));
     return text;
   };
 }

--- a/tests/adapters/pi-mcp-bridge-call-preview.test.ts
+++ b/tests/adapters/pi-mcp-bridge-call-preview.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Pi MCP bridge — live call preview for ctx_* tools.
+ *
+ * Bug: the Pi TUI renders a tool row from the tool's renderCall, and Pi
+ * re-runs it on every partial-argument update while the model streams the
+ * call. The previous Pi call renderer only printed the bold tool name, so
+ * while ctx_execute / ctx_batch_execute were running the TUI showed no
+ * command at all — the session looked hung and the executed code only
+ * became visible after the call finished.
+ *
+ * These tests pin the fix:
+ *
+ *   1. formatCtxCallPreview() produces a compact per-tool preview of the
+ *      arguments (code, commands, queries, urls, path/source).
+ *   2. The preview is width- and line-capped so long payloads never flood
+ *      the tool row.
+ *   3. The preview is safe on partial (mid-stream) and non-object args.
+ *   4. createContextModeCallRenderer() renders the tool title plus the
+ *      indented preview lines and reuses the row-local component.
+ */
+import { describe, it, expect } from "vitest";
+
+const mod = await import("../../src/adapters/pi/mcp-bridge.js");
+const { formatCtxCallPreview, createContextModeCallRenderer, formatCtxResultPreview, createContextModeResultRenderer, PiTextComponent } =
+  mod as unknown as {
+    formatCtxCallPreview: (toolName: string, args: unknown) => string[];
+    createContextModeCallRenderer: (
+      toolName: string,
+    ) => (args: unknown, theme: unknown, context: unknown) => {
+      text: string;
+    };
+    formatCtxResultPreview: (toolName: string, output: string) => string;
+    createContextModeResultRenderer: (
+      toolName: string,
+    ) => (
+      result: unknown,
+      options: { expanded: boolean; isPartial: boolean },
+      theme: unknown,
+      context: unknown,
+    ) => { text: string };
+    PiTextComponent: new (text?: string) => { text: string; setText(t: string): void };
+  };
+
+const theme = { bold: (s: string) => s, fg: (_c: string, s: string) => s };
+
+describe("formatCtxCallPreview — ctx_execute shows the code being executed", () => {
+  it("renders language plus up to 8 code lines with a more-lines marker", () => {
+    const code = ["console.log('a')", "console.log('b')", ...Array.from({ length: 10 }, () => "x")].join("\n");
+    const preview = formatCtxCallPreview("ctx_execute", { language: "javascript", code });
+    expect(preview[0]).toBe("language: javascript");
+    expect(preview[1]).toBe("console.log('a')");
+    expect(preview).toHaveLength(1 + 8 + 1);
+    expect(preview.at(-1)).toMatch(/more lines/);
+  });
+
+  it("renders nothing when no code is provided yet (empty streaming args)", () => {
+    expect(formatCtxCallPreview("ctx_execute", {})).toEqual([]);
+    expect(formatCtxCallPreview("ctx_execute", { code: "partial" })).toEqual(["partial"]);
+  });
+});
+
+describe("formatCtxCallPreview — ctx_batch_execute shows each command", () => {
+  it("renders [label] command lines capped at 10 with a marker", () => {
+    const commands = Array.from({ length: 12 }, (_, i) => ({
+      label: `c${i}`,
+      command: `echo ${i}`,
+    }));
+    const preview = formatCtxCallPreview("ctx_batch_execute", { commands });
+    expect(preview[0]).toBe("[c0] echo 0");
+    expect(preview).toHaveLength(11);
+    expect(preview.at(-1)).toBe("… 2 more commands");
+  });
+
+  it("skips malformed entries and shows unlabeled commands bare", () => {
+    const preview = formatCtxCallPreview("ctx_batch_execute", {
+      commands: [null, { command: "ls -la" }, { label: "x" }],
+    });
+    expect(preview).toEqual(["ls -la"]);
+  });
+});
+
+describe("formatCtxCallPreview — search/fetch/index previews", () => {
+  it("joins queries for ctx_search", () => {
+    expect(formatCtxCallPreview("ctx_search", { queries: ["root cause", "fix"] })).toEqual([
+      "queries: root cause | fix",
+    ]);
+    expect(formatCtxCallPreview("ctx_search", { queries: [] })).toEqual([]);
+    expect(formatCtxCallPreview("ctx_search", { queries: [1, "ok", 2] })).toEqual(["queries: ok"]);
+  });
+
+  it("lists urls for ctx_fetch_and_index (single url and requests array)", () => {
+    expect(formatCtxCallPreview("ctx_fetch_and_index", { url: "https://a.example" })).toEqual([
+      "https://a.example",
+    ]);
+    const urls = formatCtxCallPreview("ctx_fetch_and_index", {
+      requests: Array.from({ length: 7 }, (_, i) => ({ url: `https://example.com/${i}` })),
+    });
+    expect(urls[0]).toBe("https://example.com/0");
+    expect(urls).toHaveLength(7);
+    expect(urls.at(-1)).toBe("… 1 more urls");
+  });
+
+  it("renders path, source, and content preview for ctx_index", () => {
+    expect(formatCtxCallPreview("ctx_index", { path: "/tmp/docs", source: "spec", content: "l1\nl2" })).toEqual([
+      "path: /tmp/docs",
+      "source: spec",
+      "l1",
+      "l2",
+    ]);
+  });
+});
+
+describe("formatCtxCallPreview — generic fallback and safety", () => {
+  it("shows a flat one-line JSON fallback for unknown tools with args", () => {
+    expect(formatCtxCallPreview("ctx_purge", { confirm: true, scope: "project" })).toEqual([
+      '{"confirm":true,"scope":"project"}',
+    ]);
+    expect(formatCtxCallPreview("ctx_stats", {})).toEqual([]);
+  });
+
+  it("caps preview line width with an ellipsis", () => {
+    const [line] = formatCtxCallPreview("ctx_execute", { code: "y".repeat(300) });
+    expect(line.length).toBeLessThanOrEqual(110);
+    expect(line.endsWith("…")).toBe(true);
+  });
+
+  it("never throws on non-object or partial streaming args", () => {
+    expect(formatCtxCallPreview("ctx_execute", "not-an-object")).toEqual([]);
+    expect(formatCtxCallPreview("ctx_execute", null)).toEqual([]);
+    expect(formatCtxCallPreview("ctx_execute", undefined)).toEqual([]);
+    expect(
+      formatCtxCallPreview("ctx_batch_execute", {
+        commands: [{ command: "echo ok" }, { command: 42 }],
+      }),
+    ).toEqual(["echo ok"]);
+  });
+});
+
+describe("createContextModeCallRenderer — live call row", () => {
+  it("renders the tool title plus indented preview lines", () => {
+    const renderer = createContextModeCallRenderer("ctx_execute");
+    const component = renderer({ language: "python", code: "print('hi')" }, theme, {});
+    expect(component.text).toBe("ctx_execute\n  language: python\n  print('hi')");
+  });
+
+  it("renders the title only when there is nothing to preview", () => {
+    const renderer = createContextModeCallRenderer("ctx_stats");
+    const component = renderer({}, theme, {});
+    expect(component.text).toBe("ctx_stats");
+  });
+
+  it("reuses the row-local component passed via context.lastComponent", () => {
+    const renderer = createContextModeCallRenderer("ctx_search");
+    const stub = new PiTextComponent("stale");
+    const component = renderer({ queries: ["a"] }, theme, { lastComponent: stub });
+    expect(component).toBe(stub);
+    expect(stub.text).toBe("ctx_search\n  queries: a");
+  });
+});
+
+describe("formatCtxResultPreview — collapsed result shows the useful tail, not one line", () => {
+  it("shows the last 5 lines when the output is longer", () => {
+    const output = Array.from({ length: 12 }, (_, i) => `line ${i + 1}`).join("\n");
+    expect(formatCtxResultPreview("ctx_execute", output)).toBe(
+      "... (7 earlier lines, ctrl+o to expand)\nline 8\nline 9\nline 10\nline 11\nline 12",
+    );
+  });
+
+  it("shows short output as-is without a skip hint (blank lines filtered)", () => {
+    expect(formatCtxResultPreview("ctx_execute", "only line")).toBe("only line");
+    expect(formatCtxResultPreview("ctx_execute", "a\n\nb\nc\nd\ne")).toBe("a\nb\nc\nd\ne");
+  });
+
+  it("reports completion when there is no output", () => {
+    expect(formatCtxResultPreview("ctx_stats", "   \n\t\n")).toBe("ctx_stats completed");
+    expect(formatCtxResultPreview("ctx_stats", "")).toBe("ctx_stats completed");
+  });
+
+  it("singular marker for exactly one skipped line", () => {
+    expect(formatCtxResultPreview("ctx_search", "a\nb\nc\nd\ne\nf")).toBe(
+      "... (1 earlier line, ctrl+o to expand)\nb\nc\nd\ne\nf",
+    );
+  });
+});
+
+describe("createContextModeResultRenderer — phases", () => {
+  const renderer = createContextModeResultRenderer("ctx_execute");
+  const result = (text: string) => ({ content: [{ type: "text", text }] });
+
+  it("shows the in-progress indicator for partial results", () => {
+    expect(renderer(result("ignored"), { expanded: false, isPartial: true }, theme, {}).text).toBe(
+      "indexing/searching...",
+    );
+  });
+
+  it("shows the tail preview when collapsed and the full output when expanded", () => {
+    const output = Array.from({ length: 8 }, (_, i) => `out ${i + 1}`).join("\n");
+    expect(renderer(result(output), { expanded: false, isPartial: false }, theme, {}).text).toBe(
+      "... (3 earlier lines, ctrl+o to expand)\nout 4\nout 5\nout 6\nout 7\nout 8",
+    );
+    expect(renderer(result(output), { expanded: true, isPartial: false }, theme, {}).text).toBe(output);
+  });
+});


### PR DESCRIPTION
## What / Why / How

Two Pi TUI rendering fixes for the MCP bridge.

### 1. Live call preview

**Why:** Pi renders a tool row from the tool's `renderCall` and re-runs it on every partial-argument update while the model streams the call. The previous Pi call renderer only printed the bold tool name, so while `ctx_execute` / `ctx_batch_execute` were running the TUI showed no command at all — a long sandboxed run looked exactly like a hung session, and the executed code only became visible after the call finished.

**How:** `formatCtxCallPreview(toolName, args)` (exported, pure, unit-tested) builds a compact per-tool preview of the arguments:

- `ctx_execute` / `ctx_execute_file`: language + first 8 code lines
- `ctx_batch_execute`: up to 10 `[label] command` lines
- `ctx_search`: the queries, joined
- `ctx_fetch_and_index`: the URLs (single `url` or `requests[]`)
- `ctx_index`: path / source / content preview
- any other `ctx_*` tool: one flat JSON line fallback

Preview lines are capped at 110 visible cells (Pi tool rows do not wrap) and are safe on partial mid-stream args and non-object args. `createContextModeCallRenderer()` renders the tool title plus the indented preview lines, reusing the row-local `PiTextComponent` as before. This matches how Pi's built-in tools (bash, read, edit) render their arguments.

### 2. Useful collapsed result

**Why:** the collapsed (unexpanded) result row showed only the FIRST line of the tool output, which is rarely the useful part — after a `ctx_execute` you saw one line and no way to tell what happened.

**How:** `formatCtxResultPreview(toolName, output)` (exported, unit-tested) mirrors Pi's built-in bash tool: the last 5 non-empty output lines plus a `... (N earlier lines, ctrl+o to expand)` hint. Expanded view (ctrl+o) still shows the full output, and partial results keep the `indexing/searching...` indicator.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [x] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

New `tests/adapters/pi-mcp-bridge-call-preview.test.ts` (19 tests): per-tool call previews, line/width caps, partial + non-object arg safety, title-only rendering, row-local component reuse, collapsed-result tail/skip-hint/completed states, expanded passthrough, partial indicator.

- `npx tsc --noEmit` — clean
- `npx vitest run tests/adapters/pi-mcp-bridge-call-preview.test.ts` — 19/19 pass
- Manually verified end-to-end against a live Pi 0.84.x session: during a `ctx_execute` call the row shows the code as it streams in and while the tool runs; after completion it shows the last 5 output lines.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes for the touched suites
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md) — not needed; renderer behavior is an internal Pi adapter detail
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)
