### PR TITLE
fix(exec): bound ctx_execute on Pi, which has no host-side ceiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1599,6 +1599,13 @@ That blocks loopback + RFC1918 + ULA in addition to the always-blocked ranges. U
 |---|---|---|
 | `CONTEXT_MODE_DIR` | Adapter default, for example `~/.codex/context-mode` or `~/.claude/context-mode` | Since v1.0.147. Absolute writable root for context-mode storage. Sessions and stats use `<root>/sessions`; indexed content uses `<root>/content`. Empty or whitespace-only values are treated as unset and shown by `ctx_doctor`; non-empty values must be absolute. `~` is not expanded. |
 
+### Execution-timeout environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS` | `120000` under Antigravity CLI, `600000` under Pi | Fallback budget for `ctx_execute` / `ctx_execute_file` / `ctx_batch_execute` when the call itself passes no `timeout`. Applies only on hosts that do not bound an in-flight MCP tool call themselves — Antigravity CLI, and Pi, whose bridge forwards `tools/call` unbounded by design ([#643](https://github.com/mksglu/context-mode/issues/643), [#959](https://github.com/mksglu/context-mode/issues/959)). Every other host keeps no server-side timer ([#406](https://github.com/mksglu/context-mode/issues/406)). Must be a positive integer no greater than `2147483647` (the largest delay a timer can represent); anything else — blank, fractional, negative, or larger — falls back to the host default rather than to "unbounded". Prefer an explicit per-call `timeout`, or `background: true`, for jobs that legitimately run longer. |
+| `CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS` | unset | Pre-#959 alias for the above, honored only when `CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS` is unset or unusable. |
+
 ### Routing-guidance environment variables
 
 | Variable | Default | Purpose |

--- a/src/server.ts
+++ b/src/server.ts
@@ -1421,10 +1421,20 @@ export interface BatchRunResult {
 export interface BatchRunOptions {
   /**
    * Total budget (concurrency=1, shared) or per-command (concurrency>1).
-   * When `undefined`, no server-side timer fires — the MCP host's RPC
-   * timeout governs (Issue #406).
+   * When `undefined`, no server-side timer fires and the host is left to
+   * bound the call (Issue #406) — which not every host does, see
+   * {@link HOST_DEFAULT_EXEC_TIMEOUT_MS}.
    */
   timeout: number | undefined;
+  /**
+   * Whether `timeout` is a budget the CALLER asked for. A budget that only
+   * came from {@link HOST_DEFAULT_EXEC_TIMEOUT_MS} is a per-command backstop
+   * against one hung command, not a promise about total batch duration, so
+   * spending it across commands would silently truncate a long batch nobody
+   * put a deadline on. Defaults to true, preserving the historical shared
+   * budget for an explicit `timeout`.
+   */
+  callerBudget?: boolean;
   concurrency: number;
   nodeOptsPrefix: string;
   cwd?: string;
@@ -1473,22 +1483,100 @@ function truncateCommandForEcho(command: string): string {
 }
 
 /**
- * Default execution timeout (ms) applied ONLY under Antigravity CLI (`agy`).
- * agy does not enforce an MCP RPC timeout, so a ctx_execute with a runaway or
- * blocking script hangs forever — the host never kills it and the user must
- * interrupt. Every other host enforces its own RPC timeout, so we keep the
- * no-server-timer behavior there (Issue #406 — long builds need an unbounded
- * run). A caller can still pass an explicit `timeout` to override on any host.
+ * Default execution timeout (ms) under Antigravity CLI (`agy`) — see
+ * {@link HOST_DEFAULT_EXEC_TIMEOUT_MS}. agy does not enforce an MCP RPC
+ * timeout, so a ctx_execute with a runaway or blocking script hangs forever
+ * and the user must interrupt.
  */
 export const AGY_DEFAULT_EXEC_TIMEOUT_MS = 120_000;
+
+/**
+ * Default execution timeout (ms) under Pi (Issue #959).
+ *
+ * Pi's bridge deliberately forwards `tools/call` with
+ * `Number.POSITIVE_INFINITY` (#643, so long builds are not cut off at the
+ * transport), and its registered-tool callback does not yet propagate Pi's
+ * AbortSignal — so with no server-side timer a hung child is unbounded at
+ * EVERY layer and Esc cannot clear it. Measured: a `grep -rn` over a large
+ * tree ran 75 minutes on Pi 0.84.x and only ended when the session was killed;
+ * independently reported on macOS, Linux and Windows in #959.
+ *
+ * Deliberately far more generous than the agy budget: #643 removed the
+ * bridge's 120s ceiling precisely because real ctx_execute calls (test
+ * suites, `npm run build`, `cargo test`) legitimately run 2–5 minutes. 10
+ * minutes clears those by a wide margin while still bounding a true hang.
+ * Longer jobs remain expressible with an explicit `timeout`, or with
+ * `background: true` to detach instead of being killed.
+ */
+export const PI_DEFAULT_EXEC_TIMEOUT_MS = 600_000;
+
+/**
+ * Per-host fallback execution budget, applied only when the caller passes no
+ * explicit `timeout`.
+ *
+ * A host belongs here when nothing outside the executor bounds an in-flight
+ * tool call, so "no timeout" means "hang until the user intervenes".
+ *
+ * Hosts absent from this table keep today's unbounded behavior. #406 asked for
+ * a server-enforced default everywhere and was declined because "server-side
+ * timeout enforcement is the wrong layer — every MCP host already enforces its
+ * own RPC timeout". That reasoning holds wherever the premise does; this table
+ * is only for the hosts where it does not.
+ *
+ * Not listed, and why:
+ * - `omp` does not route through Pi's bridge (`bootstrapMCPTools` is called
+ *   only from `src/adapters/pi/extension.ts`), so it lacks the measured
+ *   POSITIVE_INFINITY path. Whether its own MCP client bounds a call is
+ *   untested here. Note an OMP session with no `~/.omp` marker can still
+ *   detect as `pi` and pick up this budget.
+ * - `claude-code` is reported unbounded in practice too (#936: MCP_TOOL_TIMEOUT
+ *   defaults to ~28h and stdio servers were exempt from the idle timeout before
+ *   v2.1.203). That is a much larger blast radius than this fix, so it is left
+ *   for the maintainer to decide separately.
+ */
+export const HOST_DEFAULT_EXEC_TIMEOUT_MS: Readonly<Partial<Record<PlatformId, number>>> = Object.freeze({
+  "antigravity-cli": AGY_DEFAULT_EXEC_TIMEOUT_MS,
+  pi: PI_DEFAULT_EXEC_TIMEOUT_MS,
+});
+
+/**
+ * Largest delay `setTimeout` represents (2^31-1 ms, ~24.8 days). Node wraps
+ * anything larger back to a 1ms delay with a TimeoutOverflowWarning, so a
+ * value above this fires almost immediately — a bigger number producing
+ * harsher behavior. Such a value is treated as unusable rather than honored.
+ */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
+ * Parse an env-supplied execution budget, returning `undefined` when the value
+ * cannot be honored as written: unset, blank, non-numeric, non-integer, zero,
+ * negative, or beyond {@link MAX_TIMER_DELAY_MS}. Callers fall back to the host
+ * default, so neither a typo nor an over-large "effectively unlimited" value
+ * can resurrect the hang or collapse the budget to ~1ms.
+ */
+function parseExecTimeoutEnv(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  const value = Number(trimmed);
+  if (!Number.isInteger(value)) return undefined;
+  if (value <= 0 || value > MAX_TIMER_DELAY_MS) return undefined;
+  return value;
+}
+
 export function resolveExecTimeout(timeout: number | undefined): number | undefined {
   if (timeout !== undefined) return timeout;
-  // Only agy gets a default — every other host enforces its own RPC timeout, so
-  // keep the unbounded behavior there. Detected via the env the agy bundle pins
-  // (CONTEXT_MODE_PLATFORM=antigravity-cli). Tunable via CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS.
-  if (detectPlatform().platform !== "antigravity-cli") return undefined;
-  const override = Number(process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS);
-  return Number.isFinite(override) && override > 0 ? override : AGY_DEFAULT_EXEC_TIMEOUT_MS;
+  // Hosts that bound the call themselves stay unbounded here (#406).
+  const hostDefault = HOST_DEFAULT_EXEC_TIMEOUT_MS[detectPlatform().platform];
+  if (hostDefault === undefined) return undefined;
+  // CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS tunes any defaulted host;
+  // CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS is kept as the pre-#959 alias. The cascade
+  // takes the first USABLE value, not the first one that happens to be set —
+  // an empty or malformed generic var must not mask a valid legacy one.
+  const override =
+    parseExecTimeoutEnv(process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS) ??
+    parseExecTimeoutEnv(process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS);
+  return override ?? hostDefault;
 }
 
 /**
@@ -1552,7 +1640,10 @@ export async function runBatchCommands(
   opts: BatchRunOptions,
   executor: BatchExecutor,
 ): Promise<BatchRunResult> {
-  const { timeout, concurrency, nodeOptsPrefix, cwd, onFsBytes } = opts;
+  const { timeout, concurrency, nodeOptsPrefix, cwd, onFsBytes, callerBudget = true } = opts;
+  // A host-default budget applies per command (like the parallel path below);
+  // only a caller-supplied budget is shared across the batch.
+  const sharedBudget = callerBudget ? timeout : undefined;
 
   if (concurrency <= 1) {
     // Serial path — shared timeout budget, cascading skip on timeout.
@@ -1563,10 +1654,10 @@ export async function runBatchCommands(
     let timedOut = false;
     for (let i = 0; i < commands.length; i++) {
       const cmd = commands[i];
-      let perCmdTimeout: number | undefined;
-      if (timeout !== undefined) {
+      let perCmdTimeout: number | undefined = timeout;
+      if (sharedBudget !== undefined) {
         const elapsed = Date.now() - startTime;
-        const remaining = timeout - elapsed;
+        const remaining = sharedBudget - elapsed;
         if (remaining <= 0) {
           outputs.push(`# ${cmd.label}\n\n(skipped — batch timeout exceeded)\n`);
           timedOut = true;
@@ -1704,7 +1795,7 @@ EXAMPLE: ctx_execute(language: "javascript", code: "const out = require('child_p
       timeout: z
         .coerce.number()
         .optional()
-        .describe("Max execution time in ms. When omitted, no server-side timer fires — the MCP host's RPC timeout governs (which is the right layer for this policy). Pass an explicit value for long-running builds (Gradle/Maven/SBT)."),
+        .describe("Max execution time in ms. When omitted, the host's own RPC timeout governs where it has one; on hosts that do not bound a call (Pi, Antigravity CLI) a generous server-side default applies instead. Pass an explicit value for long-running builds (Gradle/Maven/SBT), or background: true to detach."),
       // background: wrapped in coerceBoolean preprocessor so the literal
       // strings "true"/"false" arriving from OpenCode's native plugin
       // bridge (and several LLM providers' tool-call JSON) parse as the
@@ -2091,7 +2182,7 @@ EXAMPLE: ctx_execute_file(path: "data.csv", language: "javascript", code: "const
       timeout: z
         .coerce.number()
         .optional()
-        .describe("Max execution time in ms. When omitted, no server-side timer fires — the MCP host's RPC timeout governs."),
+        .describe("Max execution time in ms. When omitted, the host's own RPC timeout governs where it has one; on hosts that do not bound a call (Pi, Antigravity CLI) a generous server-side default applies instead."),
       intent: z
         .string()
         .optional()
@@ -4214,7 +4305,7 @@ EXAMPLE: ctx_batch_execute(
       timeout: z
         .coerce.number()
         .optional()
-        .describe("Max execution time in ms. When omitted, no server-side timer fires — the MCP host's RPC timeout governs. With concurrency=1, the value (when set) is a shared budget across commands; with concurrency>1, it is applied per-command."),
+        .describe("Max execution time in ms. When omitted, the host's own RPC timeout governs where it has one; on hosts that do not bound a call (Pi, Antigravity CLI) a generous server-side default applies per command. With concurrency=1, a value you pass is a shared budget across commands; with concurrency>1, it is applied per-command."),
       concurrency: z
         .coerce.number()
         .int()
@@ -4267,6 +4358,7 @@ EXAMPLE: ctx_batch_execute(
         commands,
         {
           timeout: effTimeout,
+          callerBudget: timeout !== undefined,
           concurrency,
           nodeOptsPrefix,
           cwd,
@@ -4332,9 +4424,16 @@ EXAMPLE: ctx_batch_execute(
         ? store.getDistinctiveTerms(indexed.sourceId)
         : [];
 
+      // A cut batch must not read like a complete one: `timedOut` was
+      // previously surfaced only when NOTHING ran, so a killed or skipped
+      // command in the middle looked like a command with no output.
+      const cutNotice = timedOut
+        ? ` Cut short: at least one command hit the ${effTimeout}ms limit — sections marked ` +
+          `"(timed out …)" or "(skipped …)" are incomplete.`
+        : "";
       const output = [
         `Executed ${commands.length} commands (${totalLines} lines, ${(totalBytes / 1024).toFixed(1)}KB). ` +
-          `Indexed ${indexed.totalChunks} sections. Searched ${queries.length} queries.`,
+          `Indexed ${indexed.totalChunks} sections. Searched ${queries.length} queries.${cutNotice}`,
         "",
         ...commandsInventory,
         "",

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -26,7 +26,7 @@ import { join, dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
-import { describe, test, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 
 import { classifyNonZeroExit } from "../../src/exit-classify.js";
 import { PolyglotExecutor } from "../../src/executor.js";
@@ -44,7 +44,7 @@ import {
   StorageDirectoryError,
 } from "../../src/session/db.js";
 import { ROUTING_BLOCK } from "../../hooks/routing-block.mjs";
-import { sanitizeSchemaForStrictClients, resolveExecTimeout, AGY_DEFAULT_EXEC_TIMEOUT_MS, REGISTERED_CTX_TOOLS } from "../../src/server.js";
+import { sanitizeSchemaForStrictClients, resolveExecTimeout, AGY_DEFAULT_EXEC_TIMEOUT_MS, PI_DEFAULT_EXEC_TIMEOUT_MS, HOST_DEFAULT_EXEC_TIMEOUT_MS, REGISTERED_CTX_TOOLS } from "../../src/server.js";
 import { stripJsonComments, parseJsonc } from "../../src/util/jsonc.js";
 
 // ─── Shared setup ───────────────────────────────────────────────────────────
@@ -3181,6 +3181,54 @@ describe("runBatchCommands serial path (concurrency=1)", () => {
     );
     expect(seenTimeouts).toEqual([undefined, undefined]);
   });
+
+  // A budget that came only from HOST_DEFAULT_EXEC_TIMEOUT_MS is a per-command
+  // backstop against one hung command, not a deadline for the whole batch.
+  // Spending it across commands would silently truncate a long batch that
+  // nobody put a deadline on — the parallel path already treats it per-command.
+  test("host-default budget: applied per command, no shared-budget cascade", async () => {
+    const seenTimeouts: Array<number | undefined> = [];
+    const exec = mkMockExecutor(async (_code, timeout) => {
+      seenTimeouts.push(timeout);
+      await new Promise((r) => setTimeout(r, 60)); // each call burns 60ms
+      return { stdout: "ok" };
+    });
+    const cmds: BatchCommand[] = [
+      { label: "A", command: "x" },
+      { label: "B", command: "y" },
+      { label: "C", command: "z" }, // elapsed > 100ms by here
+    ];
+    const { outputs, timedOut } = await runBatchCommands(
+      cmds,
+      { timeout: 100, callerBudget: false, concurrency: 1, nodeOptsPrefix: NOOP_PREFIX },
+      exec,
+    );
+    expect(seenTimeouts).toEqual([100, 100, 100]);
+    expect(timedOut).toBe(false);
+    expect(outputs.every((o) => !o.includes("skipped"))).toBe(true);
+  });
+
+  test("caller budget stays shared across commands (unchanged default)", async () => {
+    let callCount = 0;
+    const exec = mkMockExecutor(async () => {
+      callCount++;
+      await new Promise((r) => setTimeout(r, 60));
+      return { stdout: "ok" };
+    });
+    const cmds: BatchCommand[] = [
+      { label: "A", command: "x" },
+      { label: "B", command: "y" },
+      { label: "C", command: "z" },
+    ];
+    const { timedOut } = await runBatchCommands(
+      cmds,
+      { timeout: 100, callerBudget: true, concurrency: 1, nodeOptsPrefix: NOOP_PREFIX },
+      exec,
+    );
+    expect(callCount).toBeLessThan(3);
+    expect(timedOut).toBe(true);
+  });
+
 });
 
 describe("runBatchCommands parallel path (concurrency>1)", () => {
@@ -6625,14 +6673,22 @@ describe("parseJsonc / stripJsonComments (src/util/jsonc)", () => {
   });
 });
 
-describe("resolveExecTimeout (agy default execution timeout)", () => {
+describe("resolveExecTimeout (host default execution timeout)", () => {
   const savedPlatform = process.env.CONTEXT_MODE_PLATFORM;
-  const savedOverride = process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS;
+  const savedOverride = process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS;
+  const savedAgyOverride = process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS;
+  const restore = (key: string, value: string | undefined) => {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  };
   afterEach(() => {
-    if (savedPlatform === undefined) delete process.env.CONTEXT_MODE_PLATFORM;
-    else process.env.CONTEXT_MODE_PLATFORM = savedPlatform;
-    if (savedOverride === undefined) delete process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS;
-    else process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS = savedOverride;
+    restore("CONTEXT_MODE_PLATFORM", savedPlatform);
+    restore("CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS", savedOverride);
+    restore("CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS", savedAgyOverride);
+  });
+  beforeEach(() => {
+    delete process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS;
+    delete process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS;
   });
 
   test("passes an explicit timeout through on any platform", () => {
@@ -6640,23 +6696,101 @@ describe("resolveExecTimeout (agy default execution timeout)", () => {
     expect(resolveExecTimeout(5000)).toBe(5000);
     process.env.CONTEXT_MODE_PLATFORM = "claude-code";
     expect(resolveExecTimeout(5000)).toBe(5000);
+    process.env.CONTEXT_MODE_PLATFORM = "pi";
+    expect(resolveExecTimeout(5000)).toBe(5000);
   });
 
-  test("applies the agy default ONLY under antigravity-cli when no timeout is given", () => {
+  test("applies the agy default under antigravity-cli when no timeout is given", () => {
     process.env.CONTEXT_MODE_PLATFORM = "antigravity-cli";
-    delete process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS;
     expect(resolveExecTimeout(undefined)).toBe(AGY_DEFAULT_EXEC_TIMEOUT_MS);
   });
 
-  test("leaves the timeout unbounded (undefined) on non-agy hosts", () => {
+  // #959 — Pi's bridge forwards tools/call with Number.POSITIVE_INFINITY, so a
+  // ctx_execute with no `timeout` had no bound at ANY layer: measured a 75-minute
+  // hang that only ended when the user killed the session.
+  test("applies the pi default under pi when no timeout is given", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "pi";
+    expect(resolveExecTimeout(undefined)).toBe(PI_DEFAULT_EXEC_TIMEOUT_MS);
+  });
+
+  test("leaves the timeout unbounded (undefined) on hosts that bound the call themselves", () => {
     process.env.CONTEXT_MODE_PLATFORM = "claude-code";
+    expect(resolveExecTimeout(undefined)).toBeUndefined();
+    process.env.CONTEXT_MODE_PLATFORM = "opencode";
     expect(resolveExecTimeout(undefined)).toBeUndefined();
   });
 
-  test("honors CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS override under agy", () => {
+  test("honors CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS on every defaulted host", () => {
+    process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = "1500";
+    process.env.CONTEXT_MODE_PLATFORM = "pi";
+    expect(resolveExecTimeout(undefined)).toBe(1500);
+    process.env.CONTEXT_MODE_PLATFORM = "antigravity-cli";
+    expect(resolveExecTimeout(undefined)).toBe(1500);
+  });
+
+  test("still honors the legacy CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS override", () => {
     process.env.CONTEXT_MODE_PLATFORM = "antigravity-cli";
     process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS = "1500";
     expect(resolveExecTimeout(undefined)).toBe(1500);
+  });
+
+  test("prefers the generic override over the legacy agy one", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "antigravity-cli";
+    process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS = "1500";
+    process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = "2500";
+    expect(resolveExecTimeout(undefined)).toBe(2500);
+  });
+
+  // An unusable override must fall back to the host default, never to
+  // "unbounded" — a bad env value must not resurrect the hang.
+  test("falls back to the host default when the override is unusable", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "pi";
+    for (const bad of ["0", "-1", "abc", "", "NaN", "Infinity"]) {
+      process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = bad;
+      expect(resolveExecTimeout(undefined)).toBe(PI_DEFAULT_EXEC_TIMEOUT_MS);
+    }
+  });
+
+  // An unusable generic override must not mask a usable legacy one: `??` falls
+  // through only on null/undefined, so a blank CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS
+  // used to discard a valid CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS and silently change
+  // agy's budget. The cascade takes the first USABLE value.
+  test("an unusable generic override does not mask a usable legacy one", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "antigravity-cli";
+    process.env.CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS = "1500";
+    for (const bad of ["", " ", "0", "-1", "abc", "NaN", "Infinity", "1_000", "1e400"]) {
+      process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = bad;
+      expect(resolveExecTimeout(undefined)).toBe(1500);
+    }
+  });
+
+  // setTimeout wraps anything above 2^31-1 back to ~1ms, so a "bigger" budget
+  // used to produce the harshest possible behavior: every exec killed at once.
+  test("rejects budgets Node's timer cannot represent", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "pi";
+    for (const bad of ["2147483648", "3000000000", "1.5", "1e400"]) {
+      process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = bad;
+      expect(resolveExecTimeout(undefined)).toBe(PI_DEFAULT_EXEC_TIMEOUT_MS);
+    }
+    process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = "2147483647";
+    expect(resolveExecTimeout(undefined)).toBe(2147483647);
+  });
+
+  test("tolerates surrounding whitespace in an otherwise usable override", () => {
+    process.env.CONTEXT_MODE_PLATFORM = "pi";
+    process.env.CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS = "  2500  ";
+    expect(resolveExecTimeout(undefined)).toBe(2500);
+  });
+
+  test("every defaulted host resolves to a finite positive budget", () => {
+    for (const platform of Object.keys(HOST_DEFAULT_EXEC_TIMEOUT_MS)) {
+      process.env.CONTEXT_MODE_PLATFORM = platform;
+      const resolved = resolveExecTimeout(undefined);
+      expect(typeof resolved).toBe("number");
+      expect(Number.isFinite(resolved)).toBe(true);
+      expect(resolved as number).toBeGreaterThan(0);
+      expect(resolved as number).toBeLessThanOrEqual(2_147_483_647);
+    }
   });
 });
 


### PR DESCRIPTION
## What / Why / How

`ctx_execute` has no bound of any kind under Pi, so one hung call blocks the
turn until the user kills the session.

`resolveExecTimeout()` returned a default only under agy, justified in a
comment with "every other host enforces its own RPC timeout". For Pi that
premise does not hold, and three layers compound:

1. `src/server.ts` — `resolveExecTimeout(undefined)` → `undefined` for every
   non-agy host.
2. `src/executor.ts` — no timer is armed when the timeout is `undefined`
   (deliberate, #406).
3. `src/adapters/pi/mcp-bridge.ts` — `tools/call` is forwarded with
   `Number.POSITIVE_INFINITY` (deliberate, #643).

Nothing can end the call. Pi's `ToolDefinition.execute()` does pass an
`AbortSignal` (`pi-coding-agent` 0.84.3, `dist/core/extensions/types.d.ts:372`),
but the registered-tool callback at `mcp-bridge.ts:1034` takes only
`(_toolCallId, params)` and drops it, so Esc cannot clear it either.

**Measured**, Pi 0.84.3 + context-mode 1.0.169 on macOS: a model called
`ctx_execute` with a recursive `grep -rn` and no `timeout`. The sandbox child
ran **75 minutes** with no tool result, the session sat on `Working…`, and it
ended only when the session was killed. #959 carries independent reports on
macOS, Linux and Windows.

**How:** replace the single agy special case with
`HOST_DEFAULT_EXEC_TIMEOUT_MS`, a per-host table of fallback budgets, and add
`pi: 600_000`.

- **600s is deliberately generous.** #643 removed the bridge's 120s ceiling
  because real calls (test suites, `npm run build`, `cargo test`) legitimately
  run 2–5 minutes; 600s clears those with 2–5× headroom while still bounding a
  hang. Longer jobs stay expressible with an explicit `timeout`, or
  `background: true` to detach.
- **`CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS`** tunes any defaulted host (the
  spelling #936 proposed, since that issue would reuse this knob);
  `CONTEXT_MODE_AGY_EXEC_TIMEOUT_MS` is kept as its alias.
- **The cascade takes the first *usable* value, not the first one set.** `??`
  falls through only on `null`/`undefined`, so a blank generic var would have
  masked a valid legacy one and silently changed agy's budget — `""` +
  `AGY=1500` under agy → `120000` instead of `1500`. Now `""`, `" "`, `"0"`,
  `"-1"`, `"abc"`, `"NaN"`, `"Infinity"`, `"1_000"`, `"1e400"` all fall through
  to the next candidate, then to the host default.
- **Values a timer cannot represent are refused.** `setTimeout` wraps anything
  above 2³¹−1 back to a ~1ms delay, so `3000000000` (a fat-fingered `300000`,
  or someone meaning "effectively unlimited") made *every* `ctx_execute` die
  almost instantly — measured: settled in 1.23s with `Execution timed out
  after 3000000000ms`. A bigger number producing harsher behavior is the worst
  shape a guard can have, so out-of-range, fractional and non-integer values
  now fall back to the host default.
- **Hosts absent from the table keep today's unbounded behavior.** agy is
  unchanged for every usable value; only inputs that Node's timer cannot
  honor behave differently (they used to fire at ~1ms, now they fall back).

### `ctx_batch_execute`: the host default applies per command

The serial batch path spends an explicit `timeout` as a *shared* budget with a
cascading skip. Letting a host default do that would truncate a long batch
nobody put a deadline on: measured before this change, three
`sleep 3` commands under a 4s budget returned header `Executed 3 commands`,
`isError: undefined`, one command rendered as `(no output)` because it was
killed, and the third's `(skipped …)` line only visible if you happened to
search for it — exactly the "false failures and confusion" cited when closing
#406.

So `runBatchCommands` now takes `callerBudget`: an explicit `timeout` stays
shared (unchanged), while a budget that came only from the host table applies
per command, matching what the parallel path already does. And the success
header now says when a batch was cut, instead of surfacing `timedOut` only in
the zero-output case.

### Also corrected

The `timeout` schema text on all three tools said "When omitted, no
server-side timer fires — the MCP host's RPC timeout governs (which is the
right layer for this policy)". Under Pi that is now false, and #959's
confirming comment asks specifically that the schema stop claiming Pi has a
host RPC timeout. Reworded, along with the `BatchRunOptions.timeout` doc.

## Relationship to #959 and PR #1029

#959 asks for two things, and this PR is deliberately only one of them.

- **PR #1029** (*fix(pi): propagate MCP cancellation to executor*, open) is the
  cancellation half: Esc aborts an in-flight call. That is the better fix for
  the user-visible complaint, and this PR does not do it — after this change,
  Esc still does nothing and the user waits out the budget.
- **This PR** is the fail-safe backstop: the hang ends on its own even when the
  host never cancels, which is also the shape #936 needs.

They touch `src/server.ts` and `tests/core/server.test.ts` in different places
but will likely conflict textually; #1029 is already marked conflicting against
`next`. Happy to rebase on top of it, or to fold this into that PR, whichever
you prefer. **Refs #959** rather than *Fixes*, since the abort half remains open.

## Affected platforms

- [x] Pi
- [ ] All platforms

Antigravity CLI is touched only in that its knob gained an alias and its
override validation got stricter.

## Test plan

`tests/core/server.test.ts` — `resolveExecTimeout` goes from 4 tests to 12,
plus 2 new `runBatchCommands` tests. TDD: 5 of the 12 fail against the pre-fix
resolver, including both new guard cases (verified by restoring the old body
and re-running).

- explicit `timeout` passes through on agy, claude-code and pi
- agy default unchanged; pi default applied
- unbounded preserved where the host bounds the call (claude-code, opencode)
- `CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS` honored on every defaulted host;
  legacy alias still honored; generic wins when both are usable
- an *unusable* generic override does not mask a usable legacy one
- budgets beyond `2147483647`, and fractional ones, fall back to the host default
- `2147483647` exactly is accepted; surrounding whitespace tolerated
- every table entry resolves to a finite, positive, timer-representable budget
- batch: a host-default budget is per-command and does not cascade; an explicit
  budget stays shared

**End-to-end through the real bridge** — `bootstrapMCPTools()` spawning the
server child itself, `ctx_execute` invoked with Pi's real
`(toolCallId, params, signal, onUpdate, ctx)` shape, no `timeout` in params,
and `CONTEXT_MODE_PLATFORM` deliberately *unset* so the child performs its own
detection:

| case | result |
|---|---|
| `CONTEXT_MODE_DEFAULT_EXEC_TIMEOUT_MS=3000` | settled in 3.4s, `Execution timed out after 3000ms`, sandbox child gone |
| default 600s | still pending at 9s, child alive — the default is not aggressive |
| same via a synthetic stdio client, `CONTEXT_MODE_PLATFORM=claude-code` | still pending at 9.5s — unchanged by this PR |

Full suite green, `tsc --noEmit` clean.

### What I could not exercise

- **No live interactive Pi session with a model in the loop.** The harness
  drives the real bridge and the real server child, but the turn loop, Esc
  handling and the TUI are untested here.
- **Whether OMP's own MCP client bounds a call** is unverified, so `omp` is not
  in the table. Note an OMP session with no `~/.omp` marker can still detect as
  `pi` and pick up this budget.
- **claude-code (#936)** is left out on purpose: the same premise looks false
  there too (`MCP_TOOL_TIMEOUT` ~28h, stdio servers exempt from the idle
  timeout before v2.1.203), but adding it is a one-line table change affecting
  every Claude Code user, so that is your call.
- **Reproducing the e2e numbers needs a rebuild.** `start.mjs` prefers the
  tracked `server.bundle.mjs`, and I did not commit bundles (matching most
  src-only commits on `next`; `ci.yml` rebuilds from source for PRs to `next`).
  Against the committed bundle the pi case stays pending, as expected.

Two pre-existing things worth knowing, both only *reachable* under Pi because
of this change: `background: true` does keep the child alive past the deadline,
but the response still comes back `isError: true` with no "still running" note
unless partial stdout exists (`src/server.ts:1880`), and `background` is
ignored on the Rust path (`src/executor.ts:406`).

Unrelated flake seen while iterating:
`tests/executor/win-sandbox-782-788.test.ts` snapshots `os.tmpdir()` for leaked
`.ctx-mode-*` dirs, so a concurrent worker's sandbox can fail it under
`--maxWorkers=2` (failed once, passed on re-run with identical code, passes in
the full run). Not touched here. Separately, CONTRIBUTING.md:53-55 tells
contributors to `rm server.bundle.mjs`, which now exits 2 with
`CONTEXT_MODE_PARTIAL_INSTALL` (`start.mjs:576-589`) — stale instruction, and
the first thing anyone reproducing the above will hit.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md) — added an
      "Execution-timeout environment variables" table to README; no existing doc
      referenced the exec-timeout default
- [x] No Windows path regressions (forward slashes only) — no path code touched
- [x] Targets `next` branch
