### PR TITLE
fix(hooks): pin ABI healing to the running Node

### DIFF
--- a/hooks/ensure-deps.mjs
+++ b/hooks/ensure-deps.mjs
@@ -20,8 +20,8 @@
  */
 
 import { existsSync, copyFileSync, renameSync, unlinkSync } from "node:fs";
-import { execSync } from "node:child_process";
-import { resolve, dirname } from "node:path";
+import { execFileSync, execSync } from "node:child_process";
+import { delimiter, resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
 
@@ -101,11 +101,15 @@ export async function ensureDeps() {
  */
 function probeNativeInChildProcess(pluginRoot) {
   try {
-    execSync(`node -e "new (require('better-sqlite3'))(':memory:').close()"`, {
-      cwd: pluginRoot,
-      stdio: "pipe",
-      timeout: 10000,
-    });
+    execFileSync(
+      process.execPath,
+      ["-e", "new (require('better-sqlite3'))(':memory:').close()"],
+      {
+        cwd: pluginRoot,
+        stdio: "pipe",
+        timeout: 10000,
+      },
+    );
     return true;
   } catch {
     return false;
@@ -195,6 +199,7 @@ export function ensureNativeCompat(pluginRoot) {
         stdio: "pipe",
         timeout: 60000,
         shell: true,
+        env: envWithRunningNodeFirst(),
       });
       codesignBinary(binaryPath);
       if (existsSync(binaryPath)) {
@@ -214,6 +219,7 @@ export function ensureNativeCompat(pluginRoot) {
         stdio: "pipe",
         timeout: 60000,
         shell: true,
+        env: envWithRunningNodeFirst(),
       });
       codesignBinary(binaryPath);
       if (existsSync(binaryPath) && probeNativeInChildProcess(pluginRoot)) {
@@ -223,6 +229,17 @@ export function ensureNativeCompat(pluginRoot) {
   } catch {
     /* best effort — caller will report the error on first DB access */
   }
+}
+
+function envWithRunningNodeFirst() {
+  const env = {};
+  // Windows treats environment keys case-insensitively. Remove any existing
+  // Path/PATH entry before adding one authoritative value for the child.
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.toLowerCase() !== "path") env[key] = value;
+  }
+  env.PATH = `${dirname(process.execPath)}${delimiter}${process.env.PATH ?? ""}`;
+  return env;
 }
 
 /**

--- a/tests/hooks/ensure-deps.test.ts
+++ b/tests/hooks/ensure-deps.test.ts
@@ -12,7 +12,14 @@
 
 import { describe, test, expect, afterAll } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -276,6 +283,83 @@ describe("ensure-deps: ABI cache validation (#148 follow-up)", () => {
     expect(actions).toEqual(["probe-fail", "rebuilt", "cached"]);
   });
 
+  test("ABI rebuild uses npm from the running Node installation instead of ambient PATH", () => {
+    const root = createTempRoot();
+    const fakeBin = join(root, "fake-bin");
+    const marker = join(root, "wrong-npm-ran");
+    const releaseDir = join(root, "node_modules", "better-sqlite3", "build", "Release");
+    mkdirSync(fakeBin, { recursive: true });
+    mkdirSync(releaseDir, { recursive: true });
+    writeFileSync(join(releaseDir, "better_sqlite3.node"), "not-a-native-binary");
+
+    const fakeNpm = join(fakeBin, process.platform === "win32" ? "npm.cmd" : "npm");
+    const fakeNpmSource = process.platform === "win32"
+      ? "@echo off\r\n> \"%FAKE_NPM_MARKER%\" echo called\r\nexit /b 0\r\n"
+      : "#!/bin/sh\nprintf called > \"$FAKE_NPM_MARKER\"\nexit 0\n";
+    writeFileSync(fakeNpm, fakeNpmSource, "utf-8");
+    if (process.platform !== "win32") chmodSync(fakeNpm, 0o755);
+
+    const harness = `
+import { existsSync } from "node:fs";
+import { ensureNativeCompat } from ${JSON.stringify("file://" + ensureDepsAbsPath.replace(/\\/g, "/"))};
+process.env.PATH = ${JSON.stringify(fakeBin)};
+process.env.FAKE_NPM_MARKER = ${JSON.stringify(marker)};
+ensureNativeCompat(${JSON.stringify(root)});
+console.log(JSON.stringify({ wrongNpmRan: existsSync(${JSON.stringify(marker)}) }));
+`;
+    const harnessPath = join(root, "_runtime-pinned-rebuild.mjs");
+    writeFileSync(harnessPath, harness, "utf-8");
+
+    const result = spawnSync(process.execPath, [harnessPath], {
+      encoding: "utf-8",
+      timeout: 30_000,
+      cwd: join(fileURLToPath(import.meta.url), "..", ".."),
+    });
+    if (result.error) throw result.error;
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({ wrongNpmRan: false });
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  test("ABI probe uses the running Node executable instead of ambient PATH", () => {
+    const root = createTempRoot();
+    const fakeBin = join(root, "fake-bin");
+    const marker = join(root, "wrong-node-ran");
+    const releaseDir = join(root, "node_modules", "better-sqlite3", "build", "Release");
+    mkdirSync(fakeBin, { recursive: true });
+    mkdirSync(releaseDir, { recursive: true });
+    writeFileSync(join(releaseDir, "better_sqlite3.node"), "not-a-native-binary");
+
+    const fakeNode = join(fakeBin, process.platform === "win32" ? "node.cmd" : "node");
+    const fakeNodeSource = process.platform === "win32"
+      ? "@echo off\r\n> \"%FAKE_NODE_MARKER%\" echo called\r\nexit /b 0\r\n"
+      : "#!/bin/sh\nprintf called > \"$FAKE_NODE_MARKER\"\nexit 0\n";
+    writeFileSync(fakeNode, fakeNodeSource, "utf-8");
+    if (process.platform !== "win32") chmodSync(fakeNode, 0o755);
+
+    const harness = `
+import { existsSync } from "node:fs";
+const { ensureNativeCompat } = await import(${JSON.stringify("file://" + ensureDepsAbsPath.replace(/\\/g, "/"))});
+Object.defineProperty(process.versions, "node", { value: "20.0.0" });
+process.env.PATH = ${JSON.stringify(fakeBin)};
+process.env.FAKE_NODE_MARKER = ${JSON.stringify(marker)};
+ensureNativeCompat(${JSON.stringify(root)});
+console.log(JSON.stringify({ wrongNodeRan: existsSync(${JSON.stringify(marker)}) }));
+`;
+    const harnessPath = join(root, "_runtime-pinned-probe.mjs");
+    writeFileSync(harnessPath, harness, "utf-8");
+
+    const result = spawnSync(process.execPath, [harnessPath], {
+      encoding: "utf-8",
+      timeout: 30_000,
+      cwd: join(fileURLToPath(import.meta.url), "..", ".."),
+    });
+    if (result.error) throw result.error;
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({ wrongNodeRan: false });
+    expect(existsSync(marker)).toBe(false);
+  });
+
   test("corrupted cache with missing binary: early return after cache swap fails", () => {
     const root = createTempRoot();
     const releaseDir = join(root, "node_modules", "better-sqlite3", "build", "Release");
@@ -536,7 +620,7 @@ describe("ensure-deps: better-sqlite3 binding self-heal (#408)", () => {
       "!existsSync(resolve(pkgDir, ...NATIVE_BINARIES[pkg]))",
     );
     expect(anchor).toBeGreaterThan(-1);
-    const end = ENSURE_DEPS_SRC.indexOf("\nexport function ensureNativeCompat", anchor);
+    const end = ENSURE_DEPS_SRC.indexOf("\n/**\n * Probe-load better-sqlite3", anchor);
     const branch = ENSURE_DEPS_SRC.slice(anchor, end === -1 ? ENSURE_DEPS_SRC.length : end);
     expect(/healBetterSqlite3Binding\s*\(/.test(branch)).toBe(true);
 


### PR DESCRIPTION
## What / Why / How

Fixes #1105.

The ABI self-heal could probe with the `node` resolved from ambient `PATH`, then rebuild with the `npm` resolved from that same, potentially different Node installation. On nvm/fnm/volta-style setups, that can repeatedly rebuild `better-sqlite3` for the wrong ABI.

This change:

- runs the child-process ABI probe with `process.execPath`;
- rebuilds with a child environment whose single `PATH`/`Path` entry starts with `dirname(process.execPath)`, using the platform path delimiter;
- keeps the missing-package install branch unchanged. Open PR #863 covers that separate path and explicitly leaves ABI-mismatch healing for a separate change.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [x] All platforms

Shared Node hook bootstrap only. Bun remains on its existing early-return path.

## Test plan

- Added process-level regression coverage with fake `node` and `npm` commands placed first in ambient `PATH`.
- RED confirmed independently for both cases: the unmodified path selected the fake command; GREEN selects the running Node installation.
- `npx vitest run tests/hooks/ensure-deps.test.ts --maxWorkers=1`: 26 passed.
- Windows with the workflow's exact Node 22.5.0: the same 26 focused tests passed.
- `npm run typecheck`: passed.
- `npm run build`: passed, including bundle and asymmetric-drift assertions.
- Fork CI run [34233804708](https://github.com/Zhao0335/context-mode/actions/runs/34233804708): full install, typecheck, build, bundle assertions, test suite, and doctor passed on Ubuntu, macOS, and Windows.
- A local Node 24 Windows full-suite run had 27 existing shell executor/server failures; representative failures (`Shell: pipes + sort` and `shell: cap works with shell scripts`) reproduced unchanged on a detached `upstream/next` worktree at `e31360d`. The repository CI wrapper passed the full Windows suite.
- Fork OpenClaw E2E could not reach the test itself because `npm install` failed with npm's `Cannot read properties of null (reading 'edgesOut')` on both Ubuntu and macOS. The failure is identical on this branch ([run 34233810158](https://github.com/Zhao0335/context-mode/actions/runs/34233810158)) and unmodified `next` at `e31360d` ([run 34234009191](https://github.com/Zhao0335/context-mode/actions/runs/34234009191)).
- A live Claude Code session with two real Node-manager installations was not exercised. The regression tests simulate the divergent `PATH` boundary in subprocesses; the green CI run covers all three OSes.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes (fork CI: Ubuntu, macOS, Windows)
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (no user-facing behavior or configuration changed)
- [x] No Windows path regressions (uses `node:path` delimiter; regression tests cover Windows command shims)
- [x] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

The child environment removes every case variant of the inherited path key before setting one authoritative `PATH`. This avoids Windows' case-insensitive `Path`/`PATH` ambiguity while preserving every non-path environment variable.

</details>
