### PR TITLE
fix(codex): route Code Mode exec through PreToolUse

### DIFF
--- a/.codex-plugin/hooks.json
+++ b/.codex-plugin/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "local_shell|shell|shell_command|exec_command|Bash|Shell|apply_patch|Edit|Write|grep_files|ctx_execute|ctx_execute_file|ctx_batch_execute|ctx_fetch_and_index|ctx_search|ctx_index|mcp__",
+        "matcher": "local_shell|shell|shell_command|exec|exec_command|Bash|Shell|apply_patch|Edit|Write|grep_files|ctx_execute|ctx_execute_file|ctx_batch_execute|ctx_fetch_and_index|ctx_search|ctx_index|mcp__",
         "hooks": [
           {
             "type": "command",

--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ The Codex plugin manifest provides MCP via `.codex-plugin/mcp.json`, skills via
    ```json
    {
      "hooks": {
-      "PreToolUse": [{ "matcher": "local_shell|shell|shell_command|exec_command|Bash|Shell|apply_patch|Edit|Write|grep_files|ctx_execute|ctx_execute_file|ctx_batch_execute|ctx_fetch_and_index|ctx_search|ctx_index|mcp__", "hooks": [{ "type": "command", "command": "context-mode hook codex pretooluse" }] }],
+      "PreToolUse": [{ "matcher": "local_shell|shell|shell_command|exec|exec_command|Bash|Shell|apply_patch|Edit|Write|grep_files|ctx_execute|ctx_execute_file|ctx_batch_execute|ctx_fetch_and_index|ctx_search|ctx_index|mcp__", "hooks": [{ "type": "command", "command": "context-mode hook codex pretooluse" }] }],
        "PostToolUse": [{ "hooks": [{ "type": "command", "command": "context-mode hook codex posttooluse" }] }],
        "SessionStart": [{ "hooks": [{ "type": "command", "command": "context-mode hook codex sessionstart" }] }],
        "PreCompact": [{ "hooks": [{ "type": "command", "command": "context-mode hook codex precompact" }] }],

--- a/configs/codex/hooks.json
+++ b/configs/codex/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "local_shell|shell|shell_command|exec_command|Bash|Shell|apply_patch|Edit|Write|grep_files|ctx_execute|ctx_execute_file|ctx_batch_execute|ctx_fetch_and_index|ctx_search|ctx_index|mcp__",
+        "matcher": "local_shell|shell|shell_command|exec|exec_command|Bash|Shell|apply_patch|Edit|Write|grep_files|ctx_execute|ctx_execute_file|ctx_batch_execute|ctx_fetch_and_index|ctx_search|ctx_index|mcp__",
         "hooks": [
           { "type": "command", "command": "context-mode hook codex pretooluse" }
         ]

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -77,7 +77,8 @@ type HooksConfigReadResult =
   | { ok: false; reason: "invalid_json"; error: string }
   | { ok: false; reason: "read_error"; error: string };
 
-// PreToolUse matcher: canonical Codex tool names + context-mode bare MCP tool
+// PreToolUse matcher: canonical Codex tool names (including Code Mode's outer
+// `exec` wrapper) + context-mode bare MCP tool
 // names + external MCP catch-all literal (#529, #547 hotfix).
 //
 // Codex CLI's Rust `regex` crate does NOT support look-around, and
@@ -96,7 +97,7 @@ type HooksConfigReadResult =
 // Keep this as a single string literal — `codex.test.ts` drift-guard parses
 // the source with a `"([^"]+)"` regex.
 const PRE_TOOL_USE_MATCHER_PATTERN =
-  "local_shell|shell|shell_command|exec_command|Bash|Shell|apply_patch|Edit|Write|grep_files|ctx_execute|ctx_execute_file|ctx_batch_execute|ctx_fetch_and_index|ctx_search|ctx_index|mcp__";
+  "local_shell|shell|shell_command|exec|exec_command|Bash|Shell|apply_patch|Edit|Write|grep_files|ctx_execute|ctx_execute_file|ctx_batch_execute|ctx_fetch_and_index|ctx_search|ctx_index|mcp__";
 
 const CODEX_HOOK_COMMANDS = {
   PreToolUse: "context-mode hook codex pretooluse",

--- a/tests/adapters/codex.test.ts
+++ b/tests/adapters/codex.test.ts
@@ -371,6 +371,7 @@ describe("CodexAdapter", () => {
       expect(config.PreToolUse[0]?.matcher).toContain("apply_patch");
       expect(config.PreToolUse[0]?.matcher).toContain("Edit");
       expect(config.PreToolUse[0]?.matcher).toContain("Write");
+      expect(config.PreToolUse[0]?.matcher.split("|")).toContain("exec");
       // #547 hotfix: matcher is now charset-clean (no `.*` regex syntax) so
       // the bare `ctx_*` names cover context-mode's own MCP tools and the
       // literal `mcp__` segment exists for parity with hooks/hooks.json.


### PR DESCRIPTION
## What

Add the Code Mode outer `exec` tool name to the Codex PreToolUse matcher, and keep the generated plugin manifest, standalone Codex config, README example, and adapter test in sync.

## Why

Code Mode exposes a wrapper named `exec`. The current matcher includes `exec_command`, but Codex exact-matcher mode treats these as distinct tool names. As a result, commands routed through the outer wrapper can bypass context-mode's PreToolUse routing while direct `exec_command` calls are intercepted.

This was observed on Codex Desktop with context-mode v1.0.169. Adding the literal `exec` token locally restored routing. The matcher remains charset-clean for Codex's exact-matcher fast path.

## Testing

- `tests/adapters/codex.test.ts`: 69 passed, 1 skipped (the skipped Stop hook test requires a working Windows better-sqlite3 native binding)
- focused matcher/generation tests: 4 passed
- `tsc --noEmit`: passed
- `node scripts/assert-asymmetric-drift.mjs`: passed
- `git diff --check`: passed

## Scope

Codex adapter and its published configuration/docs only. No routing behavior for other adapters changes.