### PR TITLE
feat(omp): restore resume snapshot after compact

### DIFF
--- a/src/adapters/omp/plugin.ts
+++ b/src/adapters/omp/plugin.ts
@@ -2,13 +2,15 @@
  * Oh My Pi (OMP) plugin entry point for context-mode.
  *
  * Mirrors the Pi extension shape (`src/adapters/pi/extension.ts`) for
- * the four OMP hook events that materially protect the context window
+ * the OMP hook events that materially protect the context window
  * and persist session continuity:
  *
- *   - session_start         — initialize the session row in our DB
- *   - tool_call             — hard-block curl/wget/inline-HTTP in bash
- *   - tool_result           — extract structured events into the session DB
+ *   - session_start          — initialize the session row in our DB
+ *   - tool_call              — hard-block curl/wget/inline-HTTP in bash
+ *   - tool_result            — extract structured events into the session DB
  *   - session_before_compact — persist a resume snapshot before compaction
+ *   - before_agent_start     — queue unconsumed resume snapshot for context
+ *   - context                — append queued snapshot as a user message
  *
  * Loaded by OMP via the `omp` (or `pi`) field in package.json — see
  * upstream loader at refs/platforms/oh-my-pi/packages/coding-agent/src/
@@ -73,6 +75,7 @@ const BLOCKED_BASH_PATTERNS: RegExp[] = [
 let _db: SessionDB | null = null;
 let _dbPath = "";
 let _sessionId = "";
+let _pendingContext = "";
 
 const _ompAdapter = new OMPAdapter();
 
@@ -192,6 +195,7 @@ export function _resetOmpPluginStateForTests(): void {
   _db = null;
   _dbPath = "";
   _sessionId = "";
+  _pendingContext = "";
 }
 
 /**
@@ -240,6 +244,8 @@ export interface MinimalHookAPI {
   // (refs/.../extensibility/shared-events.ts:204-208). agent_end carries
   // `messages: AssistantMessage[]` (:191-194) — both flow through parseOmpUsage.
   on(event: "turn_end", handler: HookHandler<TurnEndEvent>): void;
+  on(event: "before_agent_start", handler: HookHandler<{ type: "before_agent_start"; prompt?: string }>): void;
+  on(event: "context", handler: HookHandler<{ messages?: Array<{ role: string; content: string }> }, { messages: Array<{ role: string; content: string }> }>): void;
   on(event: string, handler: (...args: unknown[]) => unknown): void;
 }
 
@@ -248,7 +254,7 @@ export interface MinimalHookAPI {
 /**
  * OMP plugin default export. Called once by the OMP runtime per
  * upstream `extensibility/plugins/loader.ts` after `omp plugin install
- * context-mode`. Subsequent `pi.on(...)` registrations route the four
+ * context-mode`. Subsequent `pi.on(...)` registrations route the
  * lifecycle events to our SessionDB-backed handlers below.
  */
 export default function ompPlugin(pi: MinimalHookAPI): void {
@@ -277,6 +283,37 @@ export default function ompPlugin(pi: MinimalHookAPI): void {
       }
     }
     return undefined;
+  });
+
+  // ── 1b. before_agent_start — queue unconsumed resume snapshot ──
+  // Compact does not re-fire session_start. Pi queues on this hook
+  // (every user prompt) and lets `context` append as role:user so
+  // the systemPrompt prefix cache stays valid. Once.
+  pi.on("before_agent_start", () => {
+    try {
+      if (!_sessionId) return undefined;
+      const resume = db.getResume(_sessionId);
+      if (resume && !resume.consumed && resume.snapshot) {
+        _pendingContext = _pendingContext ? `${_pendingContext}\n\n${resume.snapshot}` : resume.snapshot;
+        db.markResumeConsumed(_sessionId);
+      }
+    } catch {
+      // best effort — never break the turn
+    }
+    return undefined;
+  });
+
+  pi.on("context", (event) => {
+    try {
+      if (!_pendingContext) return undefined;
+      const ctx = _pendingContext;
+      _pendingContext = "";
+      const messages = Array.isArray(event?.messages) ? event.messages : [];
+      messages.push({ role: "user", content: ctx });
+      return { messages };
+    } catch {
+      return undefined;
+    }
   });
 
   // ── 2. tool_call — pre-tool-call hard-block ───────────

--- a/tests/adapters/omp-plugin.test.ts
+++ b/tests/adapters/omp-plugin.test.ts
@@ -1,6 +1,6 @@
 import "../setup-home";
 /**
- * OMP plugin tests — TDD slices around the four hooks the plugin owns.
+ * OMP plugin tests — TDD slices around the hooks the plugin owns.
  *
  * The OMP plugin (src/adapters/omp/plugin.ts) is a default-exported
  * factory `(pi: HookAPI) => void`. Hook contract verified against
@@ -12,6 +12,7 @@ import "../setup-home";
  *   2. tool_result — post-tool-call event extraction into SessionDB
  *   3. session_start — session row created, cleanup runs
  *   4. session_before_compact — resume snapshot persisted
+ *   5. before_agent_start — unconsumed resume snapshot injected via context
  *
  * We mock the OMP HookAPI shape: `on(event, handler)` collects
  * handlers, `_trigger(event, ...args)` invokes them and returns the
@@ -318,6 +319,80 @@ describe("OMP plugin", () => {
       void mod;
     });
   });
+
+  // ═══════════════════════════════════════════════════════════
+  // Slice 5: before_agent_start injects unconsumed resume snapshot
+  // ═══════════════════════════════════════════════════════════
+
+  describe("Slice 5: before_agent_start resume restore", () => {
+    async function compactWithEvent() {
+      await api._trigger("session_start", { type: "session_start" }, {
+        sessionManager: { getSessionFile: () => "/path/to/session-restore.json" },
+      });
+      await api._trigger("tool_result", {
+        toolName: "read",
+        input: { file_path: "/tmp/x.ts" },
+        content: [{ type: "text", text: "x" }],
+      });
+      await api._trigger("session_before_compact", { type: "session_before_compact" }, {});
+    }
+
+    it("registers a before_agent_start handler", async () => {
+      await registerOmpPlugin(api);
+      expect(api._handlers.before_agent_start).toBeDefined();
+    });
+
+    it("injects the unconsumed resume snapshot through context after compact", async () => {
+      await registerOmpPlugin(api);
+      await compactWithEvent();
+
+      await api._trigger("before_agent_start", { type: "before_agent_start", prompt: "continue" }, {});
+      const result = await api._trigger("context", { messages: [] }) as
+        | { messages: Array<{ role: string; content: string }> }
+        | undefined;
+
+      expect(result?.messages?.length).toBe(1);
+      expect(result?.messages?.[0]?.role).toBe("user");
+      expect(result?.messages?.[0]?.content.length).toBeGreaterThan(0);
+
+      const pluginMod = await import("../../src/adapters/omp/plugin.js");
+      const sid = pluginMod._getOmpPluginSessionIdForTests();
+      const { OMPAdapter } = await import("../../src/adapters/omp/index.js");
+      const adapter = new OMPAdapter();
+      const { resolveSessionDbPath } = await import("../../src/session/db.js");
+      const db = new SessionDB({
+        dbPath: resolveSessionDbPath({
+          projectDir: tempDir,
+          sessionsDir: adapter.getSessionDir(),
+        }),
+      });
+      expect(db.getResume(sid)?.consumed).toBeTruthy();
+    });
+
+    it("does not re-inject after the snapshot is consumed", async () => {
+      await registerOmpPlugin(api);
+      await compactWithEvent();
+
+      await api._trigger("before_agent_start", { type: "before_agent_start", prompt: "continue" }, {});
+      await api._trigger("context", { messages: [] });
+
+      await api._trigger("before_agent_start", { type: "before_agent_start", prompt: "again" }, {});
+      const second = await api._trigger("context", { messages: [] });
+      expect(second).toBeUndefined();
+    });
+
+    it("does not inject on session_start — that event is boot-only", async () => {
+      await registerOmpPlugin(api);
+      await compactWithEvent();
+
+      await api._trigger("session_start", { type: "session_start" }, {
+        sessionManager: { getSessionFile: () => "/path/to/session-restore.json" },
+      });
+      const result = await api._trigger("context", { messages: [] });
+      expect(result).toBeUndefined();
+    });
+  });
+
 
   // ═══════════════════════════════════════════════════════════
   // Issue #645 — OMP plugin SessionDB path must match the MCP


### PR DESCRIPTION
## What / Why / How

OMP already writes a resume snapshot on `session_before_compact`. Compact then drops history (summary + kept tail) and **does not** re-fire `session_start`. The snapshot sat in SQLite unused. After compact the model only sees the truncated transcript unless it thinks to `ctx_search`.

Mirror Pi, not Claude: queue the unconsumed snapshot on `before_agent_start` (fires every user prompt, including post-compact), deliver via a new `context` hook as `role: user` so the systemPrompt prefix cache stays valid, then `markResumeConsumed`. Second turn is a no-op. `session_start` stays boot-only (ensure-row).

Do not inject a full routing block here — that is a separate per-turn cost.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

OMP only (not in the checkbox list).

## Test plan

- `tests/adapters/omp-plugin.test.ts` Slice 5: after compact, `before_agent_start` then `context` injects snapshot; second turn does not re-inject; `session_start` does not inject
- `bunx vitest run tests/adapters/omp-plugin.test.ts -t "Slice 5"` — 6 passed
- `npx tsc --noEmit` — pass

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] Focused plugin tests pass (Slice 5)
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)