### PR TITLE
fix(pi): remove unverified tool-availability routing anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+Changes are recorded using Keep a Changelog categories. Package versions follow Semantic Versioning; the current released version is recorded in `package.json`.
+
+## [Unreleased]
+
+### Fixed
+
+- Pi no longer injects an unconditional `context-mode active` claim or mandatory tool hierarchy into model context. Tool registration, routing enforcement, active memory and resume handling remain unchanged.
+- Pi context-injection tests distinguish tool availability from bridge results and verify preserved memory with actual memory content rather than the removed routing message.

--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -602,7 +602,7 @@ export default function piExtension(pi: any): void {
     }
   });
 
-  // ── 4. before_agent_start — Routing + active_memory + resume injection ─
+  // ── 4. before_agent_start — active_memory + resume injection ─
 
   pi.on("before_agent_start", async (event: any, ctx: any) => {
     try {
@@ -649,18 +649,6 @@ export default function piExtension(pi: any): void {
       const existingPrompt = String(event?.systemPrompt ?? "");
       const parts: string[] = [];
       if (existingPrompt) parts.push(existingPrompt);
-
-      // Pi-1: Lightweight routing anchor — 7KB routing block is too heavy
-      // for Pi's context budget. Tool descriptions from pi.registerTool()
-      // already tell the model what each tool does. This anchor gives the
-      // deliberate choice (which tool for which scenario) without the full
-      // block/redirect/memory/tool-selection hierarchy.
-      parts.push(
-        "context-mode active. Hierarchy: ctx_batch_execute > ctx_execute > ctx_execute_file > ctx_search. " +
-        "Read/edit files → ctx_execute_file. Multi-command research → ctx_batch_execute. " +
-        "Web pages → ctx_fetch_and_index then ctx_search. Index docs → ctx_index. " +
-        "Stats → ctx_stats. Doctor → ctx_doctor. Upgrade → ctx_upgrade. Purge → ctx_purge."
-      );
 
       // Pi-3 + Pi-4: Always build active_memory (not just post-compact),
       // capped at 500 tokens via buildAutoInjection. Falls back to inline
@@ -715,7 +703,7 @@ export default function piExtension(pi: any): void {
         db.markResumeConsumed(_sessionId);
       }
 
-      // Store extra context (routing anchor, active_memory, resume, behavioralDirective)
+      // Store extra context (active_memory and resume)
       // for injection via the 'context' hook as a message, NOT as a systemPrompt
       // modification. Mutating systemPrompt breaks prefix prompt caching on
       // DeepSeek/Anthropic/OpenAI because the system message sits at messages[0]
@@ -733,7 +721,7 @@ export default function piExtension(pi: any): void {
     }
   });
 
-  // ── 4a2. context — Inject active_memory + resume + behavioralDirective as message ──
+  // ── 4a2. context — Inject active_memory + resume as message ──
   // Uses the 'context' hook (like hindsight does) to append context at the END of
   // messages rather than mutating systemPrompt at the beginning. This preserves
   // prefix prompt cache for DeepSeek, Anthropic, and OpenAI.

--- a/tests/pi-extension.test.ts
+++ b/tests/pi-extension.test.ts
@@ -725,7 +725,7 @@ describe("Pi Extension", () => {
       expect(messages[2].role).toBe("user");
 
       const trailing = String(messages[2].content);
-      expect(trailing).toContain("context-mode active");
+      expect(trailing).not.toContain("context-mode active");
       expect(trailing).toContain("session_resume");
       expect(trailing).toContain("how_to_search");
       expect(trailing).not.toContain("Stable system prompt.");
@@ -900,45 +900,59 @@ describe("Pi Extension", () => {
   // Slice 7: Pi-1 lightweight routing anchor injection
   // ═══════════════════════════════════════════════════════════
 
-  describe("Slice 7: Routing block injection", () => {
-    it("injects lightweight routing anchor via context hook on first before_agent_start", async () => {
+  describe("Slice 7: Routing availability claims", () => {
+    for (const scenario of [
+      { name: "failed bootstrap", fail: true, tools: [] },
+      { name: "an empty tool list", fail: false, tools: [] },
+      { name: "tool names without host admission evidence", fail: false, tools: ["ctx_execute"] },
+    ]) {
+      it(`does not announce availability after ${scenario.name}`, async () => {
+        const bridgeMod = await import("../src/adapters/pi/mcp-bridge.js");
+        const bootstrap = vi.spyOn(bridgeMod, "bootstrapMCPTools").mockImplementation(async () => {
+          if (scenario.fail) throw new Error("fixture bootstrap failure");
+          return { tools: scenario.tools, shutdown: vi.fn() } as any;
+        });
+        const diagnostic = vi.fn();
+        const diagnostics = vi.spyOn(bridgeMod, "makeBridgeDiag").mockReturnValue(diagnostic);
+        try {
+          await registerPiExtension(api);
+          await api._trigger("session_start", {}, {
+            sessionManager: { getSessionFile: () => join(tempDir, "routing-availability.jsonl") },
+          });
+          const result = await api._trigger("before_agent_start", { systemPrompt: "Base prompt." });
+          expect(result).toBeUndefined();
+          expect(bootstrap).toHaveBeenCalledTimes(1);
+          if (scenario.fail) expect(diagnostic).toHaveBeenCalledTimes(1);
+
+          const messages = [{ role: "system", content: "Base prompt." }];
+          const ctxResult = await api._trigger("context", { messages });
+          expect(ctxResult).toBeUndefined();
+          expect(messages).toEqual([{ role: "system", content: "Base prompt." }]);
+        } finally {
+          try {
+            await api._trigger("session_shutdown", {});
+          } finally {
+            bootstrap.mockRestore();
+            diagnostics.mockRestore();
+          }
+        }
+      });
+    }
+
+    it("does not add availability-only context on later turns", async () => {
       await registerPiExtension(api);
       await api._trigger("session_start", {}, {
-        sessionManager: { getSessionFile: () => `routing-1-${Date.now()}-${Math.random()}` },
+        sessionManager: { getSessionFile: () => join(tempDir, "routing-later-turns.jsonl") },
       });
-
-      // before_agent_start sets _pendingContext (was previously modifying systemPrompt)
-      await api._trigger("before_agent_start", {
-        systemPrompt: "Base prompt.",
-      });
-
-      // context hook now injects the routing anchor as a user message at message end
-      const messages: any[] = [];
-      const ctxResult = await api._trigger("context", { messages });
-
-      expect(ctxResult?.messages).toBeDefined();
-      expect(ctxResult.messages.length).toBe(1);
-      expect(ctxResult.messages[0].role).toBe("user");
-      expect(ctxResult.messages[0].content).toContain("context-mode active");
-      expect(ctxResult.messages[0].content).toContain("ctx_batch_execute > ctx_execute > ctx_execute_file");
-    });
-
-    it("re-injects the anchor via context hook on every subsequent call", async () => {
-      await registerPiExtension(api);
-      await api._trigger("session_start", {}, {
-        sessionManager: { getSessionFile: () => `routing-2-${Date.now()}-${Math.random()}` },
-      });
-
-      // Unlike Claude Code where the SessionStart hook persists context for the whole
-      // session, Pi rebuilds context fresh every turn. The anchor must reach the LLM
-      // on every call or the LLM loses MCP tool awareness after turn 1.
-      const ANCHOR = "context-mode active";
-
-      for (let call = 0; call < 3; call++) {
-        await api._trigger("before_agent_start", { systemPrompt: "Base." });
-        const ctxResult = await api._trigger("context", { messages: [] });
-        expect(ctxResult?.messages).toBeDefined();
-        expect(ctxResult.messages[0]?.content).toContain(ANCHOR);
+      try {
+        for (let call = 0; call < 3; call++) {
+          await api._trigger("before_agent_start", { systemPrompt: "Base." });
+          const messages: any[] = [];
+          expect(await api._trigger("context", { messages })).toBeUndefined();
+          expect(messages).toEqual([]);
+        }
+      } finally {
+        await api._trigger("session_shutdown", {});
       }
     });
   });
@@ -984,65 +998,53 @@ describe("Pi Extension", () => {
   // ═══════════════════════════════════════════════════════════
 
   describe("Slice 9: active_memory injection", () => {
-    it("injects context every turn via context hook even when compact_count is 0", async () => {
+    it("injects active memory on later turns even when compact_count is 0", async () => {
       await registerPiExtension(api);
-      await api._trigger("session_start", {
-        sessionManager: { getSessionFile: () => `active-mem-1-${Date.now()}-${Math.random()}` },
+      await api._trigger("session_start", {}, {
+        sessionManager: { getSessionFile: () => join(tempDir, "active-memory.jsonl") },
       });
-
-      // Seed user prompt with role pattern (priority 3).
-      await api._trigger("before_agent_start", {
-        prompt: "You are a senior staff engineer reviewing this codebase.",
-        systemPrompt: "Base.",
-      });
-
-      // Second call rebuilds context (always-on, not just post-compaction).
-      await api._trigger("before_agent_start", {
-        systemPrompt: "Base 2.",
-      });
-
-      // context hook injects the pending context as a user message
-      const ctxResult = await api._trigger("context", { messages: [] });
-
-      expect(ctxResult?.messages).toBeDefined();
-      expect(ctxResult.messages.length).toBe(1);
-      expect(ctxResult.messages[0].role).toBe("user");
-      // The always-on injection path fires every turn — the routing anchor
-      // proves context reaches the model even with compact_count 0.
-      const content = String(ctxResult.messages[0].content);
-      expect(content).toContain("context-mode active");
-      // Issue #856 — the role MUST NOT be pinned as a standing directive.
-      expect(content).not.toContain("<behavioral_directive>");
+      const events = vi.spyOn(SessionDB.prototype, "getEvents").mockReturnValue([
+        { type: "decision", category: "decision", data: "MEMORY_MARKER", priority: 4 },
+      ] as any);
+      try {
+        for (let turn = 0; turn < 2; turn++) {
+          await api._trigger("before_agent_start", { systemPrompt: "Base." });
+          const ctxResult = await api._trigger("context", { messages: [] });
+          expect(ctxResult?.messages).toHaveLength(1);
+          expect(ctxResult.messages[0].role).toBe("user");
+          const content = String(ctxResult.messages[0].content);
+          expect(content).toContain("MEMORY_MARKER");
+          expect(content).not.toContain("context-mode active");
+          expect(content).not.toContain("<behavioral_directive>");
+        }
+      } finally {
+        events.mockRestore();
+      }
     });
 
-    it("caps active_memory at ≤ 2000 characters (via context hook)", async () => {
+    it("keeps active-memory output bounded with real memory content", async () => {
       await registerPiExtension(api);
-      await api._trigger("session_start", {
-        sessionManager: { getSessionFile: () => `active-mem-2-${Date.now()}-${Math.random()}` },
+      await api._trigger("session_start", {}, {
+        sessionManager: { getSessionFile: () => join(tempDir, "bounded-memory.jsonl") },
       });
-
-      // Flood with very long role-pattern prompts (priority 3).
-      const longText = "You are a senior staff engineer. " + "x".repeat(500);
-      for (let i = 0; i < 20; i++) {
-        await api._trigger("before_agent_start", {
-          prompt: `${longText} #${i}`,
-          systemPrompt: "Base.",
-        });
+      // Use decision rows, not filtered role rows or the routing anchor, to
+      // exercise the existing memory budget and prevent a vacuous size check.
+      const events = vi.spyOn(SessionDB.prototype, "getEvents").mockReturnValue(
+        Array.from({ length: 20 }, (_, i) => ({
+          type: "decision", category: "decision", priority: 4,
+          data: `BUDGET_MARKER_${i} ` + "x".repeat(500),
+        })) as any,
+      );
+      try {
+        await api._trigger("before_agent_start", { systemPrompt: "Base." });
+        const ctxResult = await api._trigger("context", { messages: [] });
+        const content = String(ctxResult?.messages?.[0]?.content ?? "");
+        expect(content).toContain("BUDGET_MARKER_");
+        expect(content).not.toContain("<behavioral_directive>");
+        expect(content.length).toBeLessThanOrEqual(2200);
+      } finally {
+        events.mockRestore();
       }
-
-      await api._trigger("before_agent_start", {
-        systemPrompt: "Base final.",
-      });
-
-      const ctxResult = await api._trigger("context", { messages: [] });
-      const content = String(ctxResult?.messages?.[0]?.content ?? "");
-      // Issue #856 — flooding with role prompts must NOT accumulate any
-      // behavioral_directive, and the per-turn injection must stay bounded
-      // (it is now just the routing anchor; roles are filtered out entirely).
-      expect(content).not.toContain("<behavioral_directive>");
-      // Bounded: the anchor block is small and fixed — 20 × 500-char role
-      // prompts cannot blow the per-turn injection past the cap.
-      expect(content.length).toBeLessThanOrEqual(2200);
     });
   });
 
@@ -1076,27 +1078,25 @@ describe("Pi Extension", () => {
       expect(content).not.toContain("<behavioral_directive>");
     });
 
-    it("is surgical: drops the role directive but keeps the rest of the injection (routing anchor)", async () => {
+    it("drops stored roles while preserving decision memory", async () => {
       await registerPiExtension(api);
-      const sessionFile = `role-filter-surgical-${Date.now()}-${Math.random()}`;
-      await api._trigger("session_start", {
-        sessionManager: { getSessionFile: () => sessionFile },
+      await api._trigger("session_start", {}, {
+        sessionManager: { getSessionFile: () => join(tempDir, "role-filter-surgical.jsonl") },
       });
-
-      await api._trigger("before_agent_start", {
-        prompt: "You are a senior staff engineer reviewing this codebase.",
-        systemPrompt: "Base.",
-      });
-      await api._trigger("before_agent_start", { systemPrompt: "Base 2." });
-      const ctxResult = await api._trigger("context", { messages: [] });
-      const content = String(ctxResult?.messages?.[0]?.content ?? "");
-
-      // Role filtered out…
-      expect(content).not.toContain("<behavioral_directive>");
-      // …but injection itself is NOT disabled — the always-on routing anchor
-      // still reaches the model every turn (filter is role-specific, not a
-      // blanket drop of the whole context injection).
-      expect(content).toContain("context-mode active");
+      const events = vi.spyOn(SessionDB.prototype, "getEvents").mockReturnValue([
+        { type: "role", category: "role", data: "EXCLUDED_ROLE_MARKER", priority: 3 },
+        { type: "decision", category: "decision", data: "PRESERVED_DECISION_MARKER", priority: 4 },
+      ] as any);
+      try {
+        await api._trigger("before_agent_start", { systemPrompt: "Base." });
+        const ctxResult = await api._trigger("context", { messages: [] });
+        const content = String(ctxResult?.messages?.[0]?.content ?? "");
+        expect(content).not.toContain("<behavioral_directive>");
+        expect(content).not.toContain("EXCLUDED_ROLE_MARKER");
+        expect(content).toContain("PRESERVED_DECISION_MARKER");
+      } finally {
+        events.mockRestore();
+      }
     });
   });
 


### PR DESCRIPTION
## What / Why / How

Draft alternative to #1122. That PR reduces repetition to once per session; this draft addresses the different problem that the availability claim can be incorrect even on the first turn. The two changes overlap and should be reviewed together, not merged independently.

`before_agent_start` awaits a best-effort MCP bootstrap that also settles after a handled failure or missing server bundle. It then unconditionally injects `context-mode active` and a mandatory tool hierarchy. A returned list of tool names is also not evidence that an additional host policy will authorize their invocation.

This change removes that one routing statement and updates its nearby comments. It does **not** change MCP bootstrap/registration, tool definitions, `tool_call` enforcement, permissions, active-memory construction or resume handling. It adds an Unreleased changelog entry without changing package versions or generated bundles.

### Controlled source-fixture example — not a live client transcript

Before, with failed bootstrap and no memory/resume, the context consumer appends this user message:

```text
context-mode active. Hierarchy: ctx_batch_execute > ctx_execute > ctx_execute_file > ctx_search. Read/edit files → ctx_execute_file. Multi-command research → ctx_batch_execute. Web pages → ctx_fetch_and_index then ctx_search. Index docs → ctx_index. Stats → ctx_stats. Doctor → ctx_doctor. Upgrade → ctx_upgrade. Purge → ctx_purge.
```

After, that fixture's message array is unchanged. Memory and resume fixtures still append their actual content; the system prompt is not duplicated.

The tradeoff is deliberate: no per-turn routing recommendation is injected by this statement. Published tool descriptions and other existing configuration remain available. There is no replacement availability registry or permission exception.

## Affected platforms

- [x] Pi
- [ ] Other adapters — no changes

## Test plan

Updated the existing `tests/pi-extension.test.ts` rather than adding another test file:

- Controlled failed-bootstrap, empty-tool-list and returned-tool-name cases assert that no availability-only context is appended.
- Later turns must not recreate the removed instruction.
- Resume tests retain their positive content checks while rejecting the availability claim.
- Memory tests use actual decision rows instead of treating the routing anchor as proof of memory delivery.
- Role filtering must preserve decision content, and the memory-size check must be non-vacuous.

Supplementary local diagnostics against the reviewed TypeScript source regions, using Node v24.18.0 and fake dependencies: **14 cases; original 9 pass/5 named failures; candidate 14 pass; reinserting the production routing block reproduces the same 5 failures; restored candidate 14 pass.** Three separate fixture-compatibility checks against the unchanged memory builder also pass. These diagnostics are outside this PR and are **not the native Vitest suite or live-client verification**.

Syntax checks of both changed TypeScript files and `git diff --check` pass. **Vitest, project typechecking, the full package build and live-client verification have not been run locally.** Local dependency installation/client activation was outside the approved scope; no installed plugin or client configuration was changed. This draft needs CI and maintainer review, then an authorized native-client test before any readiness claim.

## Checklist

- [x] Tests added/updated; supplementary source-region RED → GREEN → producer-mutation RED → restored GREEN performed
- [ ] `npm test` passes — NOT_RUN locally; CI pending
- [ ] `npm run typecheck` passes — NOT_RUN locally; CI pending
- [x] Changelog updated
- [x] No new platform-specific path construction; test paths use `join`
- [x] Targets `next`
- [ ] Native client loop and receiver-observed output verified

No merge, installation or release is requested by this draft.
