### PR TITLE
fix(session): key cleanupOldSessions TTL off last activity, not started_at

### DIFF
--- a/hooks/session-db.bundle.mjs
+++ b/hooks/session-db.bundle.mjs
@@ -129,7 +129,7 @@ import{createRequire as ie}from"node:module";import{existsSync as ae,unlinkSync 
          AND (data LIKE '%' || ? || '%' ESCAPE '\\' OR category LIKE '%' || ? || '%' ESCAPE '\\')
          AND (? IS NULL OR category = ?)
        ORDER BY id ASC
-       LIMIT ?`),e(o.getOldSessions,"SELECT session_id FROM session_meta WHERE started_at < datetime('now', ? || ' days')"),e(o.incrementToolCall,`INSERT INTO tool_calls (session_id, tool, calls, bytes_returned)
+       LIMIT ?`),e(o.getOldSessions,"SELECT session_id FROM session_meta WHERE COALESCE(last_event_at, started_at) < datetime('now', ? || ' days')"),e(o.incrementToolCall,`INSERT INTO tool_calls (session_id, tool, calls, bytes_returned)
        VALUES (?, ?, 1, ?)
        ON CONFLICT(session_id, tool) DO UPDATE SET
          calls = calls + 1,

--- a/src/session/db.ts
+++ b/src/session/db.ts
@@ -1093,8 +1093,14 @@ export class SessionDB extends SQLiteBase {
        LIMIT ?`);
 
     // ── Cleanup ──
+    // TTL keys off last activity, not creation: `started_at` is set once by
+    // the INSERT OR IGNORE in ensureSession and never refreshed, so keying
+    // cleanup on it evicts sessions that have been continuously active via
+    // --continue/--resume (#1140). `last_event_at` is bumped by
+    // updateMetaLastEvent on every event insert; `started_at` remains the
+    // fallback for sessions that have not recorded an event yet.
     p(S.getOldSessions,
-      `SELECT session_id FROM session_meta WHERE started_at < datetime('now', ? || ' days')`);
+      `SELECT session_id FROM session_meta WHERE COALESCE(last_event_at, started_at) < datetime('now', ? || ' days')`);
 
     // ── Tool calls (persistent counter) ──
     p(S.incrementToolCall,

--- a/tests/session/cleanup-preserves-active-sessions.test.ts
+++ b/tests/session/cleanup-preserves-active-sessions.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression: cleanupOldSessions must not evict sessions that are old but
+ * still actively used.
+ *
+ * Reported in #1140: `getOldSessions` selected on `session_meta.started_at`,
+ * which `INSERT OR IGNORE` sets once at first insert and never refreshes. A
+ * session continuously used via `--continue`/`--resume` for more than
+ * maxAgeDays therefore had its entire history wiped by the next SessionStart
+ * cleanup sweep from ANY session sharing the per-project DB — even though the
+ * session was never abandoned.
+ *
+ * The fix keys the TTL off last activity:
+ *   COALESCE(last_event_at, started_at)
+ * so the horizon is a sliding idle-window. `last_event_at` is maintained by
+ * `updateMetaLastEvent` on every event insert; `started_at` remains the
+ * fallback for sessions that recorded no events yet.
+ *
+ * Test strategy: seed three sessions, backdate timestamps via raw SQL, run
+ * cleanupOldSessions(7), and assert survival/eviction. Re-running this
+ * against the unfixed code MUST fail (proves the bug: the active-old session
+ * is evicted). Modeled on cleanup-preserves-live-uuid-events.test.ts.
+ */
+
+import { afterAll, describe, expect, test } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { SessionDB } from "../../src/session/db.js";
+
+const cleanups: Array<() => void> = [];
+afterAll(() => {
+  for (const fn of cleanups) {
+    try { fn(); } catch { /* ignore cleanup errors */ }
+  }
+});
+
+function createTestDB(): SessionDB {
+  const dbPath = join(tmpdir(), `cleanup-active-${randomUUID()}.db`);
+  const db = new SessionDB({ dbPath });
+  cleanups.push(() => db.cleanup());
+  return db;
+}
+
+function makeEvent(data: string) {
+  return {
+    type: "file",
+    category: "file",
+    data,
+    priority: 2,
+    data_hash: "",
+  };
+}
+
+/**
+ * Backdate session_meta timestamps for one session.
+ * `lastEventDaysAgo === null` leaves last_event_at untouched
+ * (null for event-less rows, "now" for rows touched by insertEvent).
+ */
+function backdate(db: SessionDB, sessionId: string, startedDaysAgo: number, lastEventDaysAgo: number | null) {
+  if (lastEventDaysAgo === null) {
+    db.db
+      .prepare(`UPDATE session_meta SET started_at = datetime('now', ? || ' days') WHERE session_id = ?`)
+      .run(`-${startedDaysAgo}`, sessionId);
+  } else {
+    db.db
+      .prepare(
+        `UPDATE session_meta
+          SET started_at = datetime('now', ? || ' days'),
+              last_event_at = datetime('now', ? || ' days')
+         WHERE session_id = ?`,
+      )
+      .run(`-${startedDaysAgo}`, `-${lastEventDaysAgo}`, sessionId);
+  }
+}
+
+describe("cleanupOldSessions evicts on inactivity, not creation age (#1140)", () => {
+  test("active session older than maxAgeDays survives; idle one is evicted", () => {
+    const db = createTestDB();
+
+    const activeOld = randomUUID(); // started 10d ago, last event NOW (the #1140 repro)
+    const idleOld = randomUUID(); // started 10d ago, last event 10d ago
+    const fresh = randomUUID(); // started now
+
+    for (const id of [activeOld, idleOld, fresh]) {
+      // Hooks call ensureSession before insertEvent; insertEvent alone does
+      // not create the meta row (it only updates meta "if session exists").
+      db.ensureSession(id, "/project");
+      db.insertEvent(id, makeEvent(`/project/${id}.ts`), "PostToolUse", { projectDir: "/project" });
+    }
+
+    backdate(db, activeOld, 10, null); // keep last_event_at = now (set by insertEvent)
+    backdate(db, idleOld, 10, 10);
+    backdate(db, fresh, 0, null);
+
+    const deleted = db.cleanupOldSessions(7);
+
+    expect(deleted).toBe(1);
+    expect(db.db.prepare(`SELECT session_id FROM session_meta WHERE session_id = ?`).get(activeOld)).toBeTruthy();
+    expect(db.db.prepare(`SELECT session_id FROM session_meta WHERE session_id = ?`).get(idleOld)).toBeUndefined();
+    expect(db.db.prepare(`SELECT session_id FROM session_meta WHERE session_id = ?`).get(fresh)).toBeTruthy();
+
+    // The surviving active session keeps its events — the history-wipe from #1140.
+    expect(db.getEvents(activeOld, { limit: 10 }).length).toBe(1);
+  });
+
+  test("session with no events yet falls back to started_at", () => {
+    const db = createTestDB();
+
+    // ensureSession-style row with no events: last_event_at stays NULL.
+    const lonely = randomUUID();
+    db.db
+      .prepare(`INSERT OR IGNORE INTO session_meta (session_id, project_dir) VALUES (?, '/project')`)
+      .run(lonely);
+    backdate(db, lonely, 10, null); // NULL last_event_at
+
+    const deleted = db.cleanupOldSessions(7);
+
+    expect(deleted).toBe(1);
+    expect(db.db.prepare(`SELECT session_id FROM session_meta WHERE session_id = ?`).get(lonely)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What / Why / How

Fixes #1140.

`getOldSessions` selected on `session_meta.started_at`, which the `INSERT OR IGNORE` in `ensureSession` sets once at first insert and never refreshes. A session continuously used via `--continue`/`--resume` for more than `maxAgeDays` therefore had its entire captured history silently wiped by the next `SessionStart` cleanup sweep from **any** session sharing the per-project DB — not just its own lifecycle.

This PR keys the TTL off last activity instead:

```sql
SELECT session_id FROM session_meta
WHERE COALESCE(last_event_at, started_at) < datetime('now', ? || ' days')
```

- `last_event_at` already exists in the schema and is bumped by `updateMetaLastEvent` on every event insert — the query just never used it.
- `started_at` remains the fallback for sessions that have not recorded an event yet, so event-less rows keep the old semantics.
- The horizon is now a sliding idle-window: only sessions with no activity for `maxAgeDays` are evicted, matching the README's framing that only abandoned sessions ("if you don't `--continue`") lose history.
- `hooks/session-db.bundle.mjs` is updated with the same one-line change (surgical edit; the rest is kept byte-identical to avoid esbuild version churn).

No schema change, no migration.

## Affected platforms

- [x] All platforms (core session DB shared by every adapter)

## Test plan

New regression test `tests/session/cleanup-preserves-active-sessions.test.ts`, following the pattern of `cleanup-preserves-live-uuid-events.test.ts`:

1. **Active-but-old session survives**: started 10 days ago, last event now → `cleanupOldSessions(7)` keeps it and its events. Against the unfixed code this fails with `deleted = 2` (the active session is wrongly evicted — exactly the #1140 repro).
2. **Idle session evicted**: started and last event 10 days ago → evicted as before.
3. **Event-less session falls back to `started_at`**: meta row with NULL `last_event_at` older than the TTL is still evicted.

TDD red → green verified; `npm run typecheck` passes; `tests/session/` + bundle-consumer suites (server, cli, assert-bundle) green: 1616 passed, 4 skipped.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (behavior now matches existing README wording — no doc change needed)
- [x] No Windows path regressions (no path handling touched)
- [x] Targets `next` branch (unless hotfix)

---

Note: this change was developed with AI assistance (Claude Code); I verified the red → green cycle, typecheck, and full suite runs locally and can explain every line of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)