### PR TITLE
fix: skip Claude self-healing for non-Claude launches

### DIFF
--- a/hooks/heal-partial-install.mjs
+++ b/hooks/heal-partial-install.mjs
@@ -444,9 +444,12 @@ function logHealResult(result) {
  *   marketplaceClonePath - absolute path to the marketplace clone. Auto-derived
  *                          from pluginRoot when omitted.
  *   log                  - when true (default), appends a JSON line to
- *                          ~/.claude/context-mode/heal-partial-install.log
- *                          on every run, including skipped ones, so an
- *                          operator can grep for evidence the hook fired.
+ *                          <config-dir>/context-mode/heal-partial-install.log
+ *                          on every run that reaches a Claude Code install, so
+ *                          an operator can grep for evidence the hook fired.
+ *                          The `no-plugin-root` and `not-claude-code` skips
+ *                          are deliberately NOT logged — see those branches
+ *                          (#1072).
  *
  * Returns an object whose exact shape depends on the branch taken.
  * Common fields:
@@ -479,7 +482,8 @@ export function healPartialInstallFromMarketplace(opts = {}) {
       stillMissing: [],
       skipped: "no-plugin-root",
     };
-    if (log) logHealResult(result);
+    // A missing plugin root is not evidence of a Claude Code install. Logging
+    // it would create ~/.claude for npm-global, Codex, or other callers.
     return result;
   }
 
@@ -504,7 +508,12 @@ export function healPartialInstallFromMarketplace(opts = {}) {
       skipped: "not-claude-code",
       pluginRoot,
     };
-    if (log) logHealResult(result);
+    // #1072: deliberately NOT logged. Reaching this branch proves the caller
+    // is not a Claude Code install, so writing a diagnostic into Claude's
+    // config dir would CREATE ~/.claude for users who do not have one —
+    // e.g. `node start.mjs` from .codex-plugin/mcp.json with
+    // CONTEXT_MODE_PLATFORM=codex. The skip reason is still reported in the
+    // return value for callers that want to act on it.
     return result;
   }
 

--- a/start.mjs
+++ b/start.mjs
@@ -305,6 +305,19 @@ try {
   const { buildHookCommand, selfHealCacheHealHook, ensureShebangAndExecBit } =
     await import("./hooks/cache-heal-utils.mjs");
 
+  // #1072: Layer 4 exists only to repair Claude Code's own plugin cache, and
+  // every write below lands in Claude Code's config tree (~/.claude/hooks/ +
+  // ~/.claude/settings.json). start.mjs is NOT Claude-only — the Codex plugin
+  // launches it too (.codex-plugin/mcp.json sets CONTEXT_MODE_PLATFORM=codex),
+  // so an unguarded deploy creates ~/.claude/ for users who never installed
+  // Claude Code. A launcher that explicitly declares a non-Claude platform is
+  // therefore skipped entirely. Unset/unknown platforms keep the old behavior:
+  // Claude Code never sets CONTEXT_MODE_PLATFORM, so it always reaches this
+  // layer, and npm-global users who do run Claude Code keep their self-heal.
+  const declaredPlatform = (process.env.CONTEXT_MODE_PLATFORM || "").trim();
+  const isClaudeLaunch =
+    declaredPlatform === "" || declaredPlatform === "claude-code";
+
   // #577: honor $CLAUDE_CONFIG_DIR — without this, Claude Code spawns hooks
   // from $CLAUDE_CONFIG_DIR/settings.json but we deploy them to ~/.claude/hooks/
   // and register them in ~/.claude/settings.json. The mismatch silently
@@ -314,10 +327,10 @@ try {
   const healHookPath = resolve(globalHooksDir, "context-mode-cache-heal.mjs");
   // Clean up old bash version if it exists
   const oldBashHook = resolve(globalHooksDir, "context-mode-cache-heal.sh");
-  if (existsSync(oldBashHook)) {
+  if (isClaudeLaunch && existsSync(oldBashHook)) {
     try { unlinkSync(oldBashHook); } catch {}
   }
-  if (!existsSync(globalHooksDir)) mkdirSync(globalHooksDir, { recursive: true });
+  if (isClaudeLaunch && !existsSync(globalHooksDir)) mkdirSync(globalHooksDir, { recursive: true });
   const healScript = `#!/usr/bin/env node
 // context-mode plugin cache self-heal (auto-deployed)
 // Fixes anthropics/claude-code#46915: auto-update breaks CLAUDE_PLUGIN_ROOT
@@ -370,8 +383,9 @@ try{
 `;
   // Deploy or update the heal hook when content changes (not just when missing).
   // Allows new heal logic (e.g. #727 path normalization) to propagate on next boot.
-  let needsWrite = !existsSync(healHookPath);
-  if (!needsWrite) {
+  // #1072: skipped for declared non-Claude launches — see isClaudeLaunch above.
+  let needsWrite = isClaudeLaunch && !existsSync(healHookPath);
+  if (isClaudeLaunch && !needsWrite) {
     try { needsWrite = readFileSync(healHookPath, "utf-8") !== healScript; } catch { needsWrite = true; }
   }
   if (needsWrite) {
@@ -380,14 +394,14 @@ try{
 
   // Always re-assert shebang + chmod +x on Unix so the bare-script hook
   // command is spawnable even if the file was created without exec bit.
-  if (process.platform !== "win32") {
+  if (isClaudeLaunch && process.platform !== "win32") {
     try { ensureShebangAndExecBit(healHookPath); } catch { /* best effort */ }
   }
 
   // Register the hook in $CLAUDE_CONFIG_DIR/settings.json (Claude Code doesn't auto-discover hook files).
   // #577: must follow the same dir resolution as globalHooksDir above.
   const settingsPath = resolve(claudeConfigDir, "settings.json");
-  if (existsSync(settingsPath)) {
+  if (isClaudeLaunch && existsSync(settingsPath)) {
     const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
     const hooks = settings.hooks ?? {};
     const sessionStart = hooks.SessionStart ?? [];

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -1437,6 +1437,85 @@ describe("start.mjs CLI self-heal", () => {
     }
   });
 
+  // ── Issue #1072 — start.mjs is not a Claude-only entry point ──
+  //
+  // .codex-plugin/mcp.json launches `node ./start.mjs` with
+  // CONTEXT_MODE_PLATFORM=codex. Self-heal Layer 4 exists only to repair
+  // Claude Code's plugin cache and writes into ~/.claude/hooks/ and
+  // ~/.claude/settings.json, so an unguarded deploy creates ~/.claude/ for
+  // users who never installed Claude Code. The healer's skip-logger was the
+  // second Claude-only side effect on that same path.
+  test(
+    "Issue #1072 — a declared non-Claude launch does not create ~/.claude",
+    () => {
+      const home = mkdtempSync(join(tmpdir(), "ctx-1072-nonclaude-"));
+      try {
+        const oldHook = join(home, ".claude", "hooks", "context-mode-cache-heal.sh");
+        mkdirSync(dirname(oldHook), { recursive: true });
+        writeFileSync(oldHook, "keep this Claude state\n");
+        const res = spawnSync(process.execPath, [resolve(ROOT, "start.mjs")], {
+          cwd: ROOT,
+          input: "",
+          timeout: 60_000,
+          env: {
+            ...process.env,
+            HOME: home,
+            USERPROFILE: home, // os.homedir() reads USERPROFILE on win32
+            CONTEXT_MODE_PLATFORM: "codex",
+            CLAUDE_CONFIG_DIR: "",
+          },
+        });
+        expect(res.status).toBe(0);
+        // The Codex state dir is the correct target — it must still appear.
+        expect(existsSync(join(home, ".codex"))).toBe(true);
+        // ...and an existing Claude config tree must not be modified either.
+        expect(readFileSync(oldHook, "utf-8")).toBe("keep this Claude state\n");
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+    90_000,
+  );
+
+  test(
+    "Issue #1072 — an undeclared (Claude) launch still deploys the heal hook",
+    () => {
+      const home = mkdtempSync(join(tmpdir(), "ctx-1072-claude-"));
+      try {
+        mkdirSync(join(home, ".claude"), { recursive: true });
+        writeFileSync(join(home, ".claude", "settings.json"), "{}\n");
+        const env: NodeJS.ProcessEnv = {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          CLAUDE_CONFIG_DIR: "",
+        };
+        // Positive control for the gate: an unset platform means Claude Code,
+        // so the npm-global / dev-checkout self-heal must keep working.
+        delete env.CONTEXT_MODE_PLATFORM;
+        const res = spawnSync(process.execPath, [resolve(ROOT, "start.mjs")], {
+          cwd: ROOT,
+          input: "",
+          timeout: 60_000,
+          env,
+        });
+        expect(res.status).toBe(0);
+        expect(
+          existsSync(
+            join(home, ".claude", "hooks", "context-mode-cache-heal.mjs"),
+          ),
+        ).toBe(true);
+        const settings = JSON.parse(
+          readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
+        );
+        expect(JSON.stringify(settings)).toContain("context-mode-cache-heal");
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+    90_000,
+  );
+
   // ── hooks/heal-partial-install.mjs (partial-install auto-recovery) ──
   //
   // Claude Code's native plugin manager occasionally produces a partial
@@ -1785,6 +1864,80 @@ describe("start.mjs CLI self-heal", () => {
       expect(result.skipped).toBeUndefined();
       expect(result.pkgSource).toBe("marketplace");
       expect(result.healed).toContain("package.json");
+    });
+
+    // ── Issue #1072 — the healer must not create Claude state off-platform ──
+    //
+    // The not-claude-code skip fires exactly when the pluginRoot is not a CC
+    // cache layout — i.e. the caller is Codex/OpenCode/an npm-global install.
+    // Logging that skip into ~/.claude/context-mode/heal-partial-install.log
+    // CREATED ~/.claude for users who never installed Claude Code.
+    //
+    // $HOME is the isolation boundary below, so it has to be moved for the
+    // duration of the call. os.homedir() reads USERPROFILE on win32 and HOME
+    // elsewhere, hence both.
+    const withIsolatedHome = <T,>(home: string, fn: () => T): T => {
+      const saved = {
+        HOME: process.env.HOME,
+        USERPROFILE: process.env.USERPROFILE,
+        CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+      };
+      process.env.HOME = home;
+      process.env.USERPROFILE = home;
+      delete process.env.CLAUDE_CONFIG_DIR;
+      try {
+        return fn();
+      } finally {
+        for (const [k, v] of Object.entries(saved)) {
+          if (v === undefined) delete process.env[k];
+          else process.env[k] = v;
+        }
+      }
+    };
+
+    it("Issue #1072 — a non-Claude pluginRoot does not create the Claude config dir", async () => {
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const home = makeTmp("ctx-heal-nonclaude-");
+      const result = withIsolatedHome(home, () =>
+        healPartialInstallFromMarketplace({
+          // npm-global / Codex / dev-checkout shape — not a CC cache layout.
+          pluginRoot: resolve(home, "node_modules", "context-mode"),
+        }),
+      );
+      expect(result.skipped).toBe("not-claude-code");
+      expect(existsSync(resolve(home, ".claude"))).toBe(false);
+    });
+
+    it("Issue #1072 — a missing pluginRoot does not create the Claude config dir", async () => {
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const home = makeTmp("ctx-heal-no-root-");
+      const result = withIsolatedHome(home, () =>
+        healPartialInstallFromMarketplace({}),
+      );
+      expect(result.skipped).toBe("no-plugin-root");
+      expect(existsSync(resolve(home, ".claude"))).toBe(false);
+    });
+
+    it("Issue #1072 — a real Claude Code install still logs the heal result", async () => {
+      // Positive control: the gate keys off "is this Claude Code", it does not
+      // switch the logger off wholesale.
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const home = makeTmp("ctx-heal-still-logs-");
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+      withIsolatedHome(home, () =>
+        healPartialInstallFromMarketplace({ pluginRoot, marketplaceClonePath }),
+      );
+      expect(
+        existsSync(
+          resolve(home, ".claude", "context-mode", "heal-partial-install.log"),
+        ),
+      ).toBe(true);
     });
 
     it("healPartialInstallFromMarketplace rewrites carry-forward stale args[0] in plugin.json", async () => {


### PR DESCRIPTION
## What / Why / How

Fixes #1072. `start.mjs` is shared by Claude Code and non-Claude adapters, but Layer 4 writes Claude-only hooks and settings. Gate that layer on `CONTEXT_MODE_PLATFORM` (unset or `claude-code` keeps existing Claude behavior), and stop the partial-install healer from logging non-Claude skips into `~/.claude`. This prevents non-Claude startup from creating or mutating Claude state.

## Affected platforms

- [x] Claude Code
- [x] Codex CLI
- [x] All platforms

## Test plan

- [x] Added focused regression coverage for non-Claude preservation, Claude positive control, non-Claude plugin roots, missing roots, and real-Claude logging.
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] `npm test` passes: the full suite has 6 pre-existing Windows/environment-sensitive failures (symlink EPERM, shell/PowerShell assumptions, 8.3 cwd normalization, and server shell/path cases); all Issue #1072 tests pass.

## Checklist

- [x] Tests added/updated (TDD: red -> green)
- [ ] `npm test` passes (limitations documented above)
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (not needed)
- [x] No Windows path regressions
- [x] Targets `next` branch

<details>
<summary><strong>Cross-platform notes</strong></summary>

The change only gates existing Claude-specific writes and preserves the existing path resolution. Focused tests pass on Windows.

</details>
