### PR TITLE
fix(pi): strip echo preamble in collapsed renderResult

### DIFF
--- a/src/adapters/pi/mcp-bridge.ts
+++ b/src/adapters/pi/mcp-bridge.ts
@@ -332,6 +332,25 @@ function createContextModeCallRenderer(toolName: string) {
   };
 }
 
+/**
+ * Strip the echo preamble that ctx_execute / ctx_batch_execute prepend
+ * to every response (buildExecuteEcho / formatCommandOutput in
+ * server.ts).  In Pi's collapsed renderResult the first non-empty line
+ * is used as the status summary — without stripping, that line is the
+ * opening of a markdown code fence (e.g. ```shell) and the user sees
+ * a blank-looking tool result.  The full echo still reaches the LLM
+ * via execute(); this only affects the Pi TUI collapsed view.
+ */
+function stripEchoPreamble(output: string): string {
+  // ctx_execute: ```<lang>\n<code>\n```\n\n<output>
+  const fence = output.match(/^```[a-z]+\n[\s\S]*?\n```\n*/);
+  if (fence) return output.slice(fence[0].length);
+  // ctx_batch_execute: # <label>\n\n$ <cmd>\n\n<output>
+  const cmd = output.match(/^# .+\n\n\$ .+\n\n/);
+  if (cmd) return output.slice(cmd[0].length);
+  return output;
+}
+
 function createContextModeResultRenderer(toolName: string) {
   return (
     result: MCPCallResult,
@@ -355,7 +374,8 @@ function createContextModeResultRenderer(toolName: string) {
       text.setText(theme.fg("toolOutput", output));
       return text;
     }
-    const firstLine = output
+    const stripped = stripEchoPreamble(output);
+    const firstLine = stripped
       .split(/\r?\n/)
       .find((line) => line.trim().length > 0)
       ?.trim();


### PR DESCRIPTION
## Summary

Fixes blank TUI rendering of `ctx_execute` results in Pi's collapsed view.

## Problem

When `ctx_execute` (or `ctx_execute_file` / `ctx_batch_execute`) runs in Pi, the collapsed TUI rendering shows only the opening of a markdown code fence (e.g. triple-backtick + `shell`) and nothing else — no command, no output, no closing fence. The tool executes correctly, but the user sees a blank-looking result.

## Root Cause

`buildExecuteEcho()` in `src/server.ts` prepends a markdown code fence to every `ctx_execute` response:

```
(fence opening)shell
<code>
(fence closing)

<actual output>
```

`createContextModeResultRenderer()` in `src/adapters/pi/mcp-bridge.ts` handles Pi's collapsed (non-expanded) view by taking the first non-empty line of the response as the status summary. That first line is the code fence opening — so the user sees only that, with no actual output.

The same issue affects `ctx_batch_execute` (its `formatCommandOutput` prepends `# <label>\n\n$ <cmd>\n\n`).

## Fix

Added `stripEchoPreamble()` in `src/adapters/pi/mcp-bridge.ts` that strips both echo formats before finding the first meaningful line in collapsed mode:

- `ctx_execute` fence format: ` ```<lang>\n<code>\n```\n\n ` → stripped
- `ctx_batch_execute` command format: `# <label>\n\n$ <cmd>\n\n ` → stripped

The full echo still reaches the LLM via `execute()` and survives in FTS5 indexed chunks — this only affects what the Pi TUI shows in collapsed mode.

## Testing

- All 30 existing Pi MCP bridge tests pass (`tests/adapters/pi-mcp-bridge.test.ts`)
- All 48 adapter tests pass (1 pre-existing failure in `omp-plugin.test.ts` unrelated to this change — requires `npm run build`)

## Related issue

#1094
