### PR TITLE
fix(db-base): keep SQL comments from splitting exec statements

### DIFF
--- a/src/db-base.ts
+++ b/src/db-base.ts
@@ -63,27 +63,59 @@ export class BunSQLiteAdapter {
 
   exec(sql: string): any {
     // bun:sqlite .exec() is single-statement only.
-    // Split multi-statement SQL respecting string literals (don't split on ; inside quotes).
+    // Split multi-statement SQL respecting string literals and comments — a
+    // `;`, `'` or `"` inside a comment must neither split the statement nor
+    // open a literal.
     let current = "";
     let inString: string | null = null;
+    let inLineComment = false;
+    let inBlockComment = false;
+    // Whether `current` holds SQL outside comments. Neither bun:sqlite nor
+    // better-sqlite3 can prepare a comment-only statement, so skip those.
+    let hasCode = false;
+    const flush = (): void => {
+      const trimmed = current.trim();
+      if (hasCode && trimmed) this.#raw.prepare(trimmed).run();
+      current = "";
+      hasCode = false;
+    };
     for (let i = 0; i < sql.length; i++) {
       const ch = sql[i];
-      if (inString) {
+      const next = sql[i + 1];
+      if (inLineComment) {
+        current += ch;
+        if (ch === "\n" || ch === "\r") inLineComment = false;
+      } else if (inBlockComment) {
+        current += ch;
+        if (ch === "*" && next === "/") {
+          current += next;
+          i++;
+          inBlockComment = false;
+        }
+      } else if (inString) {
         current += ch;
         if (ch === inString) inString = null;
       } else if (ch === "'" || ch === '"') {
         current += ch;
         inString = ch;
+        hasCode = true;
+      } else if (ch === "-" && next === "-") {
+        current += ch + next;
+        i++;
+        inLineComment = true;
+      } else if (ch === "/" && next === "*") {
+        current += ch + next;
+        i++;
+        inBlockComment = true;
       } else if (ch === ";") {
-        const trimmed = current.trim();
-        if (trimmed) this.#raw.prepare(trimmed).run();
-        current = "";
+        flush();
       } else {
         current += ch;
+        // Every SQL whitespace character is at or below U+0020.
+        if (ch.charCodeAt(0) > 32) hasCode = true;
       }
     }
-    const trimmed = current.trim();
-    if (trimmed) this.#raw.prepare(trimmed).run();
+    flush();
     return this;
   }
 

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -702,6 +702,32 @@ describe("bun:sqlite adapter (#45)", () => {
     db.close();
   });
 
+  test("exec: adapter.exec() ignores ; and quotes inside SQL comments", async () => {
+    const { BunSQLiteAdapter } = await import("../../src/db-base.js");
+    const fake = await createBunLikeFake();
+    const db = new BunSQLiteAdapter(fake);
+    db.exec(`
+      CREATE TABLE t1 (id INTEGER PRIMARY KEY);
+      -- don't add the index yet; revisit later
+      CREATE TABLE t2 (id INTEGER PRIMARY KEY);
+      /* it's staged; ship next release */
+      CREATE TABLE t3 (id INTEGER PRIMARY KEY);
+    `);
+    const rows = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all() as { name: string }[];
+    expect(rows.map((r) => r.name)).toEqual(["t1", "t2", "t3"]);
+    db.close();
+  });
+
+  test("exec: adapter.exec() skips comment-only statements", async () => {
+    const { BunSQLiteAdapter } = await import("../../src/db-base.js");
+    const fake = await createBunLikeFake();
+    const db = new BunSQLiteAdapter(fake);
+    expect(() => db.exec("-- migration header\n/* nothing to do */;")).not.toThrow();
+    db.close();
+  });
+
   test("get: adapter.prepare().get() returns undefined not null for missing row", async () => {
     const { BunSQLiteAdapter } = await import("../../src/db-base.js");
     const fake = await createBunLikeFake();


### PR DESCRIPTION
## What / Why / How

`BunSQLiteAdapter.exec()` splits multi-statement SQL on `;` because bun:sqlite
accepts one statement per call. The scanner tracked string literals but not
comments, so a `;`, `'`, or `"` inside a comment was read as SQL.

Two failures follow from that:

- A `;` inside a comment ends the statement early and leaves a fragment holding
  only a comment. Neither bun:sqlite nor better-sqlite3 can prepare that, so
  `exec()` throws `The supplied SQL string contains no statements`.
- An apostrophe inside a comment opens a string literal that never closes, so
  the real `;` is consumed and the following statements reach `prepare()` as one
  string. That throws `The supplied SQL string contains more than one statement`.

In both cases the remaining statements never run, so a migration stops partway
through and the caller sees a SQLite parse error rather than the real cause.

The scanner now tracks `--` line comments and `/* */` block comments, and skips
a fragment that carries no SQL outside its comments. No new dependency, no
behavior change for comment-free SQL.

The schema SQL shipped today is comment-free, so this is latent rather than a
live user report. Adding one commented-out line to `#initSchema()` in
`src/store.ts` is enough to trigger it.

Reproduction on `next`, driving `BunSQLiteAdapter` over a real SQLite engine the
same way `tests/core/cli.test.ts` does:

```
### apostrophe in comment + 2 following statements
  error   : The supplied SQL string contains more than one statement
  tables  : ["a"]
  expected: ["a","b","c"]

### semicolon in comment
  error   : The supplied SQL string contains no statements
  tables  : ["d"]
  expected: ["d","e"]
```

## Affected platforms

- [x] All platforms

Runtime-level, not platform-level: it affects every host that resolves SQLite
through `BunSQLiteAdapter`, which is the Bun path in `loadDatabase()`.

## Test plan

Two tests added to the existing `describe("bun:sqlite adapter (#45)")` block in
`tests/core/cli.test.ts`, per the "do NOT create new test files" rule:

- `exec: adapter.exec() ignores ; and quotes inside SQL comments` — a three
  statement script with an apostrophe and a `;` in both a line comment and a
  block comment; asserts all three tables exist.
- `exec: adapter.exec() skips comment-only statements` — asserts a comment-only
  input does not throw.

Red/green confirmed on this branch:

```
# without the src change
Tests  2 failed | 9 passed | 211 skipped (222)
# with the src change
Tests  11 passed | 211 skipped (222)
```

`npx tsc --noEmit` exits 0.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)

Notes on the checklist: no docs change, the fix is internal to the adapter. No
paths touched. I ran `tests/core/cli.test.ts` and `tsc --noEmit`, not the full
suite. Bundles are left alone since `.github/workflows/bundle.yml` regenerates
and commits them on push to `main`.
