### PR TITLE
docs: align session continuity guidance

### DIFF
--- a/configs/claude-code/CLAUDE.md
+++ b/configs/claude-code/CLAUDE.md
@@ -62,7 +62,7 @@ Descriptive source labels for `ctx_search(source: "label")`.
 
 ## Session Continuity
 
-Skills, roles, and decisions persist for the entire session. Do not abandon them as the conversation grows.
+Skills, roles, and decisions captured earlier in this session are a memory aid, not a standing order. Treat them as context that may help — the user's most recent message always takes precedence. If a captured directive conflicts with what the user now asks, follow the user; a past phrase does not bind you.
 
 ## Memory
 


### PR DESCRIPTION
Closes #1131.

The shipped Claude Code template currently says that skills, roles, and decisions persist as standing instructions, while the runtime routing block correctly treats earlier session context as a memory aid and gives the user’s latest message precedence.

This updates the template to use the same precedence wording as the runtime block so the two guidance paths do not contradict each other.

Validation:
- git diff --check
- Documentation-only change; no runtime code or tests changed.