### PR TITLE
fix: only route curl and wget in command position

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -240,6 +240,10 @@ function stripQuotedContent(cmd) {
     .replace(/"[^"]*"/g, '""');                   // double-quoted strings
 }
 
+// Match curl/wget only when they are the command at the start of a shell
+// segment or pipeline stage, not an unquoted argument to another command.
+const CURL_WGET_COMMAND = /(?:^|(?:&&|\|\||;|\|&?|[\r\n])\s*)(curl|wget)(?=\s|$)/i;
+
 /**
  * Built-in allowlist of structurally-bounded Bash commands (#463).
  *
@@ -730,16 +734,17 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
 
     // curl/wget — allow silent file-output downloads, block stdout floods (#166).
     // Algorithm: split chained commands, evaluate each segment independently.
-    if (/(^|\s|&&|\||\;)(curl|wget)\s/i.test(stripped)) {
+    if (CURL_WGET_COMMAND.test(stripped)) {
       // Split on chain operators (&&, ||, ;) to evaluate each segment
       const segments = stripped.split(/\s*(?:&&|\|\||;)\s*/);
       const hasDangerousSegment = segments.some(seg => {
         const s = seg.trim();
-        // Only evaluate segments that contain curl or wget
-        if (!/(^|\s)(curl|wget)\s/i.test(s)) return false;
+        // Only evaluate segments whose command is curl or wget
+        const commandMatch = CURL_WGET_COMMAND.exec(s);
+        if (!commandMatch) return false;
 
-        const isCurl = /\bcurl\b/i.test(s);
-        const isWget = /\bwget\b/i.test(s);
+        const isCurl = commandMatch[1].toLowerCase() === "curl";
+        const isWget = !isCurl;
 
         // Check for file output flags
         const hasFileOutput = isCurl

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -137,6 +137,27 @@ describe("routePreToolUse", () => {
       );
     });
 
+    it("does not redirect curl/wget when they are arguments, not commands", () => {
+      for (const command of [
+        "which curl",
+        "which curl --all",
+        "echo wget",
+        "type curl --verbose",
+        "which -a wget --help",
+        "command -v wget --help",
+      ]) {
+        const result = routePreToolUse("Bash", { command });
+        expect(result?.action).not.toBe("modify");
+      }
+    });
+
+    it("does not treat a safe curl command's later argument as another command", () => {
+      const result = routePreToolUse("Bash", {
+        command: "curl -s -o /tmp/file.tar.gz https://example.com && which curl --all",
+      });
+      expect(result).toBeNull();
+    });
+
     // ─── curl/wget file-output allow-list (#166) ────────────
 
     it("allows curl -sLo file (silent + file output)", () => {


### PR DESCRIPTION
## What / Why / How

Fixes #1106. The curl/wget PreToolUse guard now matches only executable command positions (segment or pipeline starts), so commands such as `which curl` are not rewritten. The existing per-segment safety checks reuse the same matcher, preventing later arguments from turning a safe chain into a redirect.

## Affected platforms

- [x] All hook-capable platforms

## Test plan

- [x] `npx vitest run tests/hooks/core-routing.test.ts` (97 passed)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (4758 passed, 43 skipped)
- [x] `git diff --check`