### PR TITLE
fix(pi): timestamp injected context messages for Radius

### DIFF
--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -745,6 +745,7 @@ export default function piExtension(pi: any): void {
       event.messages.push({
         role: "user",
         content: ctx,
+        timestamp: Date.now(),
       });
       return { messages: event.messages };
     } catch {

--- a/tests/pi-extension.test.ts
+++ b/tests/pi-extension.test.ts
@@ -923,6 +923,35 @@ describe("Pi Extension", () => {
       expect(ctxResult.messages[0].content).toContain("ctx_batch_execute > ctx_execute > ctx_execute_file");
     });
 
+    it("keeps first-turn injected messages valid for pi-messages gateways", async () => {
+      await registerPiExtension(api);
+      await api._trigger("session_start", {}, {
+        sessionManager: { getSessionFile: () => join(tempDir, "gateway-session.jsonl") },
+      });
+      await api._trigger("before_agent_start", {
+        prompt: "hi",
+        systemPrompt: "Base prompt.",
+      });
+
+      const userMessage = { role: "user", content: "hi", timestamp: Date.now() };
+      const beforeInjection = Date.now();
+      const result = await api._trigger("context", { messages: [userMessage] });
+      const afterInjection = Date.now();
+      // Gateways such as Radius validate the serialized Pi message envelope.
+      const payload = JSON.parse(JSON.stringify({ context: result }));
+      expect(payload.context.messages).toHaveLength(2);
+      expect(payload.context.messages[0]).toEqual(userMessage);
+      const injected = payload.context.messages[1];
+      expect(injected.role).toBe("user");
+      expect(injected.content).toContain("context-mode active");
+      expect(
+        Number.isFinite(injected.timestamp),
+        "context.messages[1].timestamp must be a finite number",
+      ).toBe(true);
+      expect(injected.timestamp).toBeGreaterThanOrEqual(beforeInjection);
+      expect(injected.timestamp).toBeLessThanOrEqual(afterInjection);
+    });
+
     it("re-injects the anchor via context hook on every subsequent call", async () => {
       await registerPiExtension(api);
       await api._trigger("session_start", {}, {


### PR DESCRIPTION
## What / Why / How

Fix Pi context injection producing user messages without the required numeric `timestamp`.

With context-mode 1.0.169 enabled, a new Pi session can fail on its first prompt (`hi`) when using Radius:

```text
400 Bad Request: context.messages[1].timestamp must be a finite number
```

The user's message is `context.messages[0]`. The `context` hook appends the routing context as `messages[1]` with only `role` and `content`. Pi's `UserMessage` contract requires a Unix-millisecond timestamp, and the `pi-messages` transport serializes the context directly, so the missing field reaches the gateway unchanged.

Add `timestamp: Date.now()` at the injection site. This preserves the existing trailing-message injection and avoids changing the system prompt or adding gateway-specific workarounds.

## Affected platforms

- [x] Pi

## Test plan

- Added a regression test to the existing `tests/pi-extension.test.ts`. It runs the actual registered `session_start`, `before_agent_start`, and `context` handlers for a fresh session with a `hi` message, JSON-round-trips the envelope, checks the original message is preserved, and verifies the appended message has a finite timestamp within the injection interval.
- **Red:** the new test failed before the production change with `context.messages[1].timestamp must be a finite number: expected false to be true`.
- **Green:** `node node_modules/vitest/vitest.mjs run tests/pi-extension.test.ts` — **69 passed**.
- `npm run typecheck` — passed.
- `npm run build` — passed, including bundle and asymmetric-drift checks. Generated bundle changes are not included in this PR.
- Additional local transport check: executed the installed and patched compiled context callbacks and passed their output through the actual installed Pi `pi-messages` serializer/error parser with a synthetic fetch responder enforcing the numeric timestamp contract. The installed version produced the exact 400 above; the patched version passed and parsed a terminal SSE response. This was a local mock-gateway check, **not a live Radius E2E test**; no real credentials or private conversations were used.
- `npm test` — **4775 passed, 24 skipped, 1 failed** (213 test files). The only failure was the unchanged Rust executor test `execute_file: Rust exposes 'file_path' as alias for file_content_path`: the local macOS linker rejected an SDK `.tbd` containing `arm64e.x1-macos` (`unknown architecture`). Running that executor test alone reproduced the same linker failure. This PR does not modify the executor or toolchain.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes — local Rust linker/SDK blocker described above
- [x] `npm run typecheck` passes
- [x] Docs updated if needed — no public API or configuration change
- [x] No Windows path regressions — production change has no paths; test uses `path.join()`
- [x] Targets `next` branch
