### PR TITLE
fix(fetch): handle HTML tables without rows

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3287,6 +3287,12 @@ async function main() {
     const sourceBytes = Buffer.byteLength(html, 'utf-8');
     const td = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
     td.use(gfm);
+    // turndown-plugin-gfm assumes every TABLE contains at least one row.
+    // Let Turndown preserve any non-row content instead of calling that rule.
+    td.addRule('emptyTable', {
+      filter: (node) => node.nodeName === 'TABLE' && node.rows.length === 0,
+      replacement: (content) => content,
+    });
     td.remove(['script', 'style', 'nav', 'header', 'footer', 'noscript']);
     const converted = td.turndown(html);
 

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -620,6 +620,10 @@ const TurndownService = require(${JSON.stringify(turndownPath)});
 const { gfm } = require(${JSON.stringify(gfmPath)});
 const td = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
 td.use(gfm);
+td.addRule('emptyTable', {
+  filter: (node) => node.nodeName === 'TABLE' && node.rows.length === 0,
+  replacement: (content) => content,
+});
 td.remove(['script', 'style', 'nav', 'header', 'footer', 'noscript']);
 console.log(td.turndown(${JSON.stringify(html)}));
 `;
@@ -701,6 +705,25 @@ describe("turndown HTML-to-markdown conversion tests", () => {
     assert(result.stdout.includes("| Name"), `expected pipe table, got: ${result.stdout}`);
     assert(result.stdout.includes("| Alice"));
     assert(result.stdout.includes("| ---"), `expected table separator, got: ${result.stdout}`);
+  });
+
+  test("skips empty tables", async () => {
+    const result = await turndownExecutor.execute({
+      language: "javascript",
+      code: buildConversionCode("<p>Before</p><table></table><p>After</p>"),
+    });
+    assert.equal(result.exitCode, 0, `stderr: ${result.stderr}`);
+    assert(result.stdout.includes("Before"), `lost preceding content: ${result.stdout}`);
+    assert(result.stdout.includes("After"), `lost following content: ${result.stdout}`);
+  });
+
+  test("preserves content from tables without rows", async () => {
+    const result = await turndownExecutor.execute({
+      language: "javascript",
+      code: buildConversionCode("<table><caption>Summary</caption></table>"),
+    });
+    assert.equal(result.exitCode, 0, `stderr: ${result.stderr}`);
+    assert(result.stdout.includes("Summary"), `lost table content: ${result.stdout}`);
   });
 
   test("handles nested tags correctly", async () => {


### PR DESCRIPTION
## Summary
- avoid the Turndown GFM table rule when an HTML table has no rows
- preserve non-row content such as captions instead of dropping the table entirely
- add regression coverage for empty and rowless tables

Fixes #1136

## Validation
- targeted Turndown conversion tests
- npm run typecheck
- npm test: 4,723 passed; 28 existing Windows shell-executor compatibility failures outside this change
- git diff --check
