### PR TITLE
feat(omp): name MCP tools as bare ctx_*

### DIFF
--- a/hooks/core/tool-naming.mjs
+++ b/hooks/core/tool-naming.mjs
@@ -13,7 +13,7 @@
  * | VS Code Copilot    | context-mode_<tool>                                        |
  * | Kiro               | @context-mode/<tool>                                       |
  * | Zed                | mcp:context-mode:<tool>                                    |
- * | Cursor / Codex / OpenClaw / Pi | bare <tool>                                    |
+ * | Cursor / Codex / OpenClaw / Pi / OMP | bare <tool>                          |
  */
 
 const TOOL_PREFIXES = {
@@ -33,6 +33,7 @@ const TOOL_PREFIXES = {
   "kimi":           (tool) => `mcp__context-mode__${tool}`,
   "openclaw":       (tool) => tool,
   "pi":             (tool) => tool,
+  "omp":            (tool) => tool,
   "qwen-code":      (tool) => `mcp__context-mode__${tool}`,
 };
 

--- a/tests/hooks/tool-naming.test.ts
+++ b/tests/hooks/tool-naming.test.ts
@@ -136,6 +136,10 @@ describe("getToolName", () => {
     expect(getToolName("pi", "ctx_batch_execute")).toBe("ctx_batch_execute");
   });
 
+  it("returns bare name for omp", () => {
+    expect(getToolName("omp", "ctx_execute")).toBe("ctx_execute");
+  });
+
   it("falls back to claude-code for unknown platforms", () => {
     expect(getToolName("unknown-platform", "ctx_search")).toBe(
       "mcp__plugin_context-mode_context-mode__ctx_search",
@@ -166,6 +170,7 @@ describe("KNOWN_PLATFORMS", () => {
     expect(KNOWN_PLATFORMS).toContain("codex");
     expect(KNOWN_PLATFORMS).toContain("openclaw");
     expect(KNOWN_PLATFORMS).toContain("pi");
+    expect(KNOWN_PLATFORMS).toContain("omp");
     expect(KNOWN_PLATFORMS).toContain("qwen-code");
     expect(KNOWN_PLATFORMS.length).toBeGreaterThanOrEqual(14);
   });


### PR DESCRIPTION
## What / Why / How

OMP presents MCP tools without a prefix, matching Pi / OpenClaw / Cursor. `getToolName("omp", …)` currently falls through to the Claude Code `mcp__plugin_context-mode_…` prefix, so routing guidance tells OMP to call tools that do not exist under that name.

Add `omp` to `TOOL_PREFIXES` as a bare-name platform.

Live session not attached — this is a name-table mapping only.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

OMP only (not in the checkbox list). Pi already uses a bare name; unchanged.

## Test plan

- `tests/hooks/tool-naming.test.ts`: `getToolName("omp", "ctx_execute") === "ctx_execute"`
- `npm test`
- `npm run typecheck`

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)