### PR TITLE
fix(ctx-debug): redact env blocks and credential-shaped keys in captured configs

### DIFF
--- a/scripts/ctx-debug.sh
+++ b/scripts/ctx-debug.sh
@@ -67,6 +67,7 @@ redact() {
   sed -E \
     -e 's/(sk-[A-Za-z0-9_-]{4})[A-Za-z0-9_-]+/\1***REDACTED***/g' \
     -e 's/("(key|token|secret|password|apiKey|api_key|auth|credential|authorization)"[[:space:]]*:[[:space:]]*")([^"]{4})[^"]*/\1\3***REDACTED***/g' \
+    -e 's/("[A-Za-z0-9_-]*([Tt][Oo][Kk][Ee][Nn]|[Ss][Ee][Cc][Rr][Ee][Tt]|[Pp][Aa][Ss][Ss][Ww][Oo]?[Rr]?[Dd]|[Aa][Pp][Ii]_?[Kk][Ee][Yy]|[Cc][Rr][Ee][Dd][Ee][Nn][Tt][Ii][Aa][Ll])[A-Za-z0-9_-]*"[[:space:]]*:[[:space:]]*")[^"]+/\1***REDACTED***/g' \
     -e 's/(ghp_[A-Za-z0-9]{4})[A-Za-z0-9]+/\1***REDACTED***/g' \
     -e 's/(ghu_[A-Za-z0-9]{4})[A-Za-z0-9]+/\1***REDACTED***/g' \
     -e 's/(xox[bpras]-[A-Za-z0-9]{4})[A-Za-z0-9-]+/\1***REDACTED***/g' \
@@ -148,17 +149,25 @@ config_file() {
   display="$(abbrev_path "$path")"
   if [ -f "$path" ]; then
     kv "$label" "$display (exists)"
-    # Use node for proper JSON escaping of file content
+    # Redact BEFORE the content reaches the report: every value under an
+    # `env` block, every credential-shaped key, and known token shapes
+    # (scripts/lib/ctx-debug-redact.mjs, JSON-aware). The module also does
+    # the JSON escaping. Fall back to the old pattern-only redaction when the
+    # module is missing (script copied out of the repo on its own).
     local content_json
-    content_json="$(node -e "
-      const fs=require('fs');
-      let c=fs.readFileSync('$path','utf8').slice(0,3000);
-      // Redact secrets
-      c=c.replace(/(sk-[A-Za-z0-9_-]{4})[A-Za-z0-9_-]+/g,'\$1***');
-      c=c.replace(/(postgres(ql)?:\/\/[^:]+:)[^@]+(@)/g,'\$1***\$3');
-      c=c.replace(/(mongodb(\+srv)?:\/\/[^:]+:)[^@]+(@)/g,'\$1***\$3');
-      console.log(JSON.stringify(c));
-    " 2>/dev/null || echo '""')"
+    if [ -f "$SCRIPT_DIR/lib/ctx-debug-redact.mjs" ]; then
+      content_json="$(node "$SCRIPT_DIR/lib/ctx-debug-redact.mjs" "$path" 2>/dev/null || echo '""')"
+    else
+      content_json="$(node -e "
+        const fs=require('fs');
+        let c=fs.readFileSync('$path','utf8');
+        c=c.replace(/(sk-[A-Za-z0-9_-]{4})[A-Za-z0-9_-]+/g,'\$1***');
+        c=c.replace(/(postgres(ql)?:\/\/[^:]+:)[^@]+(@)/g,'\$1***\$3');
+        c=c.replace(/(mongodb(\+srv)?:\/\/[^:]+:)[^@]+(@)/g,'\$1***\$3');
+        c=c.replace(/(\"[^\"]*(token|secret|passw(or)?d|api[_-]?key|credential|authorization)[^\"]*\"\s*:\s*\")[^\"]+(\")/gi,'\$1***\$4');
+        console.log(JSON.stringify(c.slice(0,3000)));
+      " 2>/dev/null || echo '""')"
+    fi
     printf '{"t":"cfg","s":"%s","k":"%s","path":"%s","exists":true,"content":%s}\n' "$CURRENT_SECTION" "$(_jesc "$label")" "$(_jesc "$display")" "$content_json" >> "$JSONL_FILE"
   else
     kv "$label" "$display (not found)"

--- a/scripts/lib/ctx-debug-redact.mjs
+++ b/scripts/lib/ctx-debug-redact.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Redaction for the config files ctx-debug.sh copies into its report.
+ *
+ * The report is meant to be pasted into a public bug report, so a config
+ * file's secrets must never reach it: anything under an `env` block (Claude
+ * Code settings put API tokens there), any value whose key looks like a
+ * credential, and the well-known token / connection-string shapes that may
+ * appear in free text. JSON files are walked structurally so the redaction
+ * cannot be defeated by formatting; other files fall back to pattern matching.
+ *
+ * Usage: node ctx-debug-redact.mjs <file>   → prints the redacted content as a JSON string
+ */
+import { readFileSync } from "node:fs";
+
+export const REDACTED = "***REDACTED***";
+
+/** Keys whose values are credentials, wherever they sit. */
+const SECRET_KEY_RE =
+  /(token|secret|passw(or)?d|pwd|api[_-]?key|apikey|access[_-]?key|private[_-]?key|client[_-]?secret|credential|authorization|bearer|cookie|session[_-]?id|dsn|connection[_-]?string)/i;
+
+/** Objects whose every string value is an environment variable, i.e. potentially a credential. */
+const ENV_BLOCK_KEY_RE = /^env(ironment)?$/i;
+
+/** Token and connection-string shapes that can appear in any text. */
+const TEXT_PATTERNS = [
+  [/(sk-[A-Za-z0-9_-]{4})[A-Za-z0-9_-]+/g, `$1${REDACTED}`],
+  [/(gh[pousr]_[A-Za-z0-9]{4})[A-Za-z0-9]+/g, `$1${REDACTED}`],
+  [/(github_pat_[A-Za-z0-9]{4})[A-Za-z0-9_]+/g, `$1${REDACTED}`],
+  [/(xox[bpras]-[A-Za-z0-9]{4})[A-Za-z0-9-]+/g, `$1${REDACTED}`],
+  [/(AKIA[A-Z0-9]{4})[A-Z0-9]{12}/g, `$1${REDACTED}`],
+  [/(eyJ[A-Za-z0-9_-]{4})[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, `$1${REDACTED}`],
+  [/((?:postgres(?:ql)?|mongodb(?:\+srv)?|mysql|redis|amqp|https?):\/\/[^\s:@/]+:)[^\s@]+(@)/g, `$1${REDACTED}$2`],
+];
+
+/** `"SOME_TOKEN": "value"` pairs in text that is not valid JSON. */
+const KEYED_VALUE_RE =
+  /("[^"\n]*(?:token|secret|passw(?:or)?d|pwd|api[_-]?key|apikey|access[_-]?key|private[_-]?key|client[_-]?secret|credential|authorization|bearer|cookie)[^"\n]*"\s*:\s*")([^"\n]*)(")/gi;
+
+export function isSecretKey(key) {
+  return SECRET_KEY_RE.test(String(key));
+}
+
+function redactValue(value) {
+  if (typeof value === "string") return value ? REDACTED : value;
+  if (typeof value === "number" || typeof value === "boolean" || value === null) return value;
+  if (Array.isArray(value)) return value.map(redactValue);
+  if (typeof value === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) out[k] = redactValue(v);
+    return out;
+  }
+  return value;
+}
+
+/** Redact a parsed JSON value: secret-shaped keys and whole env blocks. */
+export function redactJson(value, { inEnvBlock = false } = {}) {
+  if (Array.isArray(value)) return value.map((item) => redactJson(item, { inEnvBlock }));
+  if (value === null || typeof value !== "object") {
+    return inEnvBlock ? redactValue(value) : value;
+  }
+  const out = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (inEnvBlock || isSecretKey(key)) {
+      out[key] = redactValue(child);
+    } else if (ENV_BLOCK_KEY_RE.test(key)) {
+      out[key] = redactJson(child, { inEnvBlock: true });
+    } else {
+      out[key] = redactJson(child);
+    }
+  }
+  return out;
+}
+
+/** Redact token and connection-string shapes in arbitrary text. */
+export function redactText(text) {
+  let out = String(text);
+  for (const [pattern, replacement] of TEXT_PATTERNS) out = out.replace(pattern, replacement);
+  return out.replace(KEYED_VALUE_RE, (_m, prefix, value, suffix) => `${prefix}${value ? REDACTED : ""}${suffix}`);
+}
+
+/**
+ * Redact a config file's content. JSON (with or without a trailing newline)
+ * is walked structurally and re-serialised; anything else is pattern-matched.
+ * The result is cut to `maxChars` AFTER redaction so a secret can never
+ * straddle the cut.
+ */
+export function redactConfigContent(content, { maxChars = 3000 } = {}) {
+  let out;
+  try {
+    out = JSON.stringify(redactJson(JSON.parse(content)), null, 2);
+  } catch {
+    out = content;
+  }
+  return redactText(out).slice(0, maxChars);
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  const file = process.argv[2];
+  if (!file) {
+    console.error("usage: ctx-debug-redact.mjs <file>");
+    process.exit(2);
+  }
+  process.stdout.write(JSON.stringify(redactConfigContent(readFileSync(file, "utf8"))));
+}

--- a/tests/cli/ctx-debug-redact.test.ts
+++ b/tests/cli/ctx-debug-redact.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  REDACTED,
+  isSecretKey,
+  redactConfigContent,
+  redactText,
+} from "../../scripts/lib/ctx-debug-redact.mjs";
+
+// scripts/ctx-debug.sh copies config files into a report the bug template
+// asks users to paste into a public issue. Before this module the only
+// redaction was three patterns (sk-, postgres://, mongodb://), so every value
+// in a Claude Code settings.json `env` block — API tokens included — landed in
+// the report verbatim (#1141).
+
+const settings = {
+  env: {
+    DYNATRACE_API_TOKEN: "dt0c01.ABC123.SECRETSECRET",
+    SONAR_TOKEN: "sqp_1234567890",
+    AWS_PROFILE: "work",
+    OTEL_EXPORTER_OTLP_ENDPOINT: "https://otel.example.com",
+  },
+  model: "opus",
+  hooks: {
+    PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "node hook.mjs" }] }],
+  },
+  apiKey: "sk-proj-abcdefghijklmnop",
+  nested: {
+    MY_SERVICE_PASSWORD: "hunter2",
+    url: "postgres://user:pw@db.example.com/x",
+    plain: "keep me",
+  },
+};
+
+describe("redactConfigContent on JSON", () => {
+  const out = JSON.parse(redactConfigContent(JSON.stringify(settings, null, 2)));
+
+  it("redacts every value under the env block, secret-looking or not", () => {
+    expect(out.env).toEqual({
+      DYNATRACE_API_TOKEN: REDACTED,
+      SONAR_TOKEN: REDACTED,
+      AWS_PROFILE: REDACTED,
+      OTEL_EXPORTER_OTLP_ENDPOINT: REDACTED,
+    });
+  });
+
+  it("redacts credential-shaped keys anywhere in the document", () => {
+    expect(out.apiKey).toBe(REDACTED);
+    expect(out.nested.MY_SERVICE_PASSWORD).toBe(REDACTED);
+  });
+
+  it("keeps everything else readable for diagnosis", () => {
+    expect(out.model).toBe("opus");
+    expect(out.hooks.PreToolUse[0].hooks[0].command).toBe("node hook.mjs");
+    expect(out.nested.plain).toBe("keep me");
+    expect(Object.keys(out)).toEqual(["env", "model", "hooks", "apiKey", "nested"]);
+  });
+
+  it("strips passwords out of connection strings", () => {
+    expect(out.nested.url).toBe(`postgres://user:${REDACTED}@db.example.com/x`);
+  });
+
+  it("does not turn empty or non-string values into markers", () => {
+    const value = JSON.parse(
+      redactConfigContent(JSON.stringify({ env: { EMPTY: "", PORT: 8080, DEBUG: true, NONE: null } })),
+    );
+    expect(value.env).toEqual({ EMPTY: "", PORT: 8080, DEBUG: true, NONE: null });
+  });
+
+  it("cuts to the size limit only after redacting", () => {
+    const padded = { filler: "x".repeat(4000), env: { LATE_TOKEN: "leak-me-please" } };
+    const text = redactConfigContent(JSON.stringify(padded), { maxChars: 3000 });
+    expect(text.length).toBe(3000);
+    expect(text).not.toContain("leak-me-please");
+  });
+});
+
+describe("redactConfigContent on non-JSON text", () => {
+  it("falls back to pattern redaction", () => {
+    const text = [
+      "DATABASE_URL=postgres://u:pw@h/db",
+      "GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz",
+      "OPENAI=sk-proj-abcdefghijklmnop",
+      '"MY_TOKEN": "abc"',
+      "comment = keep",
+    ].join("\n");
+    const out = redactConfigContent(text);
+    expect(out).toContain(`postgres://u:${REDACTED}@h/db`);
+    expect(out).toContain(`ghp_abcd${REDACTED}`);
+    expect(out).toContain(`sk-proj${REDACTED}`);
+    expect(out).toContain(`"MY_TOKEN": "${REDACTED}"`);
+    expect(out).toContain("comment = keep");
+    expect(out).not.toContain("abcdefghijklmnop");
+  });
+
+  it("redacts slack, aws, jwt and basic-auth shapes", () => {
+    const out = redactText(
+      "xoxb-1234-567890-abcdef AKIAIOSFODNN7EXAMPLE eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc https://me:secret@host/",
+    );
+    expect(out).toContain(`xoxb-1234${REDACTED}`);
+    expect(out).toContain(`AKIAIOSF${REDACTED}`);
+    expect(out).toContain(`eyJh${REDACTED}`);
+    expect(out).toContain(`https://me:${REDACTED}@host/`);
+  });
+});
+
+describe("isSecretKey", () => {
+  it("recognises credential-shaped names and nothing else", () => {
+    for (const key of ["apiKey", "api_key", "SONAR_TOKEN", "password", "passwd", "clientSecret", "AUTHORIZATION", "aws_access_key_id", "dsn"]) {
+      expect(isSecretKey(key), key).toBe(true);
+    }
+    for (const key of ["model", "hooks", "command", "AWS_PROFILE", "endpoint", "timeout"]) {
+      expect(isSecretKey(key), key).toBe(false);
+    }
+  });
+});

--- a/tests/cli/ctx-debug-redact.test.ts
+++ b/tests/cli/ctx-debug-redact.test.ts
@@ -98,7 +98,7 @@ describe("redactConfigContent on non-JSON text", () => {
     );
     expect(out).toContain(`xoxb-1234${REDACTED}`);
     expect(out).toContain(`AKIAIOSF${REDACTED}`);
-    expect(out).toContain(`eyJh${REDACTED}`);
+    expect(out).toContain(`eyJhbGc${REDACTED}`);
     expect(out).toContain(`https://me:${REDACTED}@host/`);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1141.

`scripts/ctx-debug.sh` copies `~/.claude/settings.json` (and the other adapters' config files) into the report that `bug_report.yml` requires users to paste into a public issue. The only redaction on that path was three regexes (`sk-`, `postgres://`, `mongodb://`), so everything in a Claude Code `env` block (`DYNATRACE_API_TOKEN`, `SONAR_TOKEN`, OTLP endpoints, …) and any other credential-shaped setting reached the report in plaintext.

## Change

- **`scripts/lib/ctx-debug-redact.mjs`** (new, ESM, no dependencies): `redactConfigContent(text)` parses JSON and walks it, replacing every value under an `env` / `environment` block (secret-looking or not: a user cannot tell which env vars are sensitive) and every value whose key looks like a credential (`*token*`, `*secret*`, `*password*`, `*api_key*`, `*access_key*`, `*private_key*`, `credential`, `authorization`, `bearer`, `cookie`, `dsn`, …) with `***REDACTED***`, then masks known shapes in the serialised text (`sk-…`, `ghp_/gho_/ghs_…`, `github_pat_…`, `xox…`, `AKIA…`, JWTs, `scheme://user:password@host`). Non-JSON files get the pattern pass plus `"…TOKEN…": "value"` masking. The 3000-character cut happens **after** redaction so a secret can never straddle it. Keys, structure, hooks, model names etc. stay readable for diagnosis; empty and non-string values are left as they are.
- **`scripts/ctx-debug.sh`**: `config_file` runs the module (it also does the JSON escaping). If the module is missing (script copied out of the repo on its own) the inline fallback now also masks `*TOKEN` / `*SECRET` / `*PASSWORD` / `*API_KEY` / `*CREDENTIAL` values. The shell `redact` helper (used for hooks.json / env output) gains the same key rule.

## Tests

`tests/cli/ctx-debug-redact.test.ts` (vitest, 11 tests): env block fully redacted incl. `AWS_PROFILE`, credential keys anywhere, non-secret values and key order preserved, connection strings, empty/number/bool/null values untouched, cut after redaction, non-JSON fallback (dotenv style, `ghp_`, `sk-`, `"MY_TOKEN": …`), slack/aws/jwt/basic-auth shapes, and `isSecretKey`.

Manual check on a settings.json with an `env` block and a nested password: `node scripts/lib/ctx-debug-redact.mjs settings.json` → all env values and the password masked, hooks and model intact; `bash -n scripts/ctx-debug.sh` clean.
