### PR TITLE
fix(detect): wait for MCP initialize before platform detect

### DIFF
--- a/src/adapters/detect.ts
+++ b/src/adapters/detect.ts
@@ -498,22 +498,6 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
     };
   }
 
-  if (existsSync(resolve(home, ".claude"))) {
-    return {
-      platform: "claude-code",
-      confidence: "medium",
-      reason: "~/.claude/ directory exists",
-    };
-  }
-
-  if (existsSync(resolve(home, ".gemini"))) {
-    return {
-      platform: "gemini-cli",
-      confidence: "medium",
-      reason: "~/.gemini/ directory exists",
-    };
-  }
-
   if (existsSync(resolve(home, ".codex"))) {
     return {
       platform: "codex",
@@ -577,6 +561,22 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
       platform: "openclaw",
       confidence: "medium",
       reason: "~/.openclaw/ directory exists",
+    };
+  }
+
+  if (existsSync(resolve(home, ".claude"))) {
+    return {
+      platform: "claude-code",
+      confidence: "medium",
+      reason: "~/.claude/ directory exists",
+    };
+  }
+
+  if (existsSync(resolve(home, ".gemini"))) {
+    return {
+      platform: "gemini-cli",
+      confidence: "medium",
+      reason: "~/.gemini/ directory exists",
     };
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5354,6 +5354,24 @@ async function main() {
   // Lifecycle guard: detect parent death + stdin close to prevent orphaned processes (#103)
   startLifecycleGuard({ onShutdown: () => gracefulShutdown() });
 
+  // Detect platform adapter after MCP initialize. server.connect()
+  // returns before the handshake, so getClientVersion() is empty on
+  // that path. Wait for oninitialized so omp-coding-agent clientInfo
+  // wins over ~/.claude config-dir fallback.
+  server.server.oninitialized = () => {
+    void (async () => {
+      try {
+        const { detectPlatform, getAdapter } = await import("./adapters/detect.js");
+        const clientInfo = server.server.getClientVersion();
+        const signal = detectPlatform(clientInfo ?? undefined);
+        _detectedAdapter = await getAdapter(signal.platform);
+        if (clientInfo) {
+          console.error(`MCP client: ${clientInfo.name} v${clientInfo.version} → ${signal.platform}`);
+        }
+      } catch { /* best effort — _detectedAdapter stays null, falls back to .claude */ }
+    })();
+  };
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
@@ -5376,17 +5394,6 @@ async function main() {
     try { writeFileSync(mcpSentinel, String(process.pid)); } catch { /* best effort */ }
   }, 30_000);
   sentinelRefresh.unref();
-
-  // Detect platform adapter — stored for platform-aware session paths
-  try {
-    const { detectPlatform, getAdapter } = await import("./adapters/detect.js");
-    const clientInfo = server.server.getClientVersion();
-    const signal = detectPlatform(clientInfo ?? undefined);
-    _detectedAdapter = await getAdapter(signal.platform);
-    if (clientInfo) {
-      console.error(`MCP client: ${clientInfo.name} v${clientInfo.version} → ${signal.platform}`);
-    }
-  } catch { /* best effort — _detectedAdapter stays null, falls back to .claude */ }
 
   // Restore tool-call counters from SessionDB BEFORE the heartbeat fires
   // so the very first persistStats() carries the prior PID's totals into

--- a/tests/adapters/detect-ambiguity-matrix.test.ts
+++ b/tests/adapters/detect-ambiguity-matrix.test.ts
@@ -76,13 +76,13 @@ describe("detectPlatform — all-pairs ambiguity matrix (issue #542)", () => {
     // ── Pi → OMP rebrand collision: OMP wins (more specific) ──
     ["pi + omp       → omp",     [".pi"],     [".omp"],     "omp"],
 
-    // ── Two-agent collision: priority is documented in detect.ts ──
-    // claude > gemini > codex > kiro > omp > pi > qwen > openclaw > cursor
-    // (issue #542 reorder — agents-first, then editors).
-    ["kiro + gemini  → gemini",  [".kiro"],   [".gemini"],  "gemini-cli"],
-    ["kiro + claude  → claude",  [".kiro"],   [".claude"],  "claude-code"],
-    ["pi + claude    → claude",  [".pi"],     [".claude"],  "claude-code"],
-    ["omp + claude   → claude",  [".omp"],    [".claude"],  "claude-code"],
+    // ── Two-agent collision: dedicated CLI dirs beat generic ~/.claude ──
+    // kiro/omp/pi > claude/gemini > editors (issue #542 agents-first, plus
+    // OMP MCP mis-detect when ~/.claude also exists).
+    ["kiro + gemini  → kiro",    [".kiro"],   [".gemini"],  "kiro"],
+    ["kiro + claude  → kiro",    [".kiro"],   [".claude"],  "kiro"],
+    ["pi + claude    → pi",      [".pi"],     [".claude"],  "pi"],
+    ["omp + claude   → omp",     [".omp"],    [".claude"],  "omp"],
 
     // ── Regressions: bare single-dir resolutions still work ──
     ["cursor only    → cursor",  [".cursor"], [".cursor"],  "cursor"],

--- a/tests/adapters/detect-config-dir.test.ts
+++ b/tests/adapters/detect-config-dir.test.ts
@@ -243,6 +243,20 @@ describe("detectPlatform — config directory branches", () => {
     expect(signal.platform).toBe(expected);
     expect(signal.confidence).toBe("medium");
   });
+
+  // Dedicated CLI agents (.omp/.pi/.kiro) MUST outrank generic ~/.claude,
+  // same #542/#774 pattern as Cursor. A machine with both ~/.claude and
+  // ~/.omp otherwise mis-detects OMP MCP as Claude Code.
+  it("agent dir ~/.omp beats ~/.claude when both exist", () => {
+    existsSyncMock.mockImplementation(
+      ((p: unknown) =>
+        p === resolve(home, ".omp") ||
+        p === resolve(home, ".claude")) as typeof fs.existsSync,
+    );
+    const signal = detectPlatform();
+    expect(signal.platform).toBe("omp");
+    expect(signal.confidence).toBe("medium");
+  });
 });
 
 describe("detectPlatform — env var priority chain", () => {

--- a/tests/adapters/detect.test.ts
+++ b/tests/adapters/detect.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { sep } from "node:path";
+import { readFileSync } from "node:fs";
+import { sep, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   detectPlatform,
   getAdapter,
@@ -775,5 +777,27 @@ describe("PLATFORM_ENV_VARS — typed registry (issue #545 algorithmic design)",
         }
       }
     }
+  });
+});
+
+describe("main() defers adapter detect until initialize handshake", () => {
+  const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+  const serverSrc = readFileSync(resolve(ROOT, "src", "server.ts"), "utf-8");
+  const mainIdx = serverSrc.indexOf("async function main()");
+  const mainBody = serverSrc.slice(mainIdx);
+
+  it("does not call getClientVersion immediately after connect", () => {
+    const connectIdx = mainBody.indexOf("await server.connect(transport)");
+    expect(connectIdx).toBeGreaterThan(-1);
+    const afterConnect = mainBody.slice(connectIdx, connectIdx + 2500);
+    expect(afterConnect.includes("getClientVersion()")).toBe(false);
+  });
+
+  it("detects from oninitialized after handshake", () => {
+    expect(mainBody.includes("server.server.oninitialized")).toBe(true);
+    const initIdx = mainBody.indexOf("server.server.oninitialized");
+    const window = mainBody.slice(initIdx, initIdx + 1200);
+    expect(window.includes("getClientVersion()")).toBe(true);
+    expect(window.includes("detectPlatform(")).toBe(true);
   });
 });


### PR DESCRIPTION
## What / Why / How

OMP MCP was mis-detected as Claude Code. `server.connect()` returns before initialize, so `getClientVersion()` is empty and `~/.claude` beat `~/.omp` in the config-dir fallback.

Detect on `server.server.oninitialized` so omp-coding-agent `clientInfo` wins. Probe dedicated CLI agent dirs (`.kiro` / `.omp` / `.pi` / `.qwen` / `.kimi` / `.openclaw` / `.codex`) before `~/.claude`, same #542/#774 pattern as Cursor.

Detect-only. No adapter / plugin rewrite.

Live OMP transcript not attached — handshake is source-inspected in `tests/adapters/detect.test.ts` plus the config-dir / ambiguity-matrix cases.

## Affected platforms

- [x] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [x] Codex CLI
- [x] OpenClaw (Pi Agent)
- [x] Pi
- [x] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

Also: OMP, Qwen, Kimi (CLI agent dirs now outrank `~/.claude`). Template has no OMP checkbox.

## Test plan

- `tests/adapters/detect-config-dir.test.ts`: `~/.omp` beats `~/.claude`
- `tests/adapters/detect.test.ts`: detect waits for `oninitialized` (existing detect file)
- `tests/adapters/detect-ambiguity-matrix.test.ts`: kiro/omp/pi beat `~/.claude` / `~/.gemini`
- `npm run typecheck` — pass
- `npm test` — detect files 146 pass. Full suite: 4772 pass; remaining 2 failures (`asymmetric-drift-assert` empty `npm pack`, `detect-locale-esm` AppleLocale) are machine/env, not this diff.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)