### PR TITLE
feat(pi): interrupt support (Esc) for in-flight ctx_* tool calls

### DIFF
--- a/src/adapters/pi/mcp-bridge.ts
+++ b/src/adapters/pi/mcp-bridge.ts
@@ -517,6 +517,12 @@ export class MCPStdioClient {
     });
     this.child.on("exit", () => this.onExit());
     this.child.on("error", () => this.onExit());
+    // A broken stdin must not crash the host. When an abort kills the child
+    // while a `notifications/cancelled` frame is still being written, the
+    // EPIPE surfaces as a stream 'error' event (Node's writev batching
+    // bypasses the per-write callback), which would be an uncaught
+    // exception. A dead stdin means the server is gone anyway.
+    this.child.stdin?.on("error", () => this.onExit());
   }
 
   private onExit(): void {
@@ -552,6 +558,7 @@ export class MCPStdioClient {
     method: string,
     params: unknown,
     timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS,
+    signal?: AbortSignal,
   ): Promise<T> {
     // Respawn-on-idle-exit (#583, #583-followup).
     //
@@ -576,6 +583,7 @@ export class MCPStdioClient {
       await this.respawnPromise;
     }
     if (!this.child) throw new Error("MCP client not started");
+    if (signal?.aborted) throw new Error("aborted");
     const id = ++this.requestId;
     return new Promise<T>((resolve, reject) => {
       // Gate the timer on a finite ms value so callers can pass
@@ -588,24 +596,47 @@ export class MCPStdioClient {
         ? setTimeout(() => {
             if (!this.pending.has(id)) return;
             this.pending.delete(id);
+            detachAbort();
             reject(new Error(`MCP request timeout after ${timeoutMs}ms: ${method}`));
           }, timeoutMs)
         : null;
+      const detachAbort = () => {
+        if (signal) signal.removeEventListener("abort", onAbort);
+      };
+      const onAbort = () => {
+        const handler = this.pending.get(id);
+        if (!handler) return; // already settled (response / timeout / exit)
+        this.pending.delete(id);
+        if (timer) clearTimeout(timer);
+        // Spec-conforming best-effort cancel. The context-mode server
+        // does not currently honor it, but future/other servers can.
+        this.notify("notifications/cancelled", { requestId: id, reason: "aborted" });
+        // Stop the real work when nothing else is in flight; the client
+        // auto-respawns the child on next use (#583).
+        if (this.pending.size === 0 && this.child) this.child.kill();
+        // "aborted" matches the built-in tools' abort convention, which
+        // is how pi turns the error into an aborted turn.
+        reject(new Error("aborted"));
+      };
       this.pending.set(id, {
         resolve: (v) => {
           if (timer) clearTimeout(timer);
+          detachAbort();
           resolve(v as T);
         },
         reject: (e) => {
           if (timer) clearTimeout(timer);
+          detachAbort();
           reject(e);
         },
       });
+      if (signal) signal.addEventListener("abort", onAbort, { once: true });
       const frame = JSON.stringify({ jsonrpc: "2.0", id, method, params });
       const rejectWrite = (err: Error) => {
         const handler = this.pending.get(id);
         if (handler) {
           this.pending.delete(id);
+          detachAbort();
           handler.reject(err);
           return;
         }
@@ -679,7 +710,7 @@ export class MCPStdioClient {
     return Array.isArray(result.tools) ? result.tools : [];
   }
 
-  async callTool(name: string, args: unknown): Promise<MCPCallResult> {
+  async callTool(name: string, args: unknown, signal?: AbortSignal): Promise<MCPCallResult> {
     // Respawn-on-idle-exit is now handled centrally in `request()`
     // (#583 follow-up). Originally patched here in #583 — moving it up
     // one layer covers `listTools` / `initialize` paths too, with a
@@ -693,10 +724,13 @@ export class MCPStdioClient {
     // executor layer (per-tool timeout / background mode / Pi cancel),
     // not the transport. `Number.POSITIVE_INFINITY` instructs
     // `request()` to skip the setTimeout entirely — see the gate there.
+    // The optional signal wires Pi's interrupt (Esc / app.interrupt) into
+    // the in-flight request: abort rejects the call and stops the child.
     return this.request<MCPCallResult>(
       "tools/call",
       { name, arguments: args ?? {} },
       Number.POSITIVE_INFINITY,
+      signal,
     );
   }
 
@@ -784,6 +818,12 @@ export interface PiToolRegistration {
   execute: (
     toolCallId: string,
     params: Record<string, unknown>,
+    /**
+     * Pi's run AbortSignal (Esc / app.interrupt). Optional in this type
+     * because older Pi versions omit it; the implementation must treat a
+     * missing signal as "never aborted".
+     */
+    signal?: AbortSignal,
   ) => Promise<{
     content: Array<{ type: "text"; text: string }>;
     details: Record<string, unknown>;
@@ -1031,8 +1071,8 @@ export async function bootstrapMCPTools(
       parameters: tool.inputSchema ?? { type: "object", properties: {} },
       renderCall: createContextModeCallRenderer(tool.name),
       renderResult: createContextModeResultRenderer(tool.name),
-      async execute(_toolCallId, params) {
-        const result = await client.callTool(tool.name, params ?? {});
+      async execute(_toolCallId, params, signal) {
+        const result = await client.callTool(tool.name, params ?? {}, signal);
         const text = (result.content ?? [])
           .filter((c) => c?.type === "text" && typeof c.text === "string")
           .map((c) => c.text as string)

--- a/tests/adapters/pi-mcp-bridge-cancel.test.ts
+++ b/tests/adapters/pi-mcp-bridge-cancel.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Pi MCP bridge — interrupt support (Esc / app.interrupt).
+ *
+ * Bug: Pi passes its run AbortSignal into tool execute()
+ * (`execute(toolCallId, params, signal, onUpdate, ctx)`), and the agent
+ * loop only re-checks `signal.aborted` AFTER the tool promise settles.
+ * The previous Pi bridge registered `execute(_toolCallId, params)` —
+ * ignoring the signal — and the MCP client had no per-request cancel, so
+ * an in-flight ctx_execute call held the whole turn hostage: pressing Esc
+ * did nothing until the tool finished on its own.
+ *
+ * These tests pin the fix:
+ *
+ *   1. Aborting an in-flight tools/call rejects the promise with
+ *      "aborted" promptly and kills the MCP child (stops the real work).
+ *   2. A pre-aborted signal rejects immediately, without contacting the
+ *      server.
+ *   3. Aborting one of two in-flight calls rejects only that call; the
+ *      sibling keeps running on the same child and completes normally.
+ *   4. After an abort-killed child, the next call self-heals via the
+ *      existing respawn path (#583).
+ *   5. A broken stdin (the EPIPE race when an abort kills the child while
+ *      a `notifications/cancelled` frame is still being written) is handled
+ *      as "server exited" instead of becoming an uncaught exception that
+ *      crashes the host process.
+ */
+import "../setup-home";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let scratch: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "ctx-pi-cancel-"));
+});
+
+afterEach(() => {
+  try {
+    rmSync(scratch, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+/** Fake MCP server: "slow" calls answer after a delay, "hang" never do. */
+function writeFakeServer() {
+  const fakePath = join(scratch, "slow-server.mjs");
+  writeFileSync(
+    fakePath,
+    `
+    process.stdin.on("data", (chunk) => {
+      for (const raw of chunk.toString("utf-8").split("\\n")) {
+        const line = raw.trim();
+        if (!line) continue;
+        let msg;
+        try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.method === "initialize") {
+          process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2025-06-18", capabilities: {} } }) + "\\n");
+        } else if (msg.method === "tools/call") {
+          const tag = msg.params?.arguments?.tag;
+          if (tag === "slow") {
+            setTimeout(() => {
+              process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { content: [{ type: "text", text: "done-slow" }] } }) + "\\n");
+            }, 400);
+          }
+          // tag === "hang": never answer — models a long ctx_execute.
+        }
+      }
+    });
+    setInterval(() => {}, 60000);
+    `,
+    "utf-8",
+  );
+  return fakePath;
+}
+
+async function pollFor(cond: () => boolean, timeoutMs = 5000, what = "condition") {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+type TestableClient = {
+  exited: boolean;
+  pending: Map<number, unknown>;
+  child: { stdin: NodeJS.WritableStream | null };
+  shutdown(): void;
+};
+
+describe("MCPStdioClient — interrupt (abort signal)", () => {
+  it("aborting an in-flight tools/call rejects with 'aborted' and kills the child", async () => {
+    const { MCPStdioClient } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const client = new MCPStdioClient(writeFakeServer()) as unknown as TestableClient;
+    try {
+      client.start();
+      await client.initialize();
+
+      const ac = new AbortController();
+      const started = performance.now();
+      const call = (client as unknown as {
+        callTool(name: string, args: unknown, signal?: AbortSignal): Promise<{ content?: Array<{ text?: string }> }>;
+      }).callTool("ctx_execute", { tag: "hang" }, ac.signal);
+
+      // Wait until the request is actually in flight.
+      await pollFor(() => client.pending.size >= 1, 5000, "in-flight request");
+
+      ac.abort();
+      await expect(call).rejects.toThrow("aborted");
+      expect(performance.now() - started).toBeLessThan(2000);
+
+      // The child must actually die so the executing work stops.
+      await pollFor(() => client.exited, 5000, "child exit");
+    } finally {
+      client.shutdown();
+    }
+  });
+
+  it("a pre-aborted signal rejects immediately without contacting the server", async () => {
+    const { MCPStdioClient } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const client = new MCPStdioClient(writeFakeServer()) as unknown as TestableClient;
+    try {
+      client.start();
+      await client.initialize();
+
+      const ac = new AbortController();
+      ac.abort();
+      const call = (client as unknown as {
+        callTool(name: string, args: unknown, signal?: AbortSignal): Promise<unknown>;
+      }).callTool("ctx_execute", { tag: "hang" }, ac.signal);
+      await expect(call).rejects.toThrow("aborted");
+      // Nothing may be in flight and the child must stay alive.
+      expect(client.pending.size).toBe(0);
+      expect(client.exited).toBe(false);
+    } finally {
+      client.shutdown();
+    }
+  });
+
+  it("aborting one of two in-flight calls leaves the sibling running on the same child", async () => {
+    const { MCPStdioClient } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const client = new MCPStdioClient(writeFakeServer()) as unknown as TestableClient;
+    const callTool = (
+      client as unknown as {
+        callTool(name: string, args: unknown, signal?: AbortSignal): Promise<{ content?: Array<{ text?: string }> }>;
+      }
+    ).callTool.bind(client);
+    try {
+      client.start();
+      await client.initialize();
+
+      const acSibling = new AbortController();
+      const acAborted = new AbortController();
+      const sibling = callTool("ctx_execute", { tag: "slow" }, acSibling.signal);
+      const doomed = callTool("ctx_execute", { tag: "hang" }, acAborted.signal);
+
+      await pollFor(() => client.pending.size >= 2, 5000, "two in-flight requests");
+      acAborted.abort();
+
+      await expect(doomed).rejects.toThrow("aborted");
+      // One request still in flight → child must NOT be killed.
+      expect(client.exited).toBe(false);
+      expect(client.pending.size).toBe(1);
+
+      // The sibling completes normally through the surviving child.
+      const result = await sibling;
+      expect(result.content?.[0]?.text).toBe("done-slow");
+      expect(client.exited).toBe(false);
+    } finally {
+      client.shutdown();
+    }
+  });
+
+  it("the next call after an abort-killed child self-heals via respawn (#583)", async () => {
+    const { MCPStdioClient } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const fakePath = writeFakeServer();
+    const client = new MCPStdioClient(fakePath) as unknown as TestableClient;
+    const callTool = (
+      client as unknown as {
+        callTool(name: string, args: unknown, signal?: AbortSignal): Promise<{ content?: Array<{ text?: string }> }>;
+      }
+    ).callTool.bind(client);
+    try {
+      client.start();
+      await client.initialize();
+
+      const ac = new AbortController();
+      const call = callTool("ctx_execute", { tag: "hang" }, ac.signal);
+      await pollFor(() => client.pending.size >= 1, 5000, "in-flight request");
+      ac.abort();
+      await expect(call).rejects.toThrow("aborted");
+      await pollFor(() => client.exited, 5000, "child exit");
+
+      // A fresh call must respawn the child and succeed.
+      const next = await callTool("ctx_execute", { tag: "slow" });
+      expect(next.content?.[0]?.text).toBe("done-slow");
+    } finally {
+      client.shutdown();
+    }
+  });
+
+  it("a broken stdin (EPIPE race on abort) is handled, not uncaught", async () => {
+    const { MCPStdioClient } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const client = new MCPStdioClient(writeFakeServer()) as unknown as TestableClient;
+    try {
+      client.start();
+      await client.initialize();
+
+      // Deterministic simulation of the OS closing the pipe's read end while
+      // a frame write is in flight — exactly what child.kill() in onAbort
+      // races against. destroy(err) emits 'error' on the stream; without a
+      // handler it is an uncaught exception that would crash the host.
+      client.child.stdin?.destroy(new Error("write EPIPE"));
+      await pollFor(() => client.exited, 5000, "client marked exited on stdin error");
+    } finally {
+      client.shutdown();
+    }
+  });
+});


### PR DESCRIPTION
## What / Why / How

Interrupt support (Esc / app.interrupt) for in-flight `ctx_*` tool calls in the Pi adapter.

**Why:** Pi passes its run `AbortSignal` into `tool.execute(toolCallId, params, signal, …)`, and the agent loop only re-checks `signal.aborted` **after** the tool promise settles. The Pi bridge registered `execute(_toolCallId, params)` — ignoring the signal — and the MCP client had no per-request cancel, so an in-flight `ctx_execute` held the whole turn hostage: pressing Esc did nothing until the tool finished on its own. A long sandboxed run looked permanently hung with no way to bail out.

**How:** the signal now flows `execute → callTool → request`:

- an in-flight `tools/call` is rejected with `"aborted"` (the built-in tools' abort convention — the message pi's agent loop expects) the moment the signal fires;
- a best-effort spec-conforming `notifications/cancelled` is sent to the server (the context-mode server does not currently honor it, but other/future servers can);
- when no other request is in flight the MCP child is killed so the executing work actually stops (a sibling request keeps the child alive);
- the next call self-heals through the existing respawn path (#583).

**Safety fix included:** the kill-vs-write race is handled. When an abort kills the child while a `notifications/cancelled` frame is still being written, the EPIPE surfaces as a stream `'error'` event (Node's `writev` batching bypasses the per-write callback), which would otherwise be an uncaught exception crashing the host process. A `stdin` error handler treats a broken stdin as "server exited" (same as `child.on("exit")`).

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [x] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

New `tests/adapters/pi-mcp-bridge-cancel.test.ts` (5 tests, fake MCP server):

1. in-flight abort rejects with "aborted" promptly and kills the child
2. pre-aborted signal rejects immediately without contacting the server
3. sibling request survives a sibling's abort on the same child
4. next call self-heals via respawn after an abort-killed child (#583)
5. a broken stdin (EPIPE race on abort) is handled, not uncaught

- `npx tsc --noEmit` — clean
- `npx vitest run tests/adapters/pi-mcp-bridge-cancel.test.ts` — 5/5 pass, repeated runs with zero unhandled errors
- Verified end-to-end against the installed bridge: in-flight call → abort at t+1500ms → promise rejects at t+1515ms, child exits, the 30s sandboxed job does not complete, next call succeeds on the respawned child.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes for the touched suites
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md) — not needed; internal Pi adapter behavior
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)
