### PR TITLE
feat(server): make echo budgets configurable per host

### DIFF
--- a/README.md
+++ b/README.md
@@ -1605,6 +1605,15 @@ That blocks loopback + RFC1918 + ULA in addition to the always-blocked ranges. U
 |---|---|---|
 | `CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY` | `10` | Cadence (in tool calls) at which the PreToolUse hook re-injects the "wrap large external-MCP payloads in `ctx_execute`" guidance. The original implementation ([#529](https://github.com/mksglu/context-mode/pull/529)) fired only once per session, which got lost after context compaction in MCP-heavy sessions (e.g. 50+ Jira/Slack/Notion calls — see [#567](https://github.com/mksglu/context-mode/issues/567) follow-up). The default re-fires every 10th matching call, keeping the guidance in the model's recent window. Range `[1, 100]`; invalid values fall back to `10`. Set to `1` for "every call" (most aggressive — adds ~250 tokens/call) or to a larger value for less frequent reminders. |
 
+### Command and code echo environment variables
+
+`ctx_execute` / `ctx_execute_file` prepend the source code they ran, and `ctx_batch_execute` echoes each `$ <command>` plus a `## Commands` inventory ([#717](https://github.com/mksglu/context-mode/issues/717), [#736](https://github.com/mksglu/context-mode/issues/736)). Hosts whose UI does not render the MCP tool input need that echo to see what the agent ran. Hosts that do render it carry the payload twice. These variables let the latter trim or drop the echo. Unset, output is unchanged on every host.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CONTEXT_MODE_CODE_ECHO_MAX` | `2000` | Character budget for the fenced source block from `ctx_execute` / `ctx_execute_file`. `0` suppresses it. Only a run of digits is accepted; empty, whitespace-only, negative and non-numeric values keep the default. The full code always reaches the sandbox; only the echo is clipped. |
+| `CONTEXT_MODE_COMMAND_ECHO_MAX` | `500` | Character budget for the `$ <command>` line in each `ctx_batch_execute` section and each `## Commands` entry. `0` suppresses both. Same parsing rules as above. Note the `$ <command>` line is part of the indexed section text, so `0` also drops it from the FTS5 index and later `ctx_search` hits will not show what ran. |
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow and TDD guidelines.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1463,13 +1463,33 @@ export function buildBatchNodeOptionsPrefix(shellPath: string, preloadPath: stri
  * Per-section budget for the echoed `$ <command>` line so a 50KB heredoc
  * payload cannot dominate the response body. The full command always reaches
  * the executor — only the echo is clipped (Issues #717 + #736).
+ *
+ * Tunable via CONTEXT_MODE_COMMAND_ECHO_MAX. Hosts that already render the
+ * tool input alongside the result show the command twice, so `0` drops the
+ * echo for them; every other host keeps the default.
  */
-const COMMAND_ECHO_MAX = 500;
+export const DEFAULT_COMMAND_ECHO_MAX = 500;
 
-function truncateCommandForEcho(command: string): string {
+/**
+ * Read an echo budget from the environment. Unlike readPositiveEnv, `0` is a
+ * meaningful value (echo suppressed), so the parse is strict: only a run of
+ * digits counts. Empty, whitespace-only, negative and non-numeric input falls
+ * back to the default rather than silently suppressing the echo.
+ */
+function resolveEchoBudget(name: string, defaultValue: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw || !/^\d+$/.test(raw)) return defaultValue;
+  return Number(raw);
+}
+
+function commandEchoBudget(): number {
+  return resolveEchoBudget("CONTEXT_MODE_COMMAND_ECHO_MAX", DEFAULT_COMMAND_ECHO_MAX);
+}
+
+function truncateCommandForEcho(command: string, budget: number): string {
   const cleaned = command.replace(/\s+/g, " ").trim();
-  if (cleaned.length <= COMMAND_ECHO_MAX) return cleaned;
-  return cleaned.slice(0, COMMAND_ECHO_MAX) + "…";
+  if (cleaned.length <= budget) return cleaned;
+  return cleaned.slice(0, budget) + "…";
 }
 
 /**
@@ -1497,22 +1517,31 @@ export function resolveExecTimeout(timeout: number | undefined): number | undefi
  * sandbox — only the echo is clipped so massive payloads don't dominate
  * the response. Multi-line preserved (unlike command echo) so the user
  * sees the actual program shape.
+ *
+ * Tunable via CONTEXT_MODE_CODE_ECHO_MAX — see DEFAULT_COMMAND_ECHO_MAX.
  */
-const CODE_ECHO_MAX = 2000;
+export const DEFAULT_CODE_ECHO_MAX = 2000;
 
-function truncateCodeForEcho(code: string): string {
-  if (code.length <= CODE_ECHO_MAX) return code;
-  return code.slice(0, CODE_ECHO_MAX) + "\n… (truncated)";
+function codeEchoBudget(): number {
+  return resolveEchoBudget("CONTEXT_MODE_CODE_ECHO_MAX", DEFAULT_CODE_ECHO_MAX);
+}
+
+function truncateCodeForEcho(code: string, budget: number): string {
+  if (code.length <= budget) return code;
+  return code.slice(0, budget) + "\n… (truncated)";
 }
 
 /**
  * Build the source-code preamble surfaced before tool stdout. Provenance
  * survives in indexed chunks (FTS5 sees the fenced block) so later
- * ctx_search hits remember what ran.
+ * ctx_search hits remember what ran. A zero budget drops the preamble for
+ * hosts that already render the tool input.
  */
 function buildExecuteEcho(language: string, code: string, path?: string): string {
+  const budget = codeEchoBudget();
+  if (budget === 0) return "";
   const header = path ? `path=${path}\n` : "";
-  const fenced = `\`\`\`${language}\n${truncateCodeForEcho(code)}\n\`\`\``;
+  const fenced = `\`\`\`${language}\n${truncateCodeForEcho(code, budget)}\n\`\`\``;
   return `${header}${fenced}\n\n`;
 }
 
@@ -1528,8 +1557,9 @@ function formatCommandOutput(label: string, command: string, raw: string, onFsBy
   // Echo the executed command below the section heading so per-chunk
   // indexed content retains provenance for later ctx_search hits
   // (Issues #717 + #736).
-  const echoed = truncateCommandForEcho(command);
-  return `# ${label}\n\n$ ${echoed}\n\n${output}\n`;
+  const budget = commandEchoBudget();
+  const echo = budget === 0 ? "" : `$ ${truncateCommandForEcho(command, budget)}\n\n`;
+  return `# ${label}\n\n${echo}${output}\n`;
 }
 
 function combineExecOutput(result: { stdout?: string; stderr?: string }): string {
@@ -4306,9 +4336,14 @@ EXAMPLE: ctx_batch_execute(
       // response itself documents intent, not just per-section echoes.
       // Placed before "## Indexed Sections" so it scans top-down with
       // the human asking "what just happened" (Issues #717 + #736).
-      const commandsInventory: string[] = ["## Commands", ""];
-      for (const c of commands) {
-        commandsInventory.push(`- ${c.label}: \`${truncateCommandForEcho(c.command)}\``);
+      const commandEchoMax = commandEchoBudget();
+      const commandsInventory: string[] = [];
+      if (commandEchoMax > 0) {
+        commandsInventory.push("## Commands", "");
+        for (const c of commands) {
+          commandsInventory.push(`- ${c.label}: \`${truncateCommandForEcho(c.command, commandEchoMax)}\``);
+        }
+        commandsInventory.push("");
       }
 
       // Build section inventory — direct query by source_id (no FTS5 MATCH needed)
@@ -4337,7 +4372,6 @@ EXAMPLE: ctx_batch_execute(
           `Indexed ${indexed.totalChunks} sections. Searched ${queries.length} queries.`,
         "",
         ...commandsInventory,
-        "",
         ...inventory,
         "",
         ...queryResults,

--- a/tests/core/echo-commands.test.ts
+++ b/tests/core/echo-commands.test.ts
@@ -16,10 +16,15 @@
  *      code before stdout
  *   5. ctx_execute_file prepends a header naming the path + a fenced
  *      `${language}` block carrying the source code before stdout
+ *   6. ctx_batch_execute summary lists every command in a "## Commands"
+ *      inventory placed before "## Indexed Sections"
+ *   7. Both echo budgets are tunable via CONTEXT_MODE_COMMAND_ECHO_MAX /
+ *      CONTEXT_MODE_CODE_ECHO_MAX; `0` suppresses the echo for hosts that
+ *      already render the tool input, invalid values keep the default
  *
  * Tests 1-3 hit the pure runBatchCommands/formatCommandOutput surface (fast,
- * no spawn). Tests 4-5 hit the live MCP server over JSON-RPC (covers the
- * tool handler wiring end-to-end).
+ * no spawn). Tests 4-6 hit the live MCP server over JSON-RPC (covers the
+ * tool handler wiring end-to-end). Behaviour 7 spans both harnesses.
  *
  * Run: npx vitest run tests/core/echo-commands.test.ts
  */
@@ -29,9 +34,10 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
 
 import {
+  DEFAULT_COMMAND_ECHO_MAX,
   runBatchCommands,
   type BatchCommand,
 } from "../../src/server.js";
@@ -310,6 +316,158 @@ describe("issue #717 — ctx_execute_file echoes the path + code it ran", () => 
       // Stdout still arrives, AFTER the echo
       expect(text).toContain(marker);
       expect(text.indexOf("```javascript")).toBeLessThan(text.indexOf(marker));
+    } finally {
+      try { proc.kill("SIGTERM"); } catch { /* best effort */ }
+    }
+  }, 30_000);
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// Behaviour 7 — echo budgets are tunable per host. Issues #717/#736 came from
+//               Pi and OpenCode, whose UIs do not render the MCP tool input,
+//               so the echo is the only way to see what ran. Hosts that DO
+//               render the input carry the code twice, once as tool_input and
+//               once in the result. CONTEXT_MODE_CODE_ECHO_MAX /
+//               CONTEXT_MODE_COMMAND_ECHO_MAX let those hosts opt out without
+//               changing the default anywhere else.
+// ════════════════════════════════════════════════════════════════════════════
+describe("echo budgets honour CONTEXT_MODE_COMMAND_ECHO_MAX", () => {
+  const original = process.env.CONTEXT_MODE_COMMAND_ECHO_MAX;
+  afterEach(() => {
+    if (original === undefined) delete process.env.CONTEXT_MODE_COMMAND_ECHO_MAX;
+    else process.env.CONTEXT_MODE_COMMAND_ECHO_MAX = original;
+  });
+
+  async function runOne(command: string): Promise<string> {
+    const exec = mkMockExecutor(() => ({ stdout: "STDOUT-MARKER\n" }));
+    const { outputs } = await runBatchCommands(
+      [{ label: "probe", command }],
+      { timeout: 5000, concurrency: 1, nodeOptsPrefix: NOOP_PREFIX },
+      exec,
+    );
+    return outputs[0];
+  }
+
+  test("0 drops the `$ <command>` line but keeps the heading and stdout", async () => {
+    process.env.CONTEXT_MODE_COMMAND_ECHO_MAX = "0";
+    const section = await runOne("git status --short");
+    expect(section).toContain("# probe");
+    expect(section).toContain("STDOUT-MARKER");
+    expect(section).not.toContain("$ git status --short");
+    expect(section.split("\n").some((l) => l.startsWith("$ "))).toBe(false);
+  });
+
+  test("a smaller budget clips the echo at that length", async () => {
+    process.env.CONTEXT_MODE_COMMAND_ECHO_MAX = "10";
+    const section = await runOne("git log --all --grep='niri' --regexp-ignore-case");
+    const dollarLine = section.split("\n").find((l) => l.startsWith("$ "))!;
+    expect(dollarLine).toBe("$ git log --…");
+  });
+
+  test("non-numeric, negative, whitespace and non-decimal values fall back to the default", async () => {
+    const command = "x".repeat(600);
+    // " " matters most: Number(" ") is 0, so a lax parse would silently
+    // suppress the echo instead of keeping the documented default.
+    for (const bad of ["nope", "-1", "1.5", " ", "\t", "1e3", "0x10"]) {
+      process.env.CONTEXT_MODE_COMMAND_ECHO_MAX = bad;
+      const dollarLine = (await runOne(command)).split("\n").find((l) => l.startsWith("$ "))!;
+      expect(dollarLine, `value ${JSON.stringify(bad)} should keep the default`)
+        .toHaveLength(2 + DEFAULT_COMMAND_ECHO_MAX + 1);
+    }
+  });
+
+  test("unset keeps the documented default", async () => {
+    delete process.env.CONTEXT_MODE_COMMAND_ECHO_MAX;
+    const section = await runOne("git status --short");
+    expect(section).toContain("$ git status --short");
+  });
+});
+
+describe("echo budgets honour CONTEXT_MODE_CODE_ECHO_MAX", () => {
+  let projectDir: string;
+  beforeAll(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "echo-budget-"));
+  });
+  afterAll(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  async function execWith(env: Record<string, string>, code: string): Promise<string> {
+    const proc = spawnServer({ CLAUDE_PROJECT_DIR: projectDir, ...env });
+    try {
+      await initServer(proc);
+      const resp = await awaitRpc(proc, 102, {
+        jsonrpc: "2.0", id: 102, method: "tools/call",
+        params: { name: "ctx_execute", arguments: { language: "javascript", code } },
+      });
+      expect(resp?.error).toBeUndefined();
+      return resp?.result?.content?.[0]?.text ?? "";
+    } finally {
+      try { proc.kill("SIGTERM"); } catch { /* best effort */ }
+    }
+  }
+
+  test("0 drops the fenced source block but keeps stdout", async () => {
+    const marker = `BUDGET-OFF-${Math.random().toString(36).slice(2)}`;
+    const code = `console.log("${marker}");`;
+    const text = await execWith({ CONTEXT_MODE_CODE_ECHO_MAX: "0" }, code);
+    expect(text).toContain(marker);
+    expect(text).not.toContain("```javascript");
+    expect(text).not.toContain(code);
+  }, 30_000);
+
+  test("a smaller budget clips the source block and marks the truncation", async () => {
+    const marker = `BUDGET-CLIP-${Math.random().toString(36).slice(2)}`;
+    const filler = "// ".concat("y".repeat(200));
+    const code = `${filler}\nconsole.log("${marker}");`;
+    const text = await execWith({ CONTEXT_MODE_CODE_ECHO_MAX: "40" }, code);
+    expect(text).toContain("```javascript");
+    expect(text).toContain("… (truncated)");
+    expect(text).not.toContain(code);
+    expect(text).toContain(marker);
+  }, 30_000);
+
+  test("an invalid value keeps the echo at the default budget", async () => {
+    const marker = `BUDGET-BAD-${Math.random().toString(36).slice(2)}`;
+    const code = `console.log("${marker}");`;
+    const text = await execWith({ CONTEXT_MODE_CODE_ECHO_MAX: " " }, code);
+    expect(text).toContain("```javascript");
+    expect(text).toContain(code);
+    expect(text).toContain(marker);
+  }, 30_000);
+});
+
+// Budget 0 must also drop the `## Commands` inventory from the
+// ctx_batch_execute summary, the one place this change touches output layout.
+describe("CONTEXT_MODE_COMMAND_ECHO_MAX=0 drops the batch Commands inventory", () => {
+  let projectDir: string;
+  beforeAll(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "echo-batch-off-"));
+  });
+  afterAll(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  test("summary keeps `## Indexed Sections` and stdout but carries no `## Commands`", async () => {
+    const proc = spawnServer({ CLAUDE_PROJECT_DIR: projectDir, CONTEXT_MODE_COMMAND_ECHO_MAX: "0" });
+    try {
+      await initServer(proc);
+      const resp = await awaitRpc(proc, 103, {
+        jsonrpc: "2.0", id: 103, method: "tools/call",
+        params: {
+          name: "ctx_batch_execute",
+          arguments: {
+            commands: [{ label: "alpha", command: "echo alpha-output" }],
+            queries: ["alpha"],
+          },
+        },
+      });
+      expect(resp?.error).toBeUndefined();
+      const text = resp?.result?.content?.[0]?.text ?? "";
+      expect(text).not.toContain("## Commands");
+      expect(text).not.toContain("$ echo alpha-output");
+      expect(text).toContain("## Indexed Sections");
+      expect(text).toContain("Executed 1 commands");
     } finally {
       try { proc.kill("SIGTERM"); } catch { /* best effort */ }
     }


### PR DESCRIPTION
## What / Why / How

`ctx_execute` / `ctx_execute_file` prepend the source code they ran, and `ctx_batch_execute` echoes each `$ <command>` plus a `## Commands` inventory (#717, #736). Both issues came from hosts that don't render the MCP tool input. Hosts that do render it carry the payload twice, once as `tool_input` and once in the result.

Adds `CONTEXT_MODE_CODE_ECHO_MAX` (default `2000`) and `CONTEXT_MODE_COMMAND_ECHO_MAX` (default `500`). `0` suppresses the echo. Non-integer and negative values keep the default.

Defaults are the existing constants, so output is unchanged wherever the vars are unset. Follows the `AGY_DEFAULT_EXEC_TIMEOUT_MS` / `resolveExecTimeout` pattern: exported default const plus a resolver reading `process.env` at call time. `resolveEchoBudget` is separate from `readPositiveEnv` because `0` is meaningful here.

## Affected platforms

- [x] All platforms

## Test plan

5 tests added to `tests/core/echo-commands.test.ts`, covering both vars: `0` suppresses, a smaller budget clips, non-integer/negative/`1.5` fall back to the default, unset keeps the default. Existing #717/#736 assertions unchanged and still passing.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes (210 files, 4724 passed, 24 skipped)
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)… bundles