### PR TITLE
Fix curl/wget pipe and multiline routing bounds

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -731,8 +731,10 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
     // curl/wget — allow silent file-output downloads, block stdout floods (#166).
     // Algorithm: split chained commands, evaluate each segment independently.
     if (/(^|\s|&&|\||\;)(curl|wget)\s/i.test(stripped)) {
-      // Split on chain operators (&&, ||, ;) to evaluate each segment
-      const segments = stripped.split(/\s*(?:&&|\|\||;)\s*/);
+      // Split on chain operators (&&, ||, ;, newline) and normalize escaped newlines first.
+      const segments = stripped
+        .replace(/\\\r?\n/g, " ")
+        .split(/\s*(?:&&|\|\||;|\r?\n)\s*/);
       const hasDangerousSegment = segments.some(seg => {
         const s = seg.trim();
         // Only evaluate segments that contain curl or wget
@@ -740,6 +742,17 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
 
         const isCurl = /\bcurl\b/i.test(s);
         const isWget = /\bwget\b/i.test(s);
+
+        // Pipe targets can be bounded by command substitutions such as head/jq/grep/wc.
+        const pipeStages = s.split("|").slice(1).map(x => x.trim()).filter(Boolean);
+        const isPassThroughPipeSink = stage => /^(cat|tee|less|more)\b/.test(stage);
+        const boundedByPipe = pipeStages.length > 0 && !pipeStages.every(isPassThroughPipeSink);
+
+        // Verbose/trace flags flood stderr even if piped.
+        if (/\s(-v|--verbose|--trace|-D\s+-)\b/.test(s)) return true;
+
+        // Bounded by a non-pass-through pipeline stage → allow through.
+        if (boundedByPipe) return false;
 
         // Check for file output flags
         const hasFileOutput = isCurl
@@ -751,9 +764,6 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
         // Stdout aliases: -o -, -o /dev/stdout, -O -
         if (isCurl && /\s(-o|--output)\s+(-|\/dev\/stdout)(\s|$)/.test(s)) return true;
         if (isWget && /\s(-O|--output-document)\s+(-|\/dev\/stdout)(\s|$)/.test(s)) return true;
-
-        // Verbose/trace flags flood stderr → context
-        if (/\s(-v|--verbose|--trace|-D\s+-)\b/.test(s)) return true;
 
         // Must be silent (curl: -s/--silent, wget: -q/--quiet) to prevent progress bar stderr flood
         const isSilent = isCurl

--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -744,8 +744,9 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
         const isWget = /\bwget\b/i.test(s);
 
         // Pipe targets can be bounded by command substitutions such as head/jq/grep/wc.
-        const pipeStages = s.split("|").slice(1).map(x => x.trim()).filter(Boolean);
-        const isPassThroughPipeSink = stage => /^(cat|tee|less|more)\b/.test(stage);
+        const pipeStages = s.split(/\|&?/).slice(1).map(x => x.trim()).filter(Boolean);
+        const isPassThroughPipeSink = stage =>
+          /^(?:&\s*)?(?:(?:command|builtin)\s+)?(?:\/?[^\s/]+\/)*(?:cat|tee|less|more)\b/.test(stage);
         const boundedByPipe = pipeStages.length > 0 && !pipeStages.every(isPassThroughPipeSink);
 
         // Verbose/trace flags flood stderr even if piped.

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -167,6 +167,64 @@ describe("routePreToolUse", () => {
       expect(result).toBeNull();
     });
 
+    it("allows curl | head on bounded output", () => {
+      const result = routePreToolUse("Bash", {
+        command: "curl -s https://example.com | head -c 200",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("allows curl | jq on bounded output", () => {
+      const result = routePreToolUse("Bash", {
+        command: "curl -s https://example.com | jq -r .name",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("allows curl | grep -c on bounded output", () => {
+      const result = routePreToolUse("Bash", {
+        command: "curl -s https://example.com | grep -c ok",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("allows curl | wc -l on bounded output", () => {
+      const result = routePreToolUse("Bash", {
+        command: "curl -s https://example.com | wc -l",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("blocks curl | cat because it is still unbounded", () => {
+      const result = routePreToolUse("Bash", {
+        command: "curl -s https://example.com | cat",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("modify");
+    });
+
+    it("allows backslash-continued piped curl command", () => {
+      const result = routePreToolUse("Bash", {
+        command: "curl -s https://example.com \\\n  | jq -r .name",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("allows multi-line curl output-bound and safe sibling commands", () => {
+      const result = routePreToolUse("Bash", {
+        command: "curl -s https://example.com -o /tmp/out.json\ncat /tmp/out.json",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("blocks multi-line block when a line has unbounded curl", () => {
+      const result = routePreToolUse("Bash", {
+        command: "curl https://example.com\ndate",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("modify");
+    });
+
     it("blocks curl -o - (stdout alias)", () => {
       const result = routePreToolUse("Bash", {
         command: "curl -s -o - https://example.com",

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -203,6 +203,30 @@ describe("routePreToolUse", () => {
       expect(result!.action).toBe("modify");
     });
 
+    it("blocks curl |& cat because it is still unbounded", () => {
+      const result = routePreToolUse("Bash", {
+        command: "curl -s https://example.com |& cat",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("modify");
+    });
+
+    it("blocks curl piped to an absolute-path cat", () => {
+      const result = routePreToolUse("Bash", {
+        command: "curl -s https://example.com | /bin/cat",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("modify");
+    });
+
+    it("blocks curl piped to cat through the shell builtin", () => {
+      const result = routePreToolUse("Bash", {
+        command: "curl -s https://example.com | command cat",
+      });
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("modify");
+    });
+
     it("allows backslash-continued piped curl command", () => {
       const result = routePreToolUse("Bash", {
         command: "curl -s https://example.com \\\n  | jq -r .name",


### PR DESCRIPTION
## Summary
- split curl/wget commands on newlines and escaped newlines as well as existing chain operators
- allow bounded pipeline sinks such as head, jq, grep, and wc while preserving unbounded/pass-through handling
- add regression coverage for curl pipelines, multiline commands, and backslash continuation

Fixes #1125

## Validation
- `npm run test -- tests/hooks/core-routing.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- targeted secret regex scan (clean)

Prettier is not configured in this repository, and `gitleaks` is unavailable in the local environment.